### PR TITLE
Fix PROJECT_DIR path traversal when installed via plugin cache

### DIFF
--- a/scripts/run-consolidation.sh
+++ b/scripts/run-consolidation.sh
@@ -13,7 +13,8 @@
 #   run-consolidation.sh    # no arguments needed
 #
 # ENVIRONMENT
-#   (none — PROJECT_DIR is auto-detected from script path)
+#   CLAUDE_PROJECT_DIR   Project root (set by Claude Code; falls back to path traversal)
+#   CLAUDE_PLUGIN_ROOT   Plugin install directory (set by Claude Code)
 #
 # DEPENDENCIES
 #   python3, claude CLI (Haiku)
@@ -34,8 +35,8 @@
 
 set -e
 
-PROJECT_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
-PIPELINE_DIR="${PROJECT_DIR}/.claude/remember"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+PIPELINE_DIR="${CLAUDE_PLUGIN_ROOT:-${PROJECT_DIR}/.claude/remember}"
 source "$(dirname "$0")/log.sh"
 rotate_logs
 

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -54,8 +54,8 @@ set -e
 
 trap 'log "error" "FAILED at line $LINENO (exit $?)"' ERR
 
-PROJECT_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
-PIPELINE_DIR="${PROJECT_DIR}/.claude/remember"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+PIPELINE_DIR="${CLAUDE_PLUGIN_ROOT:-${PROJECT_DIR}/.claude/remember}"
 source "$(dirname "$0")/log.sh"
 
 REMEMBER_TZ=$(config ".timezone" "Europe/Paris")


### PR DESCRIPTION
## Summary

- `save-session.sh` and `run-consolidation.sh` computed `PROJECT_DIR` by navigating 3 levels up from the script's own path
- This works when the plugin is copied into `.claude/remember/scripts/` inside a project, but breaks when installed via the Claude Code plugin cache — the traversal resolves to the cache root instead of the project root
- `session-start-hook.sh` already used `CLAUDE_PROJECT_DIR` correctly; this PR brings the other two scripts in line with that pattern

## Changes

Both `save-session.sh` (line 57) and `run-consolidation.sh` (line 37):

```bash
# Before:
PROJECT_DIR="$(cd "$(dirname "$0")/../../.." && pwd)"
PIPELINE_DIR="${PROJECT_DIR}/.claude/remember"

# After:
PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../../.." && pwd)}"
PIPELINE_DIR="${CLAUDE_PLUGIN_ROOT:-${PROJECT_DIR}/.claude/remember}"
```

The original path traversal is kept as a fallback, so this is fully backwards compatible for users who installed the plugin manually.

## Test plan

- [x] Install plugin via plugin cache and verify `.remember/now.md` is created after tool use threshold is reached
- [x] Verify manual install (copied into `.claude/remember/`) still works via the fallback path
- [x] Run `save-session.sh --dry` with `CLAUDE_PROJECT_DIR` set to confirm correct project root is used

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)