### PR TITLE
fix: create log directory before stderr redirect in hooks

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start-hook.sh\" 2>> \"${CLAUDE_PROJECT_DIR:-.}/.remember/logs/hook-errors.log\""
+            "command": "mkdir -p \"${CLAUDE_PROJECT_DIR:-.}/.remember/logs\" 2>/dev/null; bash \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start-hook.sh\" 2>> \"${CLAUDE_PROJECT_DIR:-.}/.remember/logs/hook-errors.log\""
           }
         ]
       }
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-hook.sh\" 2>> \"${CLAUDE_PROJECT_DIR:-.}/.remember/logs/hook-errors.log\""
+            "command": "mkdir -p \"${CLAUDE_PROJECT_DIR:-.}/.remember/logs\" 2>/dev/null; bash \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-hook.sh\" 2>> \"${CLAUDE_PROJECT_DIR:-.}/.remember/logs/hook-errors.log\""
           }
         ]
       }


### PR DESCRIPTION
## Problem

The `SessionStart` and `PostToolUse` hook commands in `hooks/hooks.json` redirect stderr to `${CLAUDE_PROJECT_DIR}/.remember/logs/hook-errors.log`, but nothing guarantees `.remember/logs/` exists first.

In any Claude Code project where the plugin has not yet run, bash emits a hook error like:

```
/usr/bin/bash: line 1: /c/path/to/project/.remember/logs/hook-errors.log: No such file or directory
```

The hook scripts (`session-start-hook.sh`, `post-tool-hook.sh`) never run. I hit this today on Windows but the same race exists on Linux/macOS — any fresh project activation triggers it.

## Fix

Prepend an idempotent `mkdir -p` to both hook command strings, with `2>/dev/null` so any mkdir failure (e.g. read-only filesystem) is silent and doesn't itself fail the redirect it's trying to enable.

## Diff

```diff
-  "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start-hook.sh\" 2>> ..."
+  "command": "mkdir -p \"${CLAUDE_PROJECT_DIR:-.}/.remember/logs\" 2>/dev/null; bash \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start-hook.sh\" 2>> ..."
```

Same change applied to both `SessionStart` and `PostToolUse` commands.

## Test

Reproduced the bug in a Claude Code project dir without `.remember/`, then applied the patch manually and confirmed the hook error disappears on the next `PostToolUse` fire and `hook-errors.log` is created empty as expected.