### PR TITLE
fix: Python 3.9 compatibility for type annotations

### DIFF
--- a/pipeline/consolidate.py
+++ b/pipeline/consolidate.py
@@ -19,6 +19,8 @@ Typical usage::
     # result.archive -> new content for archive.md
 """
 
+from __future__ import annotations
+
 from .prompts import build_consolidation_prompt
 from .haiku import call_haiku
 from .types import ConsolidationResult, TokenUsage

--- a/pipeline/extract.py
+++ b/pipeline/extract.py
@@ -19,6 +19,8 @@ Or imported::
     result = extract_session(session_id="abc123", count=5)
 """
 
+from __future__ import annotations
+
 import json
 import glob
 import os

--- a/pipeline/haiku.py
+++ b/pipeline/haiku.py
@@ -14,6 +14,8 @@ Module-level constants:
     HAIKU_CACHE_PRICE: USD cost per cache-read input token.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/pipeline/prompts.py
+++ b/pipeline/prompts.py
@@ -12,6 +12,8 @@ Templates are plain text files with mustache-style placeholders::
         consolidate-staging.prompt.txt   # {{STAGING_FILES}}, {{RECENT}}, {{ARCHIVE}}
 """
 
+from __future__ import annotations
+
 import os
 
 

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -23,6 +23,8 @@ Available subcommands::
 
 """
 
+from __future__ import annotations
+
 import json
 import os
 import sys

--- a/pipeline/types.py
+++ b/pipeline/types.py
@@ -13,6 +13,8 @@ Typical usage::
     print(usage)  # "1200+800cache→300out ($0.0021)"
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 
 


### PR DESCRIPTION
## Summary
- All 6 pipeline modules use PEP 604 (`str | None`) and PEP 585 (`list[str]`, `dict[str, str]`) type hint syntax, which requires Python 3.10+ at runtime
- macOS ships Python 3.9 via CommandLineTools, causing `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` on every pipeline import
- Adds `from __future__ import annotations` (PEP 563) to all pipeline modules, making annotations lazy strings so the newer syntax works on 3.9 without changing any signatures

## Context
Discovered while debugging why the plugin produced only empty/error log files when installed via the Claude Code plugin marketplace on macOS. The path resolution bugs were already fixed by `resolve-paths.sh` in main, but the Python 3.9 issue remained — the extraction pipeline crashes before it can do anything.

## Test plan
- [ ] Verify `python3.9 -c "from pipeline.extract import extract_session"` succeeds
- [ ] Verify existing test suite passes on Python 3.10+ (no regressions from the future import)
- [ ] Verify `save-session.sh --dry` produces extracted output on a macOS machine with system Python 3.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)