### PR TITLE
fix(tz): compute log filename date from configured timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Copy `config.example.json` to `config.json` and adjust:
 | `thresholds.delta_lines_trigger` | `50`    | Tool call output lines that trigger auto-save      |
 | `features.ndc_compression`      | `true`  | Enable hourly compression of daily files           |
 | `features.recovery`             | `true`  | Recover missed saves on session start              |
-| `timezone`                       | `UTC`   | Timezone for timestamps and daily file boundaries  |
+| `timezone`                       | *(system local)* | IANA name (e.g. `America/New_York`, `Europe/Paris`) for timestamps and daily file boundaries. Omit or leave empty to use the system clock's local zone. Set this explicitly on a VPS whose system clock is UTC. |
 | `debug`                          | `false` | Verbose logging for cooldowns and locks            |
 
 ## Running tests

--- a/config.example.json
+++ b/config.example.json
@@ -12,6 +12,5 @@
     "ndc_compression": true,
     "recovery": true
   },
-  "debug": false,
-  "timezone": "UTC"
+  "debug": false
 }

--- a/pipeline/_tz.py
+++ b/pipeline/_tz.py
@@ -1,0 +1,41 @@
+"""Timezone-aware date helpers for the memory pipeline.
+
+Reads the ``REMEMBER_TZ`` environment variable (set by ``scripts/log.sh``
+from ``config.json``'s ``.timezone`` field) and produces dates/times in
+that zone. Empty, unset, or invalid values fall back to system local
+time — NOT UTC — so that shell and Python agree on "today" regardless
+of how the plugin is installed or invoked.
+"""
+
+import os
+from datetime import datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+
+def _resolve_tz_from_env():
+    """Return a ``ZoneInfo`` from ``REMEMBER_TZ`` env, or ``None`` for local."""
+    tz_name = os.environ.get("REMEMBER_TZ", "").strip()
+    if not tz_name:
+        return None
+    try:
+        return ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError:
+        return None
+
+
+def now() -> datetime:
+    """Current datetime in ``REMEMBER_TZ`` if set, else naive system local."""
+    tz = _resolve_tz_from_env()
+    if tz is not None:
+        return datetime.now(tz)
+    return datetime.now()
+
+
+def today_str() -> str:
+    """Today's date as ``YYYY-MM-DD`` in the resolved timezone."""
+    return now().strftime("%Y-%m-%d")
+
+
+def time_str() -> str:
+    """Current time as ``HH:MM:SS`` in the resolved timezone."""
+    return now().strftime("%H:%M:%S")

--- a/pipeline/log.py
+++ b/pipeline/log.py
@@ -14,20 +14,20 @@ configured log directory (typically ``.remember/logs/``).
 
 import os
 import sys
-from datetime import datetime
 
+from ._tz import time_str, today_str
 from .types import TokenUsage
 
 
 def _log_path(log_dir: str) -> str:
     """Return today's log file path, creating the directory if needed."""
     os.makedirs(log_dir, exist_ok=True)
-    return os.path.join(log_dir, f"memory-{datetime.now():%Y-%m-%d}.log")
+    return os.path.join(log_dir, f"memory-{today_str()}.log")
 
 
 def _timestamp() -> str:
     """Return current time as HH:MM:SS string."""
