### PR TITLE
Fix silent save failures on Windows + Git Bash (path slug mismatch)

### DIFF
--- a/scripts/resolve-paths.sh
+++ b/scripts/resolve-paths.sh
@@ -91,7 +91,7 @@ fi
 case "$OSTYPE" in
     msys|cygwin)
         if [[ "$PROJECT_DIR" =~ ^/([a-zA-Z])/(.*)$ ]]; then
-            _drive="${BASH_REMATCH[1]^^}"
+            _drive=$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:lower:]' '[:upper:]')
             _rest="${BASH_REMATCH[2]//\//\\}"
             PROJECT_DIR="${_drive}:\\${_rest}"
         fi

--- a/scripts/resolve-paths.sh
+++ b/scripts/resolve-paths.sh
@@ -76,6 +76,28 @@ else
     exit 1
 fi
 
+# --- Windows shell normalization (Git Bash / MSYS / Cygwin) ----------------
+# Claude Code stores sessions under a Windows-native slug (e.g.
+# "C--Users-dev-project") computed from the Win32 path "C:\Users\dev\project".
+# But on Windows shells, $CLAUDE_PROJECT_DIR arrives as a POSIX-style path
+# ("/c/Users/dev/project") and our sed-based slug produces "-c-Users-dev-..."
+# which never matches. The plugin's `ls $SESSION_DIR/*.jsonl` then returns
+# nothing and the entire save pipeline silently no-ops.
+#
+# Convert /c/Users/... → C:\Users\... here so all downstream slug computations
+# (3 shell sites + Python `_session_dir`) align with Claude Code's storage.
+# On Linux/macOS bash $OSTYPE is "linux-gnu" or "darwin*"; the case below
+# never matches and PROJECT_DIR is left untouched.
+case "$OSTYPE" in
+    msys|cygwin)
+        if [[ "$PROJECT_DIR" =~ ^/([a-zA-Z])/(.*)$ ]]; then
+            _drive="${BASH_REMATCH[1]^^}"
+            _rest="${BASH_REMATCH[2]//\//\\}"
+            PROJECT_DIR="${_drive}:\\${_rest}"
+        fi
+        ;;
+esac
+
 # --- Validate both paths exist ---
 if [ ! -d "$PROJECT_DIR" ]; then
     _msg="FATAL: PROJECT_DIR does not exist: $PROJECT_DIR"

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -1180,6 +1180,92 @@ class TestWindowsCompatIssue11:
                 f"Path {path!r}: expected slug {expected_slug!r}, got {result!r}"
             )
 
