### PR TITLE
fix: read existing remember.md before write to satisfy Write tool check

### DIFF
--- a/skills/remember/SKILL.md
+++ b/skills/remember/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: remember
 description: Save session state for clean continuation next session.
-allowed-tools: Write
+allowed-tools: Read, Write
 ---
 
 Write a handoff note so the next session can continue cleanly. Use your knowledge of the current session — you were here. Write in first person ("I").
 
 **Path:** `{project_root}/.remember/remember.md` (overwrite). This is at the PROJECT ROOT, NOT relative to this skill file. If the project root is `/Users/foo/myproject`, the file goes to `/Users/foo/myproject/.remember/remember.md`.
+
+**If the file already exists, Read it first before Writing.** The Write tool enforces a read-before-write check on existing files; without a prior Read, the first Write call will fail with "File has not been read yet." A 1-line Read is enough to satisfy the check.
 
 Format:
 


### PR DESCRIPTION
## Summary

The `remember` skill's frontmatter only declares `allowed-tools: Write`, and the instructions say to "overwrite" the file directly. But Claude Code's `Write` tool enforces a **read-before-write check** on files that already exist: the first `Write` call against an existing `remember.md` fails with `File has not been read yet`, and the agent has to retry after a `Read`. This affects every session-end save after the first.

## Repro

1. Run `/remember` in a fresh project → succeeds (file doesn't exist yet, no read-before-write check fires).
2. Open a new session, do some work, run `/remember` again → first `Write` fails:
   ```
   <tool_use_error>File has not been read yet. Read it first before writing to it.</tool_use_error>
   ```
3. Agent retries by `Read`ing first, then `Write`s. Recovers, but with an extra round-trip and a visible error.

## Fix

Two minimal changes to `skills/remember/SKILL.md`:

1. **Frontmatter**: `allowed-tools: Write` → `allowed-tools: Read, Write`.
2. **Instructions**: add one sentence telling the agent to `Read` the file first if it exists, with a brief note about *why* (the Write tool's check). A 1-line `Read` is enough to satisfy it.

After this, `/remember` succeeds on the first `Write` attempt across all sessions, not just the bootstrap one.

## Diff

\`\`\`diff
-allowed-tools: Write
+allowed-tools: Read, Write
\`\`\`

\`\`\`diff
 **Path:** \`{project_root}/.remember/remember.md\` (overwrite). This is at the PROJECT ROOT, NOT relative to this skill file. If the project root is \`/Users/foo/myproject\`, the file goes to \`/Users/foo/myproject/.remember/remember.md\`.
+
+**If the file already exists, Read it first before Writing.** The Write tool enforces a read-before-write check on existing files; without a prior Read, the first Write call will fail with "File has not been read yet." A 1-line Read is enough to satisfy the check.
\`\`\`

## Test plan

- [x] First `/remember` in a fresh project still works (no-op for new files).
- [x] Second `/remember` (file already exists) now succeeds on the first `Write` attempt — confirmed locally by patching the cached skill at \`~/.claude/plugins/cache/claude-plugins-official/remember/0.5.0/skills/remember/SKILL.md\` with the same diff and re-running.
- [x] The "Saved." final-line behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)