### PR TITLE
fix(shell): make mktemp templates work on BSD mktemp (macOS)

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -174,7 +174,7 @@ else
 fi
 
 # 5d. Save position — round trip
-TMP_POS=$(mktemp /tmp/remember-test-pos-XXXXXX.json)
+TMP_POS=$(mktemp /tmp/remember-test-pos-XXXXXX)
 cleanup_files+=("$TMP_POS")
 (cd "$PIPELINE_DIR" && python3 -m pipeline.shell save-position "$TMP_POS" "test-session-xyz" 42)
 SAVED=$(python3 -c "import json; d=json.load(open('$TMP_POS')); print(d['session'], d['line'])")
@@ -185,9 +185,9 @@ else
 fi
 
 # 5e. Build prompt — verify substitution
-TMP_EXTRACT_F=$(mktemp /tmp/remember-test-extract-XXXXXX.txt)
-TMP_LAST_F=$(mktemp /tmp/remember-test-last-XXXXXX.txt)
-TMP_PROMPT_F=$(mktemp /tmp/remember-test-prompt-XXXXXX.txt)
+TMP_EXTRACT_F=$(mktemp /tmp/remember-test-extract-XXXXXX)
+TMP_LAST_F=$(mktemp /tmp/remember-test-last-XXXXXX)
+TMP_PROMPT_F=$(mktemp /tmp/remember-test-prompt-XXXXXX)
 cleanup_files+=("$TMP_EXTRACT_F" "$TMP_LAST_F" "$TMP_PROMPT_F")
 echo "[HUMAN] hello" > "$TMP_EXTRACT_F"
 echo "(no previous entry)" > "$TMP_LAST_F"
@@ -199,8 +199,8 @@ else
 fi
 
 # 5f. Build NDC prompt
-TMP_MEM=$(mktemp /tmp/remember-test-mem-XXXXXX.md)
-TMP_NDC=$(mktemp /tmp/remember-test-ndc-XXXXXX.txt)
+TMP_MEM=$(mktemp /tmp/remember-test-mem-XXXXXX)
+TMP_NDC=$(mktemp /tmp/remember-test-ndc-XXXXXX)
 cleanup_files+=("$TMP_MEM" "$TMP_NDC")
 echo "## 10:30 | test branch\nDid stuff" > "$TMP_MEM"
 (cd "$PIPELINE_DIR" && python3 -m pipeline.shell build-ndc-prompt "$TMP_MEM" "$TMP_NDC")

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -143,7 +143,7 @@ if [ "$DRY_RUN" = true ]; then
 fi
 
 # --- Step 2: Get last entry ---
-TMP_LAST_ENTRY=$(mktemp "${TMPDIR:-/tmp}"/remember-last-entry-XXXXXX.txt)
+TMP_LAST_ENTRY=$(mktemp "${TMPDIR:-/tmp}"/remember-last-entry-XXXXXX)
 CLEANUP_FILES+=("$TMP_LAST_ENTRY")
 if [ -f "$MEMORY_FILE" ]; then
     LAST_LINE=$(grep -n '^## ' "$MEMORY_FILE" | tail -1 | cut -d: -f1)
@@ -155,7 +155,7 @@ fi
 # --- Step 3: Build prompt ---
 BRANCH=$(cd "$PROJECT_DIR" && git branch --show-current 2>/dev/null || echo "unknown")
 CURRENT_TIME=$(TZ="$REMEMBER_TZ" date +%H:%M)
-TMP_PROMPT=$(mktemp "${TMPDIR:-/tmp}"/remember-prompt-XXXXXX.txt)
+TMP_PROMPT=$(mktemp "${TMPDIR:-/tmp}"/remember-prompt-XXXXXX)
 CLEANUP_FILES+=("$TMP_PROMPT")
 
 cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell build-prompt "$EXTRACT_FILE" "$TMP_LAST_ENTRY" "$CURRENT_TIME" "$BRANCH" "$TMP_PROMPT"
