### PR TITLE
fix(tests): export CLAUDE_PROJECT_DIR for dry-run save in run-tests.sh

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -250,7 +250,7 @@ echo ""
 # ── 7. Dry-run save ──────────────────────────────────────────────────────
 echo "7. Dry-run save (full flow, no Haiku)"
 
-DRY_OUT=$(cd "$PIPELINE_DIR" && bash scripts/save-session.sh --dry 2>/dev/null) || true
+DRY_OUT=$(cd "$PIPELINE_DIR" && CLAUDE_PROJECT_DIR="$PIPELINE_DIR" bash scripts/save-session.sh --dry 2>/dev/null) || true
 DRY_EXIT=$?
 if echo "$DRY_OUT" 2>/dev/null | grep -q "DRY RUN"; then
     LINES=$(echo "$DRY_OUT" | grep -c '^\[' 2>/dev/null || echo 0)


### PR DESCRIPTION
## What

One-line fix to `scripts/run-tests.sh` step 7 (dry-run save): export `CLAUDE_PROJECT_DIR` to the subshell before invoking `save-session.sh --dry`.

## Why

Since v0.3.0 (PR #9), `resolve-paths.sh` requires `CLAUDE_PROJECT_DIR` and fails loudly without it on marketplace-style installs. The test harness `cd`s into `PIPELINE_DIR` but never exports the variable, so the dry-run step exits non-zero on any install path that isn't local-dev. Locally this surfaces as `✗ save-session.sh --dry: exit 0` even though the underlying code is fine.

## Before / after on macOS (v0.7.1 base)

- Before: `Passed: 25 / Failed: 1 / Skipped: 1` — dry-run save fails.
- After: `Passed: 26 / Failed: 0 / Skipped: 1` — clean.

Pytest suite (327 tests) unaffected — this only touches the shell harness wrapper.

## Diff

```diff
-DRY_OUT=$(cd "$PIPELINE_DIR" && bash scripts/save-session.sh --dry 2>/dev/null) || true
+DRY_OUT=$(cd "$PIPELINE_DIR" && CLAUDE_PROJECT_DIR="$PIPELINE_DIR" bash scripts/save-session.sh --dry 2>/dev/null) || true
```