### PR TITLE
Windows: fix session-dir slug mismatch and Python detection

### DIFF
--- a/scripts/detect-tools.sh
+++ b/scripts/detect-tools.sh
@@ -84,8 +84,24 @@ safe_eval() {
 }
 
 # --- CRLF-safe session dir slug ---
-# Replaces all non-alphanumeric chars with dashes (matches bash sed pattern).
-# Works for both Unix (/home/user/project) and Windows (D:\Users\project) paths.
+# Replaces all non-alphanumeric chars with dashes. Must match Claude Code's
+# own slug pattern for its ~/.claude/projects/<slug>/ session directories.
+#
+# Unix: Claude Code slugs the native path directly (e.g., /home/u/p → -home-u-p).
+#
+# Windows: Claude Code slugs the native Windows path with the drive letter
+# lowercased (e.g., D:\Users\p → d--Users-p). Hook scripts on Git Bash / MSYS
+# receive the path in Unix form (/d/Users/p), which would slug differently
+# (-d-Users-p). Convert back to the Windows form via cygpath before slugging
+# so we match the actual directory Claude Code created.
 session_dir_slug() {
-    echo "$1" | sed 's/[^a-zA-Z0-9]/-/g'
+    local path="$1"
+    if command -v cygpath >/dev/null 2>&1; then
+        local winpath
+        winpath=$(cygpath -w "$path" 2>/dev/null) || winpath="$path"
+        # Lowercase the drive letter (first character) to match Claude Code.
+        path="${winpath:0:1}"
+        path="${path,,}${winpath:1}"
+    fi
+    echo "$path" | sed 's/[^a-zA-Z0-9]/-/g'
 }

--- a/scripts/detect-tools.sh
+++ b/scripts/detect-tools.sh
@@ -25,13 +25,21 @@
 # ============================================================================
 
 # --- Detect Python ---
-# Try python3 first (macOS/Linux default), fall back to python (Windows)
-if command -v python3 >/dev/null 2>&1; then
-    PYTHON="python3"
-elif command -v python >/dev/null 2>&1; then
-    PYTHON="python"
-else
-    echo "FATAL: Neither python3 nor python found in PATH" >&2
+# Try python3 first (macOS/Linux default), fall back to python, then the
+# Windows `py` launcher. On Windows, `python3` and `python` may resolve to
+# the Microsoft Store placeholder (a stub that only opens the Store when
+# Python is not installed via Store). A `command -v` check alone is not
+# enough — validate with `-V` to confirm the binary actually runs.
+PYTHON=""
+for _candidate in "python3" "python" "py -3" "py"; do
+    _first="${_candidate%% *}"
+    if command -v "$_first" >/dev/null 2>&1 && $_candidate -V >/dev/null 2>&1; then
+        PYTHON="$_candidate"
+        break
+    fi
+done
+if [ -z "$PYTHON" ]; then
+    echo "FATAL: No working Python found. Tried: python3, python, py -3, py. Windows users: install Python from python.org (not Microsoft Store) and ensure 'python' or 'py' works from the shell Claude Code launches hooks in." >&2
     exit 1
 fi
 export PYTHON

--- a/scripts/post-tool-hook.sh
+++ b/scripts/post-tool-hook.sh
@@ -37,7 +37,7 @@ log "hook" "post-tool: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR PYTHO
 SAVE_SCRIPT="$PLUGIN_ROOT/scripts/save-session.sh"
 LAST_SAVE_FILE="$PROJECT/.remember/tmp/last-save.json"
 PID_FILE="$PROJECT/.remember/tmp/save-session.pid"
-SESSION_DIR="$HOME/.claude/projects/$(echo "$PROJECT" | sed 's/[^a-zA-Z0-9]/-/g')"
+SESSION_DIR="$HOME/.claude/projects/$(session_dir_slug "$PROJECT")"
 
 [ -f "$SAVE_SCRIPT" ] || exit 0
 

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -100,7 +100,7 @@ for arg in "$@"; do
     esac
 done
 