@@ -165,7 +165,7 @@ head -1 "$TMP_PROMPT" | grep -q '{{TIME}}\|{{BRANCH}}' && { log "prompt" "ERROR:
 
 # --- Step 4: Call Haiku ---
 log "haiku" "calling (branch: $BRANCH)"
-HAIKU_STDERR=$(mktemp "${TMPDIR:-/tmp}"/remember-haiku-err-XXXXXX.txt)
+HAIKU_STDERR=$(mktemp "${TMPDIR:-/tmp}"/remember-haiku-err-XXXXXX)
 CLEANUP_FILES+=("$HAIKU_STDERR")
 
 HAIKU_JSON=$(cd /tmp && env -u CLAUDECODE claude -p \
@@ -227,13 +227,13 @@ if [ "$RUN_NDC" = true ]; then
     log "ndc" "now.md → today-${TODAY_DATE}.md"
     date +%s > "$NDC_MARKER"
     NDC_SRC_BYTES=$(wc -c < "$MEMORY_FILE" | tr -d ' ')
-    NDC_PROMPT=$(mktemp "${TMPDIR:-/tmp}"/remember-ndc-XXXXXX.txt)
+    NDC_PROMPT=$(mktemp "${TMPDIR:-/tmp}"/remember-ndc-XXXXXX)
 
     cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell build-ndc-prompt "$MEMORY_FILE" "$NDC_PROMPT"
 
     if [ -s "$NDC_PROMPT" ]; then
         (set +e  # don't inherit set -e — claude -p non-zero exit must not kill the subshell
-            NDC_ERR=$(mktemp "${TMPDIR:-/tmp}"/remember-ndc-err-XXXXXX.txt)
+            NDC_ERR=$(mktemp "${TMPDIR:-/tmp}"/remember-ndc-err-XXXXXX)
             NDC_JSON=$(cd /tmp && env -u CLAUDECODE claude -p \
                 --allowedTools "" --model haiku --max-turns 1 \
                 --output-format json \


### PR DESCRIPTION
## Symptom

On macOS, `bash scripts/save-session.sh --force` fails immediately with:

```
mkstemp: File exists
```

…aborting the entire save pipeline. Same failure mode in `scripts/run-tests.sh` section 5.

## Root cause

GNU `mktemp` (Linux) tolerates characters after the `XXXXXX` suffix and silently treats them as a literal suffix on the generated name. **BSD `mktemp` (macOS default) does not** — `man mktemp` says:

> The trailing 'Xs' are replaced with the current process number and/or a unique letter combination. **The Xs must occur at the end of the template.**

Templates like `mktemp /tmp/remember-prompt-XXXXXX.txt` are therefore invalid on BSD; `mktemp` errors out with `mkstemp: File exists`.

## Fix

11 templates across two scripts had characters after `XXXXXX`:

- `scripts/save-session.sh` — 5 sites (`TMP_LAST_ENTRY`, `TMP_PROMPT`, `HAIKU_STDERR`, `NDC_PROMPT`, `NDC_ERR`)
- `scripts/run-tests.sh` — 6 sites (`TMP_POS`, `TMP_EXTRACT_F`, `TMP_LAST_F`, `TMP_PROMPT_F`, `TMP_MEM`, `TMP_NDC`)

All `XXXXXX.{txt,json,md}` → `XXXXXX`. The temp files are short-lived (cleaned up via `trap`) and never opened by extension-sensitive tools, so dropping the suffix has no functional impact on Linux; it makes the templates valid on BSD.

## Verification

- macOS: `bash scripts/save-session.sh --force` now completes the save pipeline end-to-end.
- macOS: `bash scripts/run-tests.sh` no longer fails section 5 sub-tests on `mktemp`.
- Linux behavior unchanged (templates still produce the same per-call unique name; suffix never carried meaning).

## Conflict note for maintainer

PR #29 (Windows session-dir slug + Python detection) also modifies `scripts/save-session.sh` and `scripts/run-tests.sh`. The two PRs touch overlapping `mktemp` lines but with different intent. Suggested merge order:

1. Merge this PR first (small, surgical, BSD portability).
2. Ask #29 to rebase on the new `main` (mktemp lines now end at `XXXXXX`); the rebase should be mechanical.

Happy to rebase if a different order is preferred.