### PR TITLE
fix: export CLAUDE_PROJECT_DIR in hooks for background subprocesses

### DIFF
--- a/scripts/post-tool-hook.sh
+++ b/scripts/post-tool-hook.sh
@@ -31,6 +31,8 @@
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-.}/.claude/remember}"
 PROJECT="${CLAUDE_PROJECT_DIR:-.}"
 PROJECT_DIR="$PROJECT"
+export CLAUDE_PROJECT_DIR="$PROJECT"
+export CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT"
 source "$PLUGIN_ROOT/scripts/log.sh" 2>/dev/null
 SAVE_SCRIPT="$PLUGIN_ROOT/scripts/save-session.sh"
 LAST_SAVE_FILE="$PROJECT/.remember/tmp/last-save.json"

--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -40,6 +40,8 @@
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${CLAUDE_PROJECT_DIR:-.}/.claude/remember}"
 PROJECT="${CLAUDE_PROJECT_DIR:-.}"
 PROJECT_DIR="$PROJECT"
+export CLAUDE_PROJECT_DIR="$PROJECT"
+export CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT"
 CONFIG="$PLUGIN_ROOT/config.json"
 # Read a config value from config.json. Falls back to $2 if missing.
 cfg() { jq -r "$1 // empty" "$CONFIG" 2>/dev/null || echo "$2"; }


### PR DESCRIPTION
## Problem

When `post-tool-hook.sh` launches `save-session.sh` via `nohup ... &`, the child process does not inherit `CLAUDE_PROJECT_DIR` or `CLAUDE_PLUGIN_ROOT` because they are not exported. 

The `save-session.sh` script then falls back to calculating `PROJECT_DIR` from `dirname "$0"`, which resolves to the plugin cache directory instead of the actual project — causing every save to fail silently:

```
cd: .../.claude/plugins/cache/claude-plugins-official/.claude/remember: No such file or directory
```

This affects all users where the plugin is installed via the global plugin cache (the default installation method).

## Fix

Export `CLAUDE_PROJECT_DIR` and `CLAUDE_PLUGIN_ROOT` in both hook scripts so background subprocesses inherit the correct paths.

## Testing

Verified with `--dry` run that `PROJECT_DIR` and `PIPELINE_DIR` resolve correctly after the fix.