### PR TITLE
feat: add time_format config option for 12h AM/PM timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Copy `config.example.json` to `config.json` and adjust:
 | `features.ndc_compression`      | `true`  | Enable hourly compression of daily files           |
 | `features.recovery`             | `true`  | Recover missed saves on session start              |
 | `timezone`                       | `UTC`   | Timezone for timestamps and daily file boundaries  |
+| `time_format`                    | `"24h"` | Timestamp style in daily logs: `"24h"` (e.g. `14:32`) or `"12h"` (e.g. `2:32 PM`) |
 | `debug`                          | `false` | Verbose logging for cooldowns and locks            |
 
 ## Running tests

--- a/config.example.json
+++ b/config.example.json
@@ -13,5 +13,6 @@
     "recovery": true
   },
   "debug": false,
-  "timezone": "UTC"
+  "timezone": "UTC",
+  "time_format": "24h"
 }

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -154,7 +154,12 @@ fi
 
 # --- Step 3: Build prompt ---
 BRANCH=$(cd "$PROJECT_DIR" && git branch --show-current 2>/dev/null || echo "unknown")
-CURRENT_TIME=$(TZ="$REMEMBER_TZ" date +%H:%M)
+TIME_FORMAT=$(config ".time_format" "24h")
+if [ "$TIME_FORMAT" = "12h" ]; then
+    CURRENT_TIME=$(TZ="$REMEMBER_TZ" date '+%-I:%M %p')
+else
+    CURRENT_TIME=$(TZ="$REMEMBER_TZ" date '+%H:%M')
+fi
 TMP_PROMPT=$(mktemp "${TMPDIR:-/tmp}"/remember-prompt-XXXXXX.txt)
 CLEANUP_FILES+=("$TMP_PROMPT")
 
@@ -190,7 +195,7 @@ HAIKU_TEXT=$(cat "$HAIKU_TEXT_FILE")
 # --- Step 5b: Validate format (warn, never discard) ---
 if [ "$IS_SKIP" != "true" ]; then
     FIRST_LINE=$(head -1 "$HAIKU_TEXT_FILE")
-    if ! echo "$FIRST_LINE" | grep -qE '^## [0-9]{2}:[0-9]{2} \|'; then
+    if ! echo "$FIRST_LINE" | grep -qE '^## ([0-9]{2}:[0-9]{2}|[0-9]{1,2}:[0-9]{2} (AM|PM)) \|'; then
         log "validate" "WARNING: unexpected format: $(echo "$FIRST_LINE" | head -c 80)"
     fi
 fi


### PR DESCRIPTION
Introduces a new top-level `time_format` config key that controls timestamp style in save-session output:

- `"24h"` (default, backward compatible) — produces `14:32`
- `"12h"` — produces `2:32 PM`

### Changes
- `config.example.json`: add `"time_format": "24h"` default
- `scripts/save-session.sh`: read config, branch between `%H:%M` and `%-I:%M %p`
- `scripts/save-session.sh`: widen format-validation regex to accept both formats
- `README.md`: document the new key in the Configuration table

### Compatibility
No behavior change for existing users — the default preserves 24h output.

### Testing
- `scripts/run-tests.sh` passes locally on the branch
- Manually verified both `time_format: "24h"` and `time_format: "12h"` produce correctly-formatted headers that pass the updated validation regex