### PR TITLE
Windows bootstrap fix + TMPDIR portability + README prereqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,17 @@ In practice, running this all day costs **a few cents per day**. The Anthropic A
 - Python 3.9+
 - Claude CLI (`claude`) with Haiku access
 - Bash 4+
+- `jq` (used by `log.sh` / `session-start-hook.sh` to read `config.json`)
+- Standard coreutils (`date`, `find`, `tar`, `tr`, `wc`) — preinstalled on macOS/Linux
+
+### Windows
+
+All hooks and pipeline scripts are bash, so Windows users need a POSIX environment in `PATH`. Two supported options:
+
+- **Git Bash / MSYS2** (simplest) — installed by [Git for Windows](https://git-scm.com/download/win). Ships bash, coreutils, and `find`/`tar`/`tr`. You still need to install `jq` and `python3` separately (via [Scoop](https://scoop.sh/), [Chocolatey](https://chocolatey.org/), or the [official installers](https://www.python.org/downloads/windows/)).
+- **WSL** — any Linux distro; works like a native Linux install.
+
+Make sure `bash`, `jq`, and `python3` are resolvable from the shell Claude Code launches hooks in.
 
 ## Setup
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start-hook.sh\" 2>> \"${CLAUDE_PROJECT_DIR:-.}/.remember/logs/hook-errors.log\""
+            "command": "mkdir -p \"${CLAUDE_PROJECT_DIR:-.}/.remember/logs\" && bash \"${CLAUDE_PLUGIN_ROOT}/scripts/session-start-hook.sh\" 2>> \"${CLAUDE_PROJECT_DIR:-.}/.remember/logs/hook-errors.log\""
           }
         ]
       }
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-hook.sh\" 2>> \"${CLAUDE_PROJECT_DIR:-.}/.remember/logs/hook-errors.log\""
+            "command": "mkdir -p \"${CLAUDE_PROJECT_DIR:-.}/.remember/logs\" && bash \"${CLAUDE_PLUGIN_ROOT}/scripts/post-tool-hook.sh\" 2>> \"${CLAUDE_PROJECT_DIR:-.}/.remember/logs/hook-errors.log\""
           }
         ]
       }

--- a/scripts/user-prompt-hook.sh
+++ b/scripts/user-prompt-hook.sh
@@ -35,8 +35,9 @@ source "$PLUGIN_ROOT/scripts/log.sh" 2>/dev/null
 
 # --- Timestamp + context injection ---
 CTX_PCT=""
-if [ -f /tmp/claude-ctx-pct ]; then
-  CTX_PCT=$(cat /tmp/claude-ctx-pct 2>/dev/null)
+CTX_PCT_FILE="${TMPDIR:-/tmp}/claude-ctx-pct"
+if [ -f "$CTX_PCT_FILE" ]; then
+  CTX_PCT=$(cat "$CTX_PCT_FILE" 2>/dev/null)
 fi
 if [ -n "$CTX_PCT" ]; then
   TIMESTAMP="[$(TZ="$REMEMBER_TZ" date '+%H:%M %Z') — $(whoami) — ${CTX_PCT}%]"


### PR DESCRIPTION
## Summary

Three small fixes surfaced while installing the plugin on Windows (Git Bash / MSYS2). Each commit is independent — feel free to cherry-pick.

- **fix(hooks)** — the `SessionStart` and `PostToolUse` hook commands in `hooks/hooks.json` redirect stderr to `.remember/logs/hook-errors.log` via `2>>`. Bash opens the redirect target before running the script, so on the first invocation in a fresh project (when the `.remember/logs/` directory does not yet exist) the redirect fails and the hook script never runs — even though the script itself contains `mkdir -p .remember/logs` near the top. Classic chicken-and-egg. Prefix both commands with `mkdir -p ... &&` so the redirect target is guaranteed to exist.

- **fix(user-prompt-hook)** — `user-prompt-hook.sh` reads `/tmp/claude-ctx-pct`. Works on macOS/Linux, but on Windows Git Bash the `/tmp` mapping may differ from what other processes that write the file expect. Honor `\$TMPDIR` with a `/tmp` fallback. No behavior change on default macOS/Linux.

- **docs(readme)** — the Requirements section listed Python / bash / Claude CLI but not `jq` (which `log.sh` and `session-start-hook.sh` rely on). Add `jq` + coreutils, and a short Windows subsection documenting the supported POSIX environments (Git Bash/MSYS2, WSL) and the need to install `jq` / `python3` alongside Git for Windows.

## Reproduction

On a fresh project (Windows or Unix):
1. Install the plugin.
2. Start a new Claude Code session.
3. Hook logs a "No such file or directory" warning on `.remember/logs/hook-errors.log`. Subsequent invocations succeed (the hook script's own `mkdir -p` eventually runs once something else creates the directory), but the first session's SessionStart memory injection is lost.

## Test plan

- [x] Applied the same two code changes locally at `~/.claude/plugins/cache/claude-plugins-official/remember/0.5.0/` on Windows 11 with Git Bash + MSYS2 + jq + Python 3.11. Warning disappears on new-project startup; memory pipeline runs normally.
- [ ] `scripts/run-tests.sh` — not run (Windows MSYS2 test env not set up by this contributor). Upstream test run would be appreciated.

## Not changed

- `nohup` usage in `session-start-hook.sh` / `post-tool-hook.sh` — on Windows MSYS2 this doesn't truly detach, but fixing it properly likely requires a platform-specific backgrounding strategy. Out of scope for this PR.