### PR TITLE
fix: detach SessionStart hook children to prevent libuv assertion on Windows

### DIFF
--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -64,7 +64,7 @@ if [ -d "$SESSIONS_DIR" ] && [ -f "$LAST_SAVE_FILE" ]; then
     if [ -n "$LAST_JSONL" ]; then
         LAST_ID=$(basename "$LAST_JSONL" .jsonl)
         if [ "$LAST_ID" != "$SAVED_ID" ]; then
-            "$PLUGIN_ROOT/scripts/save-session.sh" "$LAST_ID" --force 2>/dev/null &
+            "$PLUGIN_ROOT/scripts/save-session.sh" "$LAST_ID" --force </dev/null >/dev/null 2>&1 & disown 2>/dev/null || true
         fi
     fi
 fi
@@ -113,7 +113,7 @@ STAGING_COUNT=$(ls "$PROJECT/.remember/today-"*.md 2>/dev/null | grep -v "today-
 if [ "$STAGING_COUNT" -gt 0 ]; then
     echo "=== MEMORY CONSOLIDATION ==="
     echo "$STAGING_COUNT day(s) of memory to compress. Running consolidation in background..."
-    nohup "$PLUGIN_ROOT/scripts/run-consolidation.sh" > /dev/null 2>&1 &
+    nohup "$PLUGIN_ROOT/scripts/run-consolidation.sh" </dev/null >/dev/null 2>&1 & disown 2>/dev/null || true
     echo ""
 fi
 


### PR DESCRIPTION
## Summary

The `SessionStart` hook in `scripts/session-start-hook.sh` backgrounds two child processes (`save-session.sh` and `run-consolidation.sh`) with bare `&`. On Windows (Git Bash + Claude Code), this triggers a libuv assertion in the parent node.js process that hosts the hook:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76
```

It surfaces as `SessionStart:startup hook error / Failed with non-blocking status code: ...` on every new session. The error is non-blocking (the hook still completes and memory injection still works), but it's noisy and shows up in every fresh terminal on Windows.

## Reproduction

1. Install the plugin on Windows (verified on Windows 11 ARM64 / Surface Pro 11, claude-remember v0.5.0 and v0.7.0).
2. Open a new Claude Code session via `claude` in Git Bash.
3. Observe the `SessionStart:startup hook error` line printed before the prompt.

## Root cause

Bash's bare `&` backgrounds the child but leaves stdin / stdout / stderr connected to the parent shell — which itself inherited them from node's `child_process.spawn`. When bash exits while those fds are still in flight to backgrounded children, libuv on the node side races on closing its async handles, hitting the `UV_HANDLE_CLOSING` assertion.

macOS/Linux libuv handles this case correctly, which is why this only manifests on Windows.

## Fix

Two-line change. Fully detach the backgrounded children:

```diff
-            "$PLUGIN_ROOT/scripts/save-session.sh" "$LAST_ID" --force 2>/dev/null &
+            "$PLUGIN_ROOT/scripts/save-session.sh" "$LAST_ID" --force </dev/null >/dev/null 2>&1 & disown 2>/dev/null || true
```

```diff
-    nohup "$PLUGIN_ROOT/scripts/run-consolidation.sh" > /dev/null 2>&1 &
+    nohup "$PLUGIN_ROOT/scripts/run-consolidation.sh" </dev/null >/dev/null 2>&1 & disown 2>/dev/null || true
```

- `</dev/null` closes the inherited stdin so the child doesn't hold the fd open.
- `>/dev/null 2>&1` closes both output streams.
- `disown` removes the job from the shell's table so bash doesn't track it at exit.
- `2>/dev/null || true` keeps the change inert if `disown` is unavailable (e.g., a non-bash POSIX shell).

Behavior on macOS/Linux is identical — the children still detach and run in the background, the hook still returns immediately.

## Test plan

- [x] Verified on Windows 11 ARM64: assertion no longer fires after the patch.
- [x] Confirmed both backgrounded children still spawn (recovery + consolidation features both still work).
- [x] No existing tests assert the exact backgrounding syntax (`grep` of `tests/test_*.py` for `2>/dev/null &` / `/dev/null 2>&1 &` returns nothing).
- [ ] CI to confirm test_path_resolution.py / test_shell.py still pass against the new line.

## Notes

If you'd prefer a different detachment idiom (e.g., dropping `nohup` since we're already disowning, or using `setsid` instead) happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)