-SESSION_DIR_PATH="$HOME/.claude/projects/$(echo "$PROJECT_DIR" | sed 's/[^a-zA-Z0-9]/-/g')"
+SESSION_DIR_PATH="$HOME/.claude/projects/$(session_dir_slug "$PROJECT_DIR")"
 if [ -z "$SESSION_ID" ]; then
     LATEST_JSONL=$(ls -t "$SESSION_DIR_PATH"/*.jsonl 2>/dev/null | head -1)
     SESSION_ID=$(basename "$LATEST_JSONL" .jsonl)

--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -61,7 +61,7 @@ done
 
 # ── Recovery: save the most recent missed session ──────────────────────────
 if [ "$(cfg '.features.recovery' true)" = "true" ]; then
-PROJECT_PATH_SLUG="$(echo "$PROJECT" | sed 's/[^a-zA-Z0-9]/-/g')"
+PROJECT_PATH_SLUG="$(session_dir_slug "$PROJECT")"
 SESSIONS_DIR="$HOME/.claude/projects/${PROJECT_PATH_SLUG}"
 LAST_SAVE_FILE="$PROJECT/.remember/tmp/last-save.json"
 


### PR DESCRIPTION
## Summary

Two independent Windows-compatibility fixes. Together, they unblock the memory pipeline on Windows 11 + MSYS2 — on my machine, `.remember/now.md` and `today-*.md` were never being written before these changes even though the hooks were registered and running.

Independent of #28 (the bootstrap `mkdir -p` + TMPDIR + README PR) — no merge conflicts expected either way. Each commit is also independent and can be cherry-picked.

## Commit 1 — `fix(windows): match Claude Code's native session-dir slug`

Every `post-tool-hook.sh` / `session-start-hook.sh` / `save-session.sh` run needs to locate the current session's JSONL under `~/.claude/projects/<slug>/`, where `<slug>` is Claude Code's own slug of the project path.

- **On Linux/macOS:** Claude Code slugs the native path (`/home/u/p` → `-home-u-p`). Hook scripts see the same path. Works.
- **On Windows:** Claude Code slugs the **native Windows path** with the drive letter lowercased (`D:\Projects\Foo` → `d--Projects-Foo`). Hook scripts on Git Bash / MSYS receive the path in POSIX form (`/d/Projects/Foo`), which slugs to `-d-Projects-Foo` — a directory that never exists. `post-tool-hook.sh` then exits silently at line 46 (no JSONL found), and no save ever runs.

Teach `session_dir_slug()` in `detect-tools.sh` to detect MSYS/Cygwin via `cygpath`, convert the POSIX path back to Windows form, lowercase the drive letter, and slug. No behavior change where `cygpath` is absent (macOS/Linux).

Replace three inline `sed '[^a-zA-Z0-9]/-/g'` call sites with `session_dir_slug()` so the fix is centralized — the helper was already sourced in all three scripts but wasn't being used.

### Repro

On Windows 11 + MSYS2 + project at `D:\Projects\Foo`:

\`\`\`bash
\$ echo \"\$PROJECT\"            # what the plugin sees
/d/Projects/Foo
\$ echo \"\$PROJECT\" | sed 's/[^a-zA-Z0-9]/-/g'   # old slug
-d-Projects-Foo
\$ ls ~/.claude/projects/                       # what actually exists
d--Projects-Foo/
\`\`\`

Mismatch → \`post-tool-hook.sh:46 [ -n \"\$LATEST_JSONL\" ] || exit 0\` fires → no save.

## Commit 2 — `fix(windows): validate Python interpreter and add py launcher fallback`

Separate failure mode on Windows without Store-installed Python: `python3` and sometimes `python` resolve to a Microsoft Store placeholder (a stub in `%LOCALAPPDATA%\Microsoft\WindowsApps\` that only opens the Store). `command -v python3` returns success on the stub, but actually running it prints "Python was not found" and exits non-zero. `save-session.sh` then fails midway with arithmetic errors on unset variables the Python pipeline was supposed to set.

Switch detection from `command -v` to a validation loop: for each candidate, verify `<candidate> -V` actually runs. Also add the Windows `py` launcher (`py -3`, `py`) as further fallbacks.

`\$PYTHON` is already used unquoted throughout the scripts, so multi-word values like `"py -3"` expand as two tokens correctly.

## Test plan

- [x] Applied both commits' changes locally at `~/.claude/plugins/cache/claude-plugins-official/remember/0.5.0/` on Windows 11 + MSYS2 + jq + Python 3.10 installed outside Store. Before: `.remember/now.md` never created; log showed only `[hook] post-tool:` breadcrumbs. After: full pipeline runs — `[extract] 187 exchanges`, `[haiku] calling`, `[tokens]`, `[write] appended`, `[ndc] running`. `.remember/now.md` + `.remember/today-*.md` populated correctly.
- [ ] `scripts/run-tests.sh` — not executed by this contributor on Windows (test harness assumes Unix mktemp paths). Maintainer Unix CI run would be appreciated.

## Not changed (potential follow-ups)

- `pipeline/extract.py::_session_dir()` uses the same Unix-form slug strategy. It was not exercised in my testing because `save-session.sh` passes the session ID directly, but code paths that call it standalone (e.g., recovery with only `project_dir`) may still produce the wrong Windows slug. Worth a follow-up.
- `scripts/run-tests.sh:135` has the same inline `sed` slug pattern. Test-only code; would be trivial to switch to `session_dir_slug` for consistency.