-    return datetime.now().strftime("%H:%M:%S")
+    return time_str()
 
 
 def log(component: str, message: str, log_dir: str) -> None:

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -195,11 +195,11 @@ def cmd_consolidate(staging_dir: str, recent_file: str, archive_file: str) -> No
     """
     import glob as globmod
     import tempfile
-    from datetime import datetime
 
+    from ._tz import today_str
     from .consolidate import consolidate
 
-    today = datetime.now().strftime("%Y-%m-%d")
+    today = today_str()
 
     # Find staging files (exclude today + .done files)
     staging_contents: dict[str, str] = {}

--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -40,7 +40,36 @@ if ! mkdir -p "$REMEMBER_LOG_DIR" 2>/dev/null; then
     return 1 2>/dev/null || true
 fi
 
-MEMORY_LOG_DATE=$(TZ="$REMEMBER_TZ" date +%Y-%m-%d)
+# Read .timezone from config.json BEFORE computing MEMORY_LOG_DATE — otherwise
+# TZ="" falls back to UTC on macOS/BSD and produces next-day filenames after
+# ~20:00 local in zones west of UTC.
+REMEMBER_CONFIG="${PROJECT_DIR:-.}/.claude/remember/config.json"
+config() {
+    local key="$1"
+    local default="$2"
+    if [ -f "$REMEMBER_CONFIG" ] && command -v jq >/dev/null 2>&1; then
+        local val
+        val=$(jq -r "$key // empty" "$REMEMBER_CONFIG" 2>/dev/null)
+        [ -n "$val" ] && echo "$val" || echo "$default"
+    else
+        echo "$default"
+    fi
+}
+
+REMEMBER_TZ=$(config ".timezone" "")
+export REMEMBER_TZ
+
+# Resolve "today" / "now" using REMEMBER_TZ when set, else system local.
+# Crucially, an empty REMEMBER_TZ must NOT produce `TZ="" date` — that's UTC.
+_remember_date() {
+    if [ -n "$REMEMBER_TZ" ]; then
+        TZ="$REMEMBER_TZ" date "$@"
+    else
+        date "$@"
+    fi
+}
+
+MEMORY_LOG_DATE=$(_remember_date +%Y-%m-%d)
 MEMORY_LOG_FILE="${REMEMBER_LOG_DIR}/memory-${MEMORY_LOG_DATE}.log"
 
 # Log a timestamped message to the daily pipeline log file.
@@ -56,7 +85,7 @@ log() {
     local component="$1"
     local message="$2"
     local timestamp
-    timestamp=$(TZ="$REMEMBER_TZ" date +%H:%M:%S)
+    timestamp=$(_remember_date +%H:%M:%S)
     echo "${timestamp} [${component}] ${message}" >> "$MEMORY_LOG_FILE" 2>/dev/null \
         || echo "${timestamp} [${component}] ${message}" >&2
 }
@@ -116,21 +145,6 @@ safe_eval() {
 #
 # Usage:
 #   SAVE_COOLDOWN=$(config ".cooldowns.save_seconds" 120)
-REMEMBER_CONFIG="${PROJECT_DIR:-.}/.claude/remember/config.json"
-config() {
-    local key="$1"
-    local default="$2"
-    if [ -f "$REMEMBER_CONFIG" ] && command -v jq >/dev/null 2>&1; then
-        local val
-        val=$(jq -r "$key // empty" "$REMEMBER_CONFIG" 2>/dev/null)
-        [ -n "$val" ] && echo "$val" || echo "$default"
-    else
-        echo "$default"
-    fi
-}
-
-REMEMBER_TZ=$(config ".timezone" "Europe/Paris")
-
 # Dispatch a lifecycle event to all registered hooks.
 #
 # Runs every executable in hooks.d/<event>/, passing the project path

--- a/scripts/post-tool-hook.sh
+++ b/scripts/post-tool-hook.sh
@@ -89,7 +89,7 @@ if [ "$DELTA" -gt "$DELTA_THRESHOLD" ]; then
 
     if [ "$ALREADY_RUNNING" = false ]; then
         mkdir -p "$PROJECT/.remember/logs/autonomous"
-        nohup "$SAVE_SCRIPT" "$SESSION_ID" > "$PROJECT/.remember/logs/autonomous/save-$(date +%H%M%S).log" 2>&1 &
+        nohup "$SAVE_SCRIPT" "$SESSION_ID" > "$PROJECT/.remember/logs/autonomous/save-$(_remember_date +%H%M%S).log" 2>&1 &
         echo $! > "$PID_FILE"
         SAVE_TRIGGERED="true"
     fi

--- a/scripts/resolve-paths.sh
+++ b/scripts/resolve-paths.sh
@@ -50,7 +50,7 @@ else
     # Try to log if we can find a log directory
     _log_dir="${CLAUDE_PROJECT_DIR:-.}/.remember/logs"
     if [ -d "$_log_dir" ]; then
-        echo "$(date '+%H:%M:%S') [resolve] $_msg" >> "$_log_dir/memory-$(date +%Y-%m-%d).log" 2>/dev/null
+        echo "$(date '+%H:%M:%S') [resolve] $_msg" >> "$_log_dir/memory-$(date '+%Y-%m-%d').log" 2>/dev/null
     fi
     exit 1
 fi
@@ -71,7 +71,7 @@ else
     echo "$_msg" >&2
     _log_dir="${PROJECT_DIR:-.}/.remember/logs"
     if [ -d "$_log_dir" ]; then
-        echo "$(date '+%H:%M:%S') [resolve] $_msg" >> "$_log_dir/memory-$(date +%Y-%m-%d).log" 2>/dev/null
+        echo "$(date '+%H:%M:%S') [resolve] $_msg" >> "$_log_dir/memory-$(date '+%Y-%m-%d').log" 2>/dev/null
     fi
     exit 1
 fi

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -3,12 +3,25 @@
 import os
 import sys
 import tempfile
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from pipeline.log import log, log_tokens, format_duration
 from pipeline.types import TokenUsage
+
+
+def _frozen_datetime(moment_utc):
+    """A minimal drop-in for ``datetime`` whose ``now()`` is fixed in time."""
+    class Frozen:
+        @staticmethod
+        def now(tz=None):
+            if tz is None:
+                return moment_utc.astimezone().replace(tzinfo=None)
+            return moment_utc.astimezone(tz)
+
+    return Frozen
 
 
 def test_log_creates_file_and_writes():
@@ -90,3 +103,32 @@ def test_log_tokens_with_zero_cost():
         content = open(os.path.join(d, files[0])).read()
         assert "[save] tokens:" in content
         assert "$0.0000" in content
+
+
+def test_log_filename_uses_remember_tz(monkeypatch):
+    """Regression: at 03:12 UTC on 04-23, with REMEMBER_TZ=America/New_York,
+    the filename must be memory-2026-04-22.log (local EDT), not 04-23 (UTC).
+
+    This is the exact bug: the plugin was stamping filenames with UTC,
+    producing next-day filenames after 20:00 local on EDT.
+    """
+    monkeypatch.setenv("REMEMBER_TZ", "America/New_York")
+    moment = datetime(2026, 4, 23, 3, 12, 0, tzinfo=timezone.utc)
+    with tempfile.TemporaryDirectory() as d:
+        with patch("pipeline._tz.datetime", _frozen_datetime(moment)):
+            log("test", "boundary check", d)
+        files = os.listdir(d)
+    assert files == ["memory-2026-04-22.log"], (
+        f"Expected memory-2026-04-22.log (EDT), got {files}"
+    )
+
+
+def test_log_timestamp_uses_remember_tz(monkeypatch):
+    """Timestamp inside the log line must be in REMEMBER_TZ, not UTC."""
+    monkeypatch.setenv("REMEMBER_TZ", "America/New_York")
+    moment = datetime(2026, 4, 23, 3, 12, 45, tzinfo=timezone.utc)
+    with tempfile.TemporaryDirectory() as d:
+        with patch("pipeline._tz.datetime", _frozen_datetime(moment)):
+            log("test", "stamp check", d)
+        content = open(os.path.join(d, os.listdir(d)[0])).read()
+    assert content.startswith("23:12:45 [test]"), f"unexpected content: {content!r}"

--- a/tests/test_log_sh.py
+++ b/tests/test_log_sh.py
@@ -1,0 +1,123 @@
+"""Shell-level regression tests for scripts/log.sh.
+
+The critical bug we're locking down: ``MEMORY_LOG_DATE`` used to be
+computed at source-time (line 43 of log.sh) BEFORE ``REMEMBER_TZ`` was
+set (line 132). With an empty ``TZ=`` prefix, macOS/BSD ``date`` silently
+falls back to UTC, producing filenames one day ahead of the user's
+local date after roughly 20:00 EDT.
+
+These tests run log.sh in a subprocess with a forced system ``TZ=UTC``
+and a config pointing to ``America/Los_Angeles``. If log.sh respects
+the config, ``MEMORY_LOG_DATE`` should match the LA date. If log.sh
+has the ordering bug, it will match the UTC date instead.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LOG_SH = REPO_ROOT / "scripts" / "log.sh"
+
+
+def _run_logsh(project_dir, system_tz):
+    """Source log.sh under the given system TZ and return MEMORY_LOG_DATE + expected date for the configured TZ."""
+    script = f"""
+    set -e
+    export PROJECT_DIR={project_dir}
+    source {LOG_SH}
+    # Compute what the date SHOULD be if log.sh honored REMEMBER_TZ
+    expected=$(TZ="$REMEMBER_TZ" date +%Y-%m-%d)
+    # Extract the date embedded in MEMORY_LOG_FILE
+    actual=$(basename "$MEMORY_LOG_FILE" | sed -E 's/^memory-//;s/\\.log$//')
+    echo "EXPECTED=$expected"
+    echo "ACTUAL=$actual"
+    echo "REMEMBER_TZ=$REMEMBER_TZ"
+    """
+    env = {**os.environ, "TZ": system_tz}
+    result = subprocess.run(
+        ["bash", "-c", script], env=env, capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"log.sh failed: {result.stderr}"
+    parsed = {}
+    for line in result.stdout.strip().splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            parsed[k] = v
+    return parsed
+
+
+def _make_project(tmp_path, timezone_value):
+    project = tmp_path / "proj"
+    (project / ".claude" / "remember").mkdir(parents=True)
+    (project / ".remember" / "logs").mkdir(parents=True)
+    if timezone_value is not None:
+        (project / ".claude" / "remember" / "config.json").write_text(
+            f'{{"timezone": "{timezone_value}"}}'
+        )
+    return project
+
+
+def test_log_sh_uses_configured_timezone_over_system_tz(tmp_path):
+    """Regression: config.timezone must drive MEMORY_LOG_DATE, not system TZ.
+
+    With system TZ=UTC and config.timezone=America/Los_Angeles, the
+    resolved MEMORY_LOG_DATE must match the LA date at the same instant.
+    If the load-order bug returns, this will match the UTC date instead
+    (roughly 5–8pm Pacific onwards, LA and UTC disagree on day).
+    """
+    project = _make_project(tmp_path, "America/Los_Angeles")
+    result = _run_logsh(project, system_tz="UTC")
+    assert result["REMEMBER_TZ"] == "America/Los_Angeles"
+    assert result["ACTUAL"] == result["EXPECTED"], (
+        f"MEMORY_LOG_DATE={result['ACTUAL']} but LA date is {result['EXPECTED']} "
+        "(ordering bug: MEMORY_LOG_DATE computed before REMEMBER_TZ was set)"
+    )
+
+
+def test_log_sh_no_config_falls_back_to_system_local_not_utc(tmp_path):
+    """Regression: no config.json should mean system local, NOT UTC.
+
+    If REMEMBER_TZ falls back to empty string, log.sh must not pass
+    ``TZ=""`` to date — that silently becomes UTC on BSD/macOS/Linux.
+    Expected behavior: omit TZ prefix entirely, letting date use system TZ.
+    """
+    project = _make_project(tmp_path, timezone_value=None)
+    # Force a known system TZ so we can assert against it
+    result = _run_logsh(project, system_tz="America/Los_Angeles")
+    # Expected: LA date (system TZ) — not UTC
+    expected_la = subprocess.run(
+        ["bash", "-c", "TZ=America/Los_Angeles date +%Y-%m-%d"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    assert result["ACTUAL"] == expected_la, (
+        f"Empty REMEMBER_TZ should fall back to system local ({expected_la}), "
+        f"not UTC. Got: {result['ACTUAL']}"
+    )
+
+
+def test_log_sh_log_function_produces_filename_matching_configured_tz(tmp_path):
+    """End-to-end: calling log() writes to a file whose name matches REMEMBER_TZ date."""
+    project = _make_project(tmp_path, "America/Los_Angeles")
+    log_dir = project / ".remember" / "logs"
+    script = f"""
+    set -e
+    export PROJECT_DIR={project}
+    source {LOG_SH}
+    log test "hello from tz test"
+    """
+    subprocess.run(
+        ["bash", "-c", script],
+        env={**os.environ, "TZ": "UTC"},
+        check=True,
+        capture_output=True,
+    )
+    files = list(log_dir.iterdir())
+    assert len(files) == 1
+    expected_la = subprocess.run(
+        ["bash", "-c", "TZ=America/Los_Angeles date +%Y-%m-%d"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+    assert files[0].name == f"memory-{expected_la}.log", (
+        f"Log file {files[0].name} does not match LA date {expected_la}"
+    )

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -4,6 +4,7 @@ import json
 import os
 import sys
 import tempfile
+from datetime import datetime, timezone
 from io import StringIO
 from unittest.mock import patch
 
@@ -332,8 +333,8 @@ def test_cmd_parse_haiku_with_output_file(capsys):
 
 def test_cmd_consolidate_skips_today_file(capsys):
     """A staging file named with today's date is excluded from consolidation."""
-    from datetime import datetime
-    today = datetime.now().strftime("%Y-%m-%d")
+    from pipeline._tz import today_str
+    today = today_str()
 
     with tempfile.TemporaryDirectory() as d:
         today_file = os.path.join(d, f"today-{today}.md")
@@ -343,6 +344,43 @@ def test_cmd_consolidate_skips_today_file(capsys):
         cmd_consolidate(staging_dir=d, recent_file="/nonexistent", archive_file="/nonexistent")
 
     assert "STAGING_COUNT=0" in capsys.readouterr().out
+
+
+def test_cmd_consolidate_today_filter_respects_remember_tz(monkeypatch, capsys):
+    """Regression: the 'today' filter in consolidate uses REMEMBER_TZ, not UTC.
+
+    At 03:12 UTC on 04-23 with REMEMBER_TZ=America/New_York, 'today' is
+    04-22 in the user's zone. A staging file named ``today-2026-04-22.md``
+    must be SKIPPED (it's today locally), not consolidated as yesterday.
+    If Python used UTC here, the file would be consolidated prematurely —
+    a correctness bug, not just cosmetic.
+    """
+    monkeypatch.setenv("REMEMBER_TZ", "America/New_York")
+    moment = datetime(2026, 4, 23, 3, 12, 0, tzinfo=timezone.utc)
+
+    class Frozen:
+        @staticmethod
+        def now(tz=None):
+            if tz is None:
+                return moment.astimezone().replace(tzinfo=None)
+            return moment.astimezone(tz)
+
+    with tempfile.TemporaryDirectory() as d:
+        edt_today = os.path.join(d, "today-2026-04-22.md")
+        with open(edt_today, "w") as f:
+            f.write("today in EDT — should be skipped")
+
+        # Guard rail: patch consolidate so a bug here can never hit the real API.
+        with patch("pipeline.consolidate.consolidate") as mock_con, \
+                patch("pipeline._tz.datetime", Frozen):
+            cmd_consolidate(
+                staging_dir=d,
+                recent_file="/nonexistent",
+                archive_file="/nonexistent",
+            )
+
+    assert "STAGING_COUNT=0" in capsys.readouterr().out
+    mock_con.assert_not_called()
 
 
 def test_cmd_consolidate_skips_done_file(capsys):

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -1,0 +1,92 @@
+"""Tests for pipeline._tz — timezone-aware date helpers.
+
+Regression tests for the bug where log filenames were stamped with UTC
+instead of the configured timezone, producing filenames like
+``memory-2026-04-23.log`` when the user's local date was still 04-22.
+
+The helpers read the ``REMEMBER_TZ`` environment variable (which the
+shell sets from config.json's ``.timezone`` field). Empty/unset/invalid
+values fall back to system local time — never to UTC — so a user on a
+local-time system clock without a config file still gets correct dates.
+"""
+
+import os
+import sys
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from pipeline import _tz
+
+
+def _fake_datetime_at(moment_utc: datetime):
+    """Return a mock replacement for ``datetime`` that freezes ``now()``."""
+    class FrozenDatetime:
+        @staticmethod
+        def now(tz=None):
+            if tz is None:
+                # Simulate system local clock. Tests that rely on this must
+                # also set TZ-independent expectations or mock further.
+                return moment_utc.astimezone().replace(tzinfo=None)
+            return moment_utc.astimezone(tz)
+
+    return FrozenDatetime
+
+
+def test_today_str_uses_remember_tz_env(monkeypatch):
+    """REMEMBER_TZ=America/New_York produces yesterday's local date at 03:12 UTC."""
+    monkeypatch.setenv("REMEMBER_TZ", "America/New_York")
+    # 2026-04-23 03:12 UTC == 2026-04-22 23:12 EDT
+    moment = datetime(2026, 4, 23, 3, 12, 0, tzinfo=timezone.utc)
+    with patch("pipeline._tz.datetime", _fake_datetime_at(moment)):
+        assert _tz.today_str() == "2026-04-22"
+
+
+def test_time_str_uses_remember_tz_env(monkeypatch):
+    """REMEMBER_TZ=America/New_York produces EDT wall-clock time, not UTC."""
+    monkeypatch.setenv("REMEMBER_TZ", "America/New_York")
+    moment = datetime(2026, 4, 23, 3, 12, 45, tzinfo=timezone.utc)
+    with patch("pipeline._tz.datetime", _fake_datetime_at(moment)):
+        assert _tz.time_str() == "23:12:45"
+
+
+def test_today_str_empty_tz_env_does_not_fallback_to_utc(monkeypatch):
+    """Empty REMEMBER_TZ means system local time — NOT UTC (that was the bug)."""
+    monkeypatch.setenv("REMEMBER_TZ", "")
+    moment = datetime(2026, 4, 23, 3, 12, 0, tzinfo=timezone.utc)
+    with patch("pipeline._tz.datetime", _fake_datetime_at(moment)):
+        result = _tz.today_str()
+    # We can't assert a specific date without knowing the CI tz, but we CAN
+    # assert it's not the UTC date unless the system also runs in UTC — so
+    # we verify the format and that the function completed. The shell-level
+    # test covers the UTC-specific regression.
+    assert len(result) == 10 and result[4] == "-" and result[7] == "-"
+
+
+def test_today_str_unset_tz_env_uses_system_local(monkeypatch):
+    """Unset REMEMBER_TZ falls back to system local, not UTC."""
+    monkeypatch.delenv("REMEMBER_TZ", raising=False)
+    result = _tz.today_str()
+    assert len(result) == 10 and result[4] == "-" and result[7] == "-"
+
+
+def test_today_str_invalid_tz_falls_back_silently(monkeypatch):
+    """An unknown TZ name does not crash — falls back to system local."""
+    monkeypatch.setenv("REMEMBER_TZ", "Not/AReal/Zone")
+    result = _tz.today_str()
+    assert len(result) == 10 and result[4] == "-" and result[7] == "-"
+
+
+def test_now_returns_aware_datetime_when_tz_set(monkeypatch):
+    """With a valid TZ, now() returns a timezone-aware datetime."""
+    monkeypatch.setenv("REMEMBER_TZ", "America/New_York")
+    result = _tz.now()
+    assert result.tzinfo is not None
+
+
+def test_now_returns_naive_datetime_when_tz_unset(monkeypatch):
+    """With no TZ configured, now() returns a naive datetime (system local)."""
+    monkeypatch.delenv("REMEMBER_TZ", raising=False)
+    result = _tz.now()
+    assert result.tzinfo is None


### PR DESCRIPTION
## Summary

The daily log filename (`memory-YYYY-MM-DD.log`) is being stamped with UTC instead of the user's configured timezone, producing next-day filenames after ~20:00 local in zones west of UTC.

**Root cause:** `scripts/log.sh:43` computes `MEMORY_LOG_DATE` with `TZ="$REMEMBER_TZ" date +%Y-%m-%d`, but `REMEMBER_TZ` isn't defined until `scripts/log.sh:132` — 89 lines later. With an empty `TZ=` prefix, macOS/BSD `date` silently falls back to UTC. The `log()` function's *internal* timestamps were correct because they're computed lazily, after `REMEMBER_TZ` was populated. Filenames were wrong; content was right.

## How I reproduced it

At 23:12 EDT on 2026-04-22:
- `TZ="" date` → `2026-04-23 03:12 UTC` ✗
- `TZ="America/New_York" date` → `2026-04-22 23:12 EDT` ✓

`silent-stone/.remember/logs/` had both `memory-2026-04-22.log` *and* `memory-2026-04-23.log` side-by-side, with EDT-correct timestamps (`23:12:06`) written inside the 04-23-named file.

## Fix

- **`scripts/log.sh`** — move `REMEMBER_CONFIG` / `config()` / `REMEMBER_TZ` definitions above `MEMORY_LOG_DATE`. Introduce `_remember_date()` so an empty `REMEMBER_TZ` uses system local time (omit `TZ=` prefix), **not** UTC. Change the fallback default from `"Europe/Paris"` to empty string. `export REMEMBER_TZ` so Python subprocesses inherit it.
- **`pipeline/_tz.py`** *(new)* — shared `now()` / `today_str()` / `time_str()` reading `REMEMBER_TZ` via `zoneinfo`. Invalid TZ names fall back silently to system local.
- **`pipeline/log.py`** — filename + timestamp now route through `_tz`.
- **`pipeline/shell.py`** — `cmd_consolidate`'s "today" filter uses `_tz.today_str()`. This was a silent correctness bug beyond filenames: the filter excludes today's staging files from consolidation by substring-matching `today` against filenames. If Python disagreed with shell about "today," staging files could be consolidated prematurely.
- **`config.example.json`** — remove the `"timezone": "UTC"` landmine so users who copy the example verbatim don't inherit the same bug.
- **`scripts/post-tool-hook.sh`** — autonomous save-log filename now uses `_remember_date` (runs after `log.sh` is sourced).
- **`README.md`** — clarify that `timezone` is optional and defaults to system local.

## Regression tests (all new)

- `tests/test_tz.py` — 7 tests covering `REMEMBER_TZ` resolution, empty/unset/invalid fallbacks, and the specific day-boundary frozen at 2026-04-23 03:12 UTC → 2026-04-22 23:12 EDT.
- `tests/test_log_sh.py` — 3 shell-level regressions running `log.sh` in subprocesses with a forced `TZ=UTC` system env and `timezone: America/Los_Angeles` config. Verifies filenames track the configured zone, and that an empty config correctly falls back to system local instead of UTC.
- `tests/test_log.py` — 2 new Python regressions.
- `tests/test_shell.py` — 1 new regression for `cmd_consolidate`'s today-filter (with a `mock_con.assert_not_called()` guard rail so a future bug here can't accidentally hit the real Haiku API, as my first RED run unfortunately did).

## Test plan

- [x] `pytest tests/` — 199 passed (baseline was 186), coverage 99.12% (≥80% enforced).
- [x] Manual end-to-end: `log.sh` with `timezone: America/New_York` + system `TZ=UTC` → filename matches EDT date.
- [x] Manual end-to-end: empty config + system `TZ=America/Los_Angeles` → filename matches LA date, not UTC.
- [x] Round-trip: `timezone: UTC` + system `TZ=America/New_York` → filename matches UTC (verifies config actually drives the date, not system clock).
- [x] Python: `log()` with frozen clock at 03:12 UTC + `REMEMBER_TZ=America/New_York` → `memory-2026-04-22.log` with `23:12` timestamp inside.
- [x] Python: `cmd_consolidate`'s today-filter correctly skips a staging file named for EDT "today" (04-22) even when UTC date is 04-23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)