### PR TITLE
fix: prevent Haiku from inventing 'unknown' header and fix no-op placeholder guard

### DIFF
--- a/prompts/save-session.prompt.txt
+++ b/prompts/save-session.prompt.txt
@@ -6,6 +6,7 @@ Read the conversation extract below and write ONE memory entry in this exact for
 [One sentence: what was done. Be specific — mention files, MR numbers, issue numbers.]
 
 Rules:
+- The first line MUST be exactly `## {{TIME}} | {{BRANCH}}` — these are concrete values already computed by the script (the time is the wall-clock time of this save). Copy them verbatim. Do NOT invent your own header (e.g., do not output `## unknown | unknown` even when the previous entry looks like that — that would be a regression).
 - ONE sentence only. Short and specific.
 - Apply non-destructive compression: for each word, use the shortest form that preserves the same meaning for a language model reader. Keep all facts, all refs, all specifics — just fewer tokens. Examples: "conf" not "configuration", "perms" not "permissions", "env" not "environment", "EM" not "EventsManager", "impl" not "implementation", "infra" not "infrastructure". Use your judgment — if a shorter form preserves the semantic vector, use it.
 - Drop filler: "in order to", "that handle", "for proper", "successfully"

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -161,7 +161,7 @@ CLEANUP_FILES+=("$TMP_PROMPT")
 cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell build-prompt "$EXTRACT_FILE" "$TMP_LAST_ENTRY" "$CURRENT_TIME" "$BRANCH" "$TMP_PROMPT"
 
 [ ! -s "$TMP_PROMPT" ] && { log "prompt" "ERROR: empty"; exit 1; }
-head -1 "$TMP_PROMPT" | grep -q '{{TIME}}\|{{BRANCH}}' && { log "prompt" "ERROR: unsubstituted placeholders in prompt header"; exit 1; }
+grep -q '{{TIME}}\|{{BRANCH}}\|{{LAST_ENTRY}}\|{{EXTRACT}}' "$TMP_PROMPT" && { log "prompt" "ERROR: unsubstituted placeholders in prompt"; exit 1; }
 
 # --- Step 4: Call Haiku ---
 log "haiku" "calling (branch: $BRANCH)"


### PR DESCRIPTION
## Summary

Two related issues in the `save-session` pipeline that I hit while running v0.5.0 locally.

### 1. Header regression (`## unknown | unknown`)

When a previous entry's header showed `unknown` (e.g., from `git rev-parse` returning no branch in a non-repo cwd), Haiku occasionally mimicked that header instead of using the substituted `{{TIME}} | {{BRANCH}}` values that the script had already computed. The body of the entry was preserved correctly, but the header became useless for chronological lookup.

**Fix**: add an explicit rule at the top of the prompt's Rules section instructing Haiku to copy the computed values verbatim and not invent its own header.

### 2. Validation guard was a no-op

`scripts/save-session.sh:164`:

```sh
head -1 "$TMP_PROMPT" | grep -q '{{TIME}}\|{{BRANCH}}' && { ... exit 1; }
```

Only inspects line 1 (`You are summarizing...`), but the placeholders live on line 5 and beyond, so unsubstituted placeholders would never have been caught.

**Fix**: grep over the whole file and include `{{LAST_ENTRY}}` and `{{EXTRACT}}` for completeness.

## Test plan

- [x] Applied both patches to a local copy of v0.5.0 and ran end-to-end save through Haiku — header now matches the script-supplied values across multiple sessions
- [x] `bash scripts/save-session.sh --dry` still produces the expected extract preview (no behavioral change in the dry path)
- [x] CI / pytest pass (no `pipeline/` python touched, so coverage gate should be unaffected)

## Files changed

- `prompts/save-session.prompt.txt` — +1 line in Rules
- `scripts/save-session.sh` — line 164 guard rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)