+    # ── Point 1b: Git Bash / MSYS / Cygwin POSIX-style paths ──
+    # Claude Code on Windows stores sessions under the Win32-path slug
+    # (e.g. C--Users-dev-project from C:\Users\dev\project). But Git Bash
+    # exposes $CLAUDE_PROJECT_DIR as a POSIX-style path (/c/Users/...),
+    # which the existing tests above don't cover and which slugs to a
+    # different folder name (-c-Users-...). resolve-paths.sh normalizes
+    # the POSIX form to Win32 before the slug is computed.
+    #
+    # The transformation is tested via a temp script file (not bash -c) so
+    # that bash parses backslashes the same way it does in the production
+    # script — `bash -c '<body>'` mishandles `\\}` inside `${var//\//\\}`
+    # in some interactive contexts.
+
+    @staticmethod
+    def _msys_normalize_path(path: str, tmp_path) -> tuple[int, str, str]:
+        """Run the production OSTYPE=msys normalization block on a path; return (rc, stdout, stderr)."""
+        script = tmp_path / "msys-normalize.sh"
+        script.write_text(
+            '#!/bin/bash\n'
+            'PROJECT_DIR="$1"\n'
+            'OSTYPE="msys"\n'
+            'case "$OSTYPE" in\n'
+            '    msys|cygwin)\n'
+            '        if [[ "$PROJECT_DIR" =~ ^/([a-zA-Z])/(.*)$ ]]; then\n'
+            '            _drive="${BASH_REMATCH[1]^^}"\n'
+            '            _rest="${BASH_REMATCH[2]//\\//\\\\}"\n'
+            '            PROJECT_DIR="${_drive}:\\\\${_rest}"\n'
+            '        fi\n'
+            '        ;;\n'
+            'esac\n'
+            'printf "%s" "$PROJECT_DIR"\n'
+        )
+        result = subprocess.run(
+            ["bash", str(script), path],
+            capture_output=True, text=True,
+        )
+        return result.returncode, result.stdout, result.stderr
+
+    def test_resolve_paths_normalizes_msys_posix_path(self, tmp_path):
+        """resolve-paths.sh on $OSTYPE=msys converts /c/Users/... to C:\\Users\\..."""
+        for posix_path, expected_win in [
+            ("/c/Users/dev/project", r"C:\Users\dev\project"),
+            ("/d/Repos/My Project", r"D:\Repos\My Project"),
+            ("/C/UPPER/case", r"C:\UPPER\case"),
+        ]:
+            rc, stdout, stderr = self._msys_normalize_path(posix_path, tmp_path)
+            assert rc == 0, f"bash failed: {stderr!r}"
+            assert stdout == expected_win, (
+                f"Posix path {posix_path!r}: expected {expected_win!r}, got {stdout!r}"
+            )
+
+    def test_resolve_paths_leaves_unix_paths_unchanged(self, tmp_path):
+        """resolve-paths.sh on $OSTYPE=msys must not touch already-Win32 or pure-Unix paths."""
+        for path in [
+            r"C:\Users\dev\project",          # already Win32 — unchanged
+            "/home/user/project",             # Linux home — multi-letter first dir doesn't match
+            "/Users/dev/project",             # macOS home — uppercase first dir doesn't match
+        ]:
+            rc, stdout, stderr = self._msys_normalize_path(path, tmp_path)
+            assert rc == 0, f"bash failed: {stderr!r}"
+            assert stdout == path, (
+                f"Path {path!r} should be unchanged, got {stdout!r}"
+            )
+
+    def test_normalized_msys_path_yields_windows_slug(self):
+        """End-to-end: a /c/Users/... path post-normalization slugs to the same folder Claude Code uses."""
+        # After resolve-paths.sh normalizes /c/Users/dev/project → C:\Users\dev\project,
+        # the Python _session_dir (and bash sed) must produce the same slug Claude Code
+        # uses to store session JSONLs on Windows.
+        normalized = r"C:\Users\dev\project"
+        slug = _session_dir(normalized).rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+        assert slug == "C--Users-dev-project", (
+            f"Normalized Win32 path slug mismatch: got {slug!r}"
+        )
+
+    def test_resolve_paths_has_msys_normalization_block(self):
+        """resolve-paths.sh contains the OSTYPE=msys|cygwin normalization block."""
+        with open(os.path.join(REPO_ROOT, "scripts", "resolve-paths.sh")) as f:
+            content = f.read()
+        assert 'msys|cygwin' in content, (
+            "resolve-paths.sh missing the Git Bash / MSYS / Cygwin normalization case"
+        )
+        assert 'BASH_REMATCH' in content, (
+            "resolve-paths.sh missing the regex-based POSIX→Win32 conversion"
+        )
+
     # ── Point 2: python3/python detection via detect-tools.sh ──
     # Fixed: detect-tools.sh tries python3 then python, exports $PYTHON.
 

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -1204,7 +1204,7 @@ class TestWindowsCompatIssue11:
             'case "$OSTYPE" in\n'
             '    msys|cygwin)\n'
             '        if [[ "$PROJECT_DIR" =~ ^/([a-zA-Z])/(.*)$ ]]; then\n'
-            '            _drive="${BASH_REMATCH[1]^^}"\n'
+            '            _drive=$(printf \'%s\' "${BASH_REMATCH[1]}" | tr \'[:lower:]\' \'[:upper:]\')\n'
             '            _rest="${BASH_REMATCH[2]//\\//\\\\}"\n'
             '            PROJECT_DIR="${_drive}:\\\\${_rest}"\n'
             '        fi\n'


### PR DESCRIPTION
## Problem

On Windows with Git Bash (the default shell Claude Code uses for hooks on Windows), the plugin silently never saves anything. `.remember/` accumulates `logs/memory-YYYY-MM-DD.log` showing `[hook] post-tool` lines, but no `now.md`, `today-*.md`, or `tmp/last-save.json` is ever created. There are no error messages — the hook just exits cleanly.

## Root cause

Claude Code stores session JSONL files at `~/.claude/projects/<slug>/`, where `<slug>` is the project root path with non-alphanumerics replaced by `-`. On Windows, Claude Code computes the slug from the **Win32-native** path:

```
C:\Users\dev\project   →   C--Users-dev-project
```

The plugin computes the slug from `CLAUDE_PROJECT_DIR`, which Git Bash/MSYS exposes as a **POSIX-style** path:

```
/c/Users/dev/project   →   -c-Users-dev-project   ← does not match
```

`post-tool-hook.sh:46` does:

```bash
LATEST_JSONL=$(ls -t "$SESSION_DIR"/*.jsonl 2>/dev/null | head -1)
[ -n "$LATEST_JSONL" ] || exit 0
```

— so on Windows it always exits early. `save-session.sh` is never invoked, no Haiku call, no `now.md`. The existing `test_session_dir_windows_backslash` covers `D:\Users\dev\project` but not the `/d/Users/dev/project` form that Git Bash actually produces.

## Fix

Normalize `CLAUDE_PROJECT_DIR` to its Win32 form inside `resolve-paths.sh` so all downstream slug computations (3 shell sites + Python `_session_dir`) match Claude Code's storage path.

```bash
case "\$OSTYPE" in
    msys|cygwin)
        if [[ "\$PROJECT_DIR" =~ ^/([a-zA-Z])/(.*)\$ ]]; then
            _drive="\${BASH_REMATCH[1]^^}"
            _rest="\${BASH_REMATCH[2]//\//\\}"
            PROJECT_DIR="\${_drive}:\\\${_rest}"
        fi
        ;;
esac
```

Pure-bash regex (no `cygpath` dependency for CI portability); upper-cases the drive letter and converts forward slashes to backslashes before the existing path-existence validation. On Linux/macOS bash `\$OSTYPE` is `linux-gnu` or `darwin*`, so the `case` never matches and `PROJECT_DIR` is left untouched.

## Verification

End-to-end verified on Windows 11 + Git Bash with the v0.5.0 cached install:

```
$ bash <plugin>/scripts/save-session.sh --force
[hook] save-session: PROJECT_DIR=C:\Users\home\Desktop\power-dev ...
[force] bypassing cooldown + min msgs
[extract] session 5f41ebda-...
[extract] 62 exchanges (7 human)
[haiku] calling (branch: claude/...)
[tokens] tokens: 9+0cache→1166out (\$0.058894)
[write] appended: ## 06:06 | claude/...
[write] position → 279
[ndc] now.md → today-2026-05-02.md
```

`.remember/now.md`, `today-2026-05-02.md`, and `tmp/last-save.json` all created as expected.

## Tests

Four new cases under `TestWindowsCompatIssue11`:

- `test_resolve_paths_normalizes_msys_posix_path` — `/c/Users/dev/project` → `C:\Users\dev\project`, including drive-letter casing and paths with spaces
- `test_resolve_paths_leaves_unix_paths_unchanged` — Win32 paths, Linux home, macOS home all pass through unchanged
- `test_normalized_msys_path_yields_windows_slug` — end-to-end: post-normalization slug equals the slug Claude Code uses to store sessions
- `test_resolve_paths_has_msys_normalization_block` — structural guard against the block being removed

The transformation is exercised via a temp script file (not `bash -c`) so bash parses backslashes the same way it does in the production script.

## Notes

- `\$OSTYPE` is `msys` on Git Bash for Windows and MSYS2, `cygwin` on Cygwin. Both produce `/c/...` paths.
- `cygpath -w` was an alternative implementation — chose pure-bash regex for portability/CI test simplicity (Linux CI doesn't ship `cygpath`).
- Existing `test_session_dir_windows_backslash` and `test_session_dir_windows_colon` cover Win32-style input but never the POSIX-style input that Git Bash actually delivers, which is why the bug went undetected.