### PR TITLE
feat: external data directory, layered config, and automatic git backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Put cross-project preferences (timezone, cooldowns) in `~/.remember/config.json`
 | `data_dir`                       | `.remember` | Where memory files are written. Relative paths resolve inside the project root (legacy default). Absolute paths or paths starting with `~` are expanded and treated as external — see [External storage mode](#external-storage-mode). |
 | `cooldowns.save_seconds`         | `120`   | Minimum seconds between saves                      |
 | `cooldowns.ndc_seconds`          | `3600`  | Compression interval (hourly)                      |
+| `cooldowns.git_backup_seconds`   | `900`   | Minimum seconds between auto-backup commits (no-op if `~/.remember/` is not a git repo) |
 | `thresholds.min_human_messages`  | `3`     | Minimum messages before saving                     |
 | `thresholds.delta_lines_trigger` | `50`    | Tool call output lines that trigger auto-save      |
 | `features.ndc_compression`      | `true`  | Enable hourly compression of daily files           |
@@ -306,12 +307,25 @@ Because `~/.remember/` lives outside any project repo it won't be accidentally c
 ```bash
 cd ~/.remember
 git init
-echo "tmp/" >> .gitignore
-git add config.json
+git remote add origin git@github.com:youruser/remember-backup.git  # private repo
+# Write .gitignore BEFORE any git add — this excludes runtime state and log files.
+# Running git add before this step will track log dirs you don't want committed.
+cat > .gitignore <<'EOF'
+.git-backup.lock
+.last-git-backup-ts
+*/logs/
+*/tmp/
+EOF
+git add .gitignore config.json
 git commit -m "init: remember config"
+git push -u origin main
 ```
 
-Commit after sessions you want to preserve. Push to a private remote to sync across machines.
+#### Automatic commits
+
+Once `~/.remember/` is a git repo, the `after_save` hook commits each project's memory subdir on its own schedule — one commit per project save, throttled by `cooldowns.git_backup_seconds` (default 15 min) — and pushes to your configured remote. No further setup is needed beyond credential availability (SSH agent or git credential helper) in the environment Claude Code launches hooks in.
+
+If you don't want automatic commits, leave `~/.remember/` as a plain directory and commit manually as before.
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -212,25 +212,35 @@ Before clearing context or ending a session, type `/remember`. The agent writes 
 
 ## Data files
 
-The pipeline writes to `.remember/` (created automatically, self-gitignored):
+The pipeline writes to `REMEMBER_DIR` (created automatically). By default this is `.remember/` inside your project root; in external storage mode it is a per-project subdirectory of `~/.remember/` (see [External storage mode](#external-storage-mode)).
 
 | File                           | Purpose                                           |
 | ------------------------------ | ------------------------------------------------- |
-| `.remember/now.md`             | Current session buffer                            |
-| `.remember/today-*.md`         | Daily compressed summaries                        |
-| `.remember/recent.md`          | Last 7 days consolidated                          |
-| `.remember/archive.md`         | Older history consolidated                        |
-| `.remember/logs/`              | Pipeline logs                                     |
-| `.remember/tmp/`               | Lock files, cooldown markers                      |
+| `now.md`                       | Current session buffer                            |
+| `today-*.md`                   | Daily compressed summaries                        |
+| `recent.md`                    | Last 7 days consolidated                          |
+| `archive.md`                   | Older history consolidated                        |
+| `remember.md`                  | Handoff note written by `/remember`               |
+| `logs/`                        | Pipeline logs                                     |
+| `tmp/`                         | Lock files, cooldown markers                      |
+| `identity.md`                  | Per-project identity override (optional)          |
 | `.claude/remember/identity.md` | Your agent's identity and values (you write this) |
 
 ## Configuration
 
-Copy `config.example.json` to `config.json` and adjust:
+Config is resolved by deep-merging three layers (highest priority wins):
+
+| Layer | Path | Scope |
+|-------|------|-------|
+| Plugin bundled | `<plugin>/config.json` | Shipped defaults |
+| User-global | `~/.remember/config.json` | All your projects |
+| Per-project | `<REMEMBER_DIR>/config.json` | One project |
+
+Put cross-project preferences (timezone, cooldowns) in `~/.remember/config.json`. Put project-specific overrides in `<REMEMBER_DIR>/config.json`. See `config.user.example.json` for a user-global template and `config.example.json` for all available keys.
 
 | Key                              | Default | Purpose                                            |
 | -------------------------------- | ------- | -------------------------------------------------- |
-| `data_dir`                       | `.remember` | Where output files are written                 |
+| `data_dir`                       | `.remember` | Where memory files are written. Relative paths resolve inside the project root (legacy default). Absolute paths or paths starting with `~` are expanded and treated as external — see [External storage mode](#external-storage-mode). |
 | `cooldowns.save_seconds`         | `120`   | Minimum seconds between saves                      |
 | `cooldowns.ndc_seconds`          | `3600`  | Compression interval (hourly)                      |
 | `thresholds.min_human_messages`  | `3`     | Minimum messages before saving                     |
@@ -240,6 +250,68 @@ Copy `config.example.json` to `config.json` and adjust:
 | `timezone`                       | *(system local)* | IANA name (e.g. `America/New_York`, `Europe/Paris`) for timestamps and daily file boundaries. Omit or leave empty to use the system clock's local zone. Set this explicitly on a VPS whose system clock is UTC. |
 | `time_format`                    | `24h`   | `24h` or `12h` — controls timestamp format in log files (e.g. `14:30:00` vs `2:30:00 PM`) |
 | `debug`                          | `false` | Verbose logging for cooldowns and locks            |
+
+## External storage mode
+
+By default, memory data lives in `.remember/` inside each project directory. This works but has a drawback: it pollutes `git status` and siloes memory per repo clone.
+
+**External storage mode** relocates `REMEMBER_DIR` to a path outside the project, one subdirectory per project identified by a slug. The `{slug}` placeholder expands to the same value Claude Code uses for `~/.claude/projects/<slug>/` — so memory stays project-scoped without living inside the repo.
+
+### Enable
+
+Create `~/.remember/config.json`:
+
+```json
+{ "data_dir": "~/.remember/{slug}" }
+```
+
+On next session start, the plugin:
+1. Resolves `REMEMBER_DIR` to `~/.remember/<slug-of-project>/`
+2. Auto-migrates any existing `<project>/.remember/` to the new location — once, leaving a `MIGRATED-TO.txt` marker in the old directory
+3. Skips writing `.gitignore` (the external directory is not inside a git repo)
+
+### `{slug}` expansion
+
+`data_dir` values starting with `/` or `~` are treated as absolute. The `{slug}` token is replaced with the slugged project path — identical to the slug Claude Code uses when naming `~/.claude/projects/<slug>/`. All non-alphanumeric characters become `-`:
+
+```
+~/.remember/{slug}  →  ~/.remember/-home-alice-projects-my-app
+```
+
+### Handoff path
+
+When external mode is active, `session-start-hook.sh` emits a `=== HANDOFF ===` block at session start:
+
+```
+=== HANDOFF ===
+Write next handoff to: /home/alice/.remember/-home-alice-projects-my-app/remember.md
+```
+
+The `/remember` skill reads this block to know where to write. If no block is present (legacy mode), it falls back to `{project_root}/.remember/remember.md`.
+
+### Per-project identity override
+
+Place an `identity.md` directly in `REMEMBER_DIR` to override the plugin-bundled identity for that one project:
+
+```
+~/.remember/<slug>/identity.md
+```
+
+If this file exists it takes precedence over `<plugin>/identity.md`. The per-project version is never overwritten by plugin updates.
+
+### Back up your memory
+
+Because `~/.remember/` lives outside any project repo it won't be accidentally committed or lost on re-clone. To keep it safe, track it in a private git repository:
+
+```bash
+cd ~/.remember
+git init
+echo "tmp/" >> .gitignore
+git add config.json
+git commit -m "init: remember config"
+```
+
+Commit after sessions you want to preserve. Push to a private remote to sync across machines.
 
 ## Running tests
 
@@ -269,7 +341,7 @@ pipeline/           Python core — extraction, prompts, parsing, types
 
 prompts/            Prompt templates (txt with {{PLACEHOLDER}} substitution)
 scripts/            Shell orchestration — locks, cooldowns, file I/O, backgrounding
-tests/              pytest suite (186 tests, 99%+ coverage)
+tests/              pytest suite (347 tests, 99%+ coverage)
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ pipeline/           Python core — extraction, prompts, parsing, types
 
 prompts/            Prompt templates (txt with {{PLACEHOLDER}} substitution)
 scripts/            Shell orchestration — locks, cooldowns, file I/O, backgrounding
-tests/              pytest suite (347 tests, 99%+ coverage)
+tests/              pytest suite (357 tests, 99%+ coverage)
 ```
 
 ## License

--- a/config.example.json
+++ b/config.example.json
@@ -2,7 +2,8 @@
   "data_dir": ".remember",
   "cooldowns": {
     "save_seconds": 120,
-    "ndc_seconds": 3600
+    "ndc_seconds": 3600,
+    "git_backup_seconds": 900
   },
   "thresholds": {
     "min_human_messages": 3,

--- a/config.example.json
+++ b/config.example.json
@@ -13,5 +13,27 @@
     "recovery": true
   },
   "debug": false,
-  "time_format": "24h"
+  "time_format": "24h",
+
+  "_comments": {
+    "data_dir": [
+      "Controls where memory data files are stored.",
+      "",
+      "Legacy default — project-relative (unchanged behaviour):",
+      "  '.remember'  →  {project_dir}/.remember",
+      "",
+      "External mode — absolute or home-relative path:",
+      "  '~/.remember/{slug}'  →  ~/.remember/<session-dir-slug>/",
+      "  '/var/lib/remember/{slug}'  →  /var/lib/remember/<slug>/",
+      "",
+      "{slug} is replaced by the same slug Claude Code uses for",
+      "~/.claude/projects/<slug>/, so each project gets its own",
+      "isolated subtree. The .gitignore is NOT written in external",
+      "mode — manage the ~/.remember/ tree as your own private repo.",
+      "",
+      "User-global config lives at ~/.remember/config.json and is",
+      "merged on top of this file (per-project overrides user-global",
+      "which overrides these shipped defaults). See config.user.example.json."
+    ]
+  }
 }

--- a/config.user.example.json
+++ b/config.user.example.json
@@ -1,0 +1,12 @@
+{
+  "_purpose": "Copy this file to ~/.remember/config.json to enable external storage mode.",
+  "_notes": [
+    "Settings here override the plugin-shipped defaults for ALL your projects.",
+    "Per-project overrides go in {REMEMBER_DIR}/config.json (e.g. ~/.remember/<slug>/config.json).",
+    "Layered merge order (highest priority wins): per-project > user-global > plugin defaults."
+  ],
+
+  "data_dir": "~/.remember/{slug}",
+
+  "timezone": ""
+}

--- a/config.user.example.json
+++ b/config.user.example.json
@@ -8,5 +8,9 @@
 
   "data_dir": "~/.remember/{slug}",
 
-  "timezone": ""
+  "timezone": "",
+
+  "cooldowns": {
+    "git_backup_seconds": 900
+  }
 }

--- a/hooks.d/after_save/50-git-backup.sh
+++ b/hooks.d/after_save/50-git-backup.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# ============================================================================
+# 50-git-backup.sh — Commit & push the current slug's memory to git
+# ============================================================================
+#
+# DESCRIPTION
+#   Runs on the after_save dispatch. If $REMEMBER_DIR's parent is itself a
+#   git toplevel (and not the project directory), commits the current slug's
+#   subtree and pushes to the configured remote.
+#
+#   No-op when:
+#     - REMEMBER_DIR is in legacy mode (parent = PROJECT_DIR)
+#     - Parent is not a git toplevel
+#     - Another instance holds the global lock
+#     - Backup cooldown hasn't elapsed
+#     - There is nothing to commit for this slug
+#
+# RUNTIME ENV (provided by save-session.sh via dispatch)
+#   PROJECT_DIR, PIPELINE_DIR, REMEMBER_DIR, REMEMBER_PROJECT
+#
+# ============================================================================
+
+set -u  # not -e — we never want to fail loudly here
+
+# ── Source logging (gives us log(), config(), _remember_date(), REMEMBER_TZ) ─
+source "$PIPELINE_DIR/scripts/log.sh"
+
+# ── Activation guard ─────────────────────────────────────────────────────────
+REPO_ROOT=$(dirname "$REMEMBER_DIR")
+SLUG=$(basename "$REMEMBER_DIR")
+
+# Legacy mode (REMEMBER_DIR is inside PROJECT_DIR) → never run.
+[ "$REPO_ROOT" = "$PROJECT_DIR" ] && exit 0
+
+# REPO_ROOT must be the toplevel of a git repo, not just inside one.
+TOPLEVEL=$(git -C "$REPO_ROOT" rev-parse --show-toplevel 2>/dev/null) || exit 0
+[ "$TOPLEVEL" = "$REPO_ROOT" ] || exit 0
+
+# ── Cooldown ─────────────────────────────────────────────────────────────────
+COOLDOWN_MARKER="$REPO_ROOT/.last-git-backup-ts"
+BACKUP_COOLDOWN=$(config ".cooldowns.git_backup_seconds" 900)
+if [ -f "$COOLDOWN_MARKER" ]; then
+    LAST_MOD=$(cat "$COOLDOWN_MARKER" 2>/dev/null || echo 0)
+    ELAPSED=$(( $(date +%s) - LAST_MOD ))
+    if [ "$ELAPSED" -lt "$BACKUP_COOLDOWN" ]; then
+        [ "${REMEMBER_DEBUG:-0}" = "1" ] && log "git-backup" "cooldown ${ELAPSED}s < ${BACKUP_COOLDOWN}s, skip"
+        exit 0
+    fi
+fi
+
+# ── Lock (atomic via noclobber) ───────────────────────────────────────────────
+LOCK_FILE="$REPO_ROOT/.git-backup.lock"
+if ! ( set -o noclobber; echo $$ > "$LOCK_FILE" ) 2>/dev/null; then
+    LOCK_PID=$(cat "$LOCK_FILE" 2>/dev/null)
+    if kill -0 "$LOCK_PID" 2>/dev/null; then
+        [ "${REMEMBER_DEBUG:-0}" = "1" ] && log "git-backup" "locked by PID $LOCK_PID, skip"
+        exit 0
+    fi
+    log "git-backup" "stale lock (PID $LOCK_PID dead), taking over"
+    # Delete stale lock, then re-acquire atomically via noclobber.
+    rm -f "$LOCK_FILE"
+    ( set -o noclobber; echo $$ > "$LOCK_FILE" ) 2>/dev/null || exit 0
+fi
+
+# ── Background subshell — never blocks save-session.sh ───────────────────────
+(
+    trap 'rm -f "$LOCK_FILE"' EXIT
+
+    # Prevent outer git env vars from overriding git -C behaviour.
+    unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
+    # Remove the bootstrap-written per-slug .gitignore (contains "*") that was placed
+    # to prevent commits when memory lived inside a project repo. In external git-backup
+    # mode it blocks all staging; the root-level .gitignore covers logs/tmp exclusions.
+    SLUG_GITIGNORE="$REPO_ROOT/$SLUG/.gitignore"
+    if [ -f "$SLUG_GITIGNORE" ] && [ "$(cat "$SLUG_GITIGNORE")" = "*" ]; then
+        rm -f "$SLUG_GITIGNORE"
+        log "git-backup" "removed per-slug .gitignore (legacy bootstrap artifact)"
+    fi
+
+    # Auto-untrack logs/tmp if they were accidentally staged before .gitignore was in place.
+    git -C "$REPO_ROOT" rm --cached -- "$SLUG/logs/" "$SLUG/tmp/" 2>/dev/null || true
+
+    # Stage only this slug's subtree. -- required: slug names may start with '-'.
+    git -C "$REPO_ROOT" add -- "$SLUG/" 2>/dev/null
+
+    # Anything actually staged?
+    if git -C "$REPO_ROOT" diff --cached --quiet -- "$SLUG/" 2>/dev/null; then
+        log "git-backup" "nothing to commit for $SLUG, skip"
+        exit 0
+    fi
+
+    TS=$(_remember_date '+%H:%M')
+    if git -C "$REPO_ROOT" commit --no-gpg-sign \
+            -m "auto: $SLUG $TS" \
+            -- "$SLUG/" >/dev/null 2>&1; then
+        log "git-backup" "committed $SLUG"
+        date +%s > "$COOLDOWN_MARKER"
+    else
+        log "git-backup" "ERROR: commit failed for $SLUG"
+        exit 0
+    fi
+
+    # Push, but tolerate any error (no remote, no network, auth, etc.).
+    # GIT_TERMINAL_PROMPT=0 ensures missing credentials fail fast, not hang.
+    if GIT_TERMINAL_PROMPT=0 git -C "$REPO_ROOT" push >/dev/null 2>&1; then
+        log "git-backup" "pushed $SLUG"
+    else
+        log "git-backup" "push deferred (will retry next backup)"
+    fi
+) </dev/null >/dev/null 2>&1 &
+disown $! 2>/dev/null || true
+
+exit 0

--- a/pipeline/extract.py
+++ b/pipeline/extract.py
@@ -45,9 +45,14 @@ def _session_dir(project_dir: str) -> str:
     return os.path.expanduser("~/.claude/projects/" + slug)
 
 
-def _last_save_path(project_dir: str) -> str:
-    """Return the path to last-save.json for incremental extraction."""
-    return os.path.join(project_dir, ".remember", "tmp", "last-save.json")
+def _last_save_path(project_dir: str, remember_dir: str | None = None) -> str:
+    """Return the path to last-save.json for incremental extraction.
+
+    Uses REMEMBER_DIR env var when set, so external-mode paths work
+    without changing the call signature everywhere.
+    """
+    effective = remember_dir or os.environ.get("REMEMBER_DIR") or os.path.join(project_dir, ".remember")
+    return os.path.join(effective, "tmp", "last-save.json")
 
 
 def _validate_session_id(session_id: str) -> None:
@@ -84,7 +89,8 @@ def find_session(session_id: str | None = None,
 
 
 def get_last_save_line(session_id: str,
-                       project_dir: str = _DEFAULT_PROJECT_DIR) -> int:
+                       project_dir: str = _DEFAULT_PROJECT_DIR,
+                       remember_dir: str | None = None) -> int:
     """Return the JSONL line number where the last save happened.
 
     Reads ``last-save.json`` and returns the saved line position if it
@@ -94,11 +100,13 @@ def get_last_save_line(session_id: str,
     Args:
         session_id: Session UUID to match against the saved position.
         project_dir: Root directory of the Claude Code project.
+        remember_dir: Override for the memory data directory. When None,
+            falls back to the REMEMBER_DIR env var or project-relative default.
 
     Returns:
         Line number (0-indexed) to resume extraction from, or 0.
     """
-    path = _last_save_path(project_dir)
+    path = _last_save_path(project_dir, remember_dir)
     if not os.path.exists(path):
         return 0
     try:
@@ -240,6 +248,7 @@ def extract_session(
     project_dir: str = _DEFAULT_PROJECT_DIR,
     count: int | None = None,
     show_all: bool = False,
+    remember_dir: str | None = None,
 ) -> ExtractResult:
     """Main entry point: extract exchanges from a session.
 
@@ -248,6 +257,8 @@ def extract_session(
         project_dir: Project root directory.
         count: If set, return only the last N exchanges.
         show_all: If True, extract from line 0.
+        remember_dir: Override for the memory data directory (external mode).
+            When None, falls back to REMEMBER_DIR env var or project default.
 
     Returns:
         ExtractResult with formatted exchanges and position.
@@ -265,7 +276,7 @@ def extract_session(
         messages = extract_messages(path, skip_lines=0)
         messages = messages[-count:]
     else:
-        last_line = get_last_save_line(actual_id, project_dir)
+        last_line = get_last_save_line(actual_id, project_dir, remember_dir)
         messages = extract_messages(path, skip_lines=last_line)
 
     # Format as text

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -53,6 +53,9 @@ def cmd_extract(session_id: str, project_dir: str) -> None:
     Writes the formatted exchange text to a temp file (avoiding shell
     escaping of large text) and prints its path as ``EXTRACT_FILE``.
 
+    Respects the REMEMBER_DIR environment variable for external-mode
+    last-save.json lookup.
+
     Args:
         session_id: UUID of the session to extract.
         project_dir: Root directory of the Claude Code project.
@@ -62,7 +65,8 @@ def cmd_extract(session_id: str, project_dir: str) -> None:
         EXTRACT_FILE (path to temp file containing exchange text).
     """
     import tempfile
-    r = extract_session(session_id=session_id, project_dir=project_dir)
+    remember_dir = os.environ.get("REMEMBER_DIR") or None
+    r = extract_session(session_id=session_id, project_dir=project_dir, remember_dir=remember_dir)
 
     # Write exchanges to temp file (avoids shell escaping of large text)
     fd, extract_file = tempfile.mkstemp(prefix="remember-extract-", suffix=".txt")

--- a/scripts/bootstrap-dirs.sh
+++ b/scripts/bootstrap-dirs.sh
@@ -4,27 +4,49 @@
 # ============================================================================
 #
 # DESCRIPTION
-#   Creates the .remember/ directory structure and sets up stderr logging.
-#   Every hook script sources this after resolve-paths.sh to guarantee the
-#   directory tree exists before any file I/O.
+#   Creates the memory directory structure and sets up stderr logging.
+#   Every hook script sources this after resolve-paths.sh and detect-tools.sh
+#   to guarantee the directory tree exists before any file I/O.
 #
-#   This replaces the inline 2>> redirect that was in hooks.json, which
-#   failed on fresh projects because bash opens the redirect target before
-#   the script runs (chicken-and-egg bug: GitHub issues #23, #27, #31, #32).
+#   When REMEMBER_DIR points outside the project (external mode), the legacy
+#   ${PROJECT_DIR}/.remember/ is migrated automatically on first run and a
+#   MIGRATED-TO.txt marker is left behind.
 #
 # USAGE
 #   source "$(dirname "$0")/resolve-paths.sh"
+#   source "$(dirname "$0")/detect-tools.sh"
 #   source "$(dirname "$0")/bootstrap-dirs.sh"
 #
 # REQUIRES
-#   PROJECT_DIR   must be set (by resolve-paths.sh)
+#   PROJECT_DIR      must be set (by resolve-paths.sh)
+#   PIPELINE_DIR     must be set (by resolve-paths.sh)
+#   session_dir_slug must be defined (by detect-tools.sh)
+#
+# EXPORTS
+#   REMEMBER_DIR    — absolute path to memory data directory (via lib-memory-dir.sh)
+#   SYS_TMPDIR      — portable system temp directory
 #
 # ============================================================================
 
-REMEMBER_DIR="${PROJECT_DIR}/.remember"
+# Resolve REMEMBER_DIR via the shared helper (no-op if already loaded).
+_BOOTSTRAP_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_BOOTSTRAP_SCRIPT_DIR/lib-memory-dir.sh"
+unset _BOOTSTRAP_SCRIPT_DIR
 
 # --- System temp directory (portable: macOS, Linux, Windows/Git Bash) ---
 SYS_TMPDIR="${TMPDIR:-/tmp}"
+
+# --- One-shot migration: legacy ${PROJECT_DIR}/.remember → external REMEMBER_DIR ---
+_legacy_dir="${PROJECT_DIR}/.remember"
+if [ "$REMEMBER_DIR" != "$_legacy_dir" ] && [ -d "$_legacy_dir" ] && [ ! -e "$REMEMBER_DIR" ]; then
+    mkdir -p "$(dirname "$REMEMBER_DIR")" 2>/dev/null
+    if mv "$_legacy_dir" "$REMEMBER_DIR" 2>/dev/null; then
+        mkdir -p "$_legacy_dir"
+        printf 'Memory data migrated to:\n  %s\nThis directory is now empty; you may delete it.\n' \
+            "$REMEMBER_DIR" > "$_legacy_dir/MIGRATED-TO.txt"
+    fi
+fi
+unset _legacy_dir
 
 # --- Create directory structure ---
 mkdir -p \
@@ -33,8 +55,15 @@ mkdir -p \
     "$REMEMBER_DIR/logs/autonomous" \
     2>/dev/null
 
-# --- Gitignore so .remember/ never gets committed ---
-[ -f "$REMEMBER_DIR/.gitignore" ] || echo '*' > "$REMEMBER_DIR/.gitignore" 2>/dev/null
+# --- Gitignore: only write when REMEMBER_DIR is inside the project tree ---
+# In external mode (REMEMBER_DIR outside PROJECT_DIR) there is no gitignore
+# to write — the user manages that tree themselves (typically as a private git
+# repo at ~/.remember/).
+case "$REMEMBER_DIR" in
+    "$PROJECT_DIR"/*)
+        [ -f "$REMEMBER_DIR/.gitignore" ] || echo '*' > "$REMEMBER_DIR/.gitignore" 2>/dev/null
+        ;;
+esac
 
 # --- Redirect stderr to hook-errors.log ---
 # This replaces the 2>> that was in hooks.json. Now the directory is

--- a/scripts/lib-memory-dir.sh
+++ b/scripts/lib-memory-dir.sh
@@ -66,6 +66,16 @@ _resolve_remember_dir() {
     case "$data_dir" in
         /*|~*)
             # Absolute / home-relative: expand ~ and substitute {slug}.
+            # Guard: session_dir_slug may not be defined if detect-tools.sh was
+            # not sourced yet (e.g. log.sh sourced directly in tests). Define a
+            # minimal inline fallback so the slug is never silently empty.
+            if ! type session_dir_slug >/dev/null 2>&1; then
+                session_dir_slug() {
+                    local _p="$1"
+                    command -v cygpath >/dev/null 2>&1 && _p=$(cygpath -m "$_p")
+                    echo "$_p" | sed 's/[^a-zA-Z0-9]/-/g'
+                }
+            fi
             local slug
             slug=$(session_dir_slug "$proj")
             # shellcheck disable=SC2016  # we want literal ~ expansion here

--- a/scripts/lib-memory-dir.sh
+++ b/scripts/lib-memory-dir.sh
@@ -35,8 +35,8 @@
 #
 # ============================================================================
 
-# Guard against double-sourcing.
-[ -n "$_LIB_MEMORY_DIR_LOADED" ] && return 0
+# Guard against double-sourcing. Use default-expansion so set -u callers don't error.
+[ -n "${_LIB_MEMORY_DIR_LOADED:-}" ] && return 0
 _LIB_MEMORY_DIR_LOADED=1
 
 # ── Helpers ──────────────────────────────────────────────────────────────────

--- a/scripts/lib-memory-dir.sh
+++ b/scripts/lib-memory-dir.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# ============================================================================
+# lib-memory-dir.sh — Resolve REMEMBER_DIR and produce a merged REMEMBER_CONFIG
+# ============================================================================
+#
+# DESCRIPTION
+#   Single source of truth for two closely coupled concerns:
+#
+#   1. REMEMBER_DIR — where memory data files live.
+#      Normally "${PROJECT_DIR}/.remember" (legacy default).
+#      When config.json carries a data_dir starting with "/" or "~", the path
+#      is expanded and the {slug} placeholder is replaced with the
+#      session_dir_slug of PROJECT_DIR, matching Claude Code's own naming for
+#      ~/.claude/projects/<slug>/.
+#
+#   2. REMEMBER_CONFIG — the merged config.json that every caller reads via
+#      config(). Built by deep-merging three layers (highest priority wins):
+#        1. ${PIPELINE_DIR}/config.json          (plugin-bundled defaults)
+#        2. ${HOME}/.remember/config.json         (user-global, survives updates)
+#        3. ${REMEMBER_DIR}/config.json           (per-project override)
+#
+# USAGE
+#   source "$(dirname "$0")/resolve-paths.sh"   # sets PROJECT_DIR, PIPELINE_DIR
+#   source "$(dirname "$0")/detect-tools.sh"    # sets session_dir_slug
+#   source "$(dirname "$0")/lib-memory-dir.sh"  # exports REMEMBER_DIR, REMEMBER_CONFIG
+#
+# REQUIRES
+#   PROJECT_DIR    — set by resolve-paths.sh
+#   PIPELINE_DIR   — set by resolve-paths.sh
+#   session_dir_slug — defined by detect-tools.sh
+#
+# EXPORTS
+#   REMEMBER_DIR      — absolute path to memory data directory
+#   REMEMBER_CONFIG   — absolute path to merged config (tmp file)
+#
+# ============================================================================
+
+# Guard against double-sourcing.
+[ -n "$_LIB_MEMORY_DIR_LOADED" ] && return 0
+_LIB_MEMORY_DIR_LOADED=1
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+# _read_data_dir <config-file>
+# Prints the raw data_dir value from a single config file, empty if absent.
+_read_data_dir() {
+    local cfg="$1"
+    [ -f "$cfg" ] || return 0
+    if command -v jq >/dev/null 2>&1; then
+        jq -r '.data_dir // empty' "$cfg" 2>/dev/null || true
+    else
+        # Minimal grep fallback — handles simple string values only.
+        grep -o '"data_dir"[[:space:]]*:[[:space:]]*"[^"]*"' "$cfg" 2>/dev/null \
+            | sed 's/.*"data_dir"[[:space:]]*:[[:space:]]*"\([^"]*\)"/\1/'
+    fi
+}
+
+# _resolve_remember_dir <data_dir_value> <project_dir>
+# Resolves the final absolute REMEMBER_DIR.
+# If data_dir starts with / or ~ treat as absolute; expand ~ and {slug}.
+# Otherwise treat as a path relative to PROJECT_DIR (legacy behaviour).
+_resolve_remember_dir() {
+    local data_dir="$1"
+    local proj="$2"
+
+    case "$data_dir" in
+        /*|~*)
+            # Absolute / home-relative: expand ~ and substitute {slug}.
+            local slug
+            slug=$(session_dir_slug "$proj")
+            # shellcheck disable=SC2016  # we want literal ~ expansion here
+            local expanded="${data_dir/#\~/$HOME}"
+            echo "${expanded//\{slug\}/$slug}"
+            ;;
+        *)
+            # Relative (legacy): resolve against PROJECT_DIR.
+            echo "${proj}/${data_dir}"
+            ;;
+    esac
+}
+
+# ── Pass 1: resolve REMEMBER_DIR ─────────────────────────────────────────────
+# Read data_dir from the plugin-bundled config and the user-global config only
+# (the per-project config lives inside REMEMBER_DIR, which we don't know yet).
+
+_bundled_cfg="${PIPELINE_DIR}/config.json"
+_user_cfg="${HOME}/.remember/config.json"
+
+# Highest-priority source that has data_dir wins.
+_data_dir_raw=""
+for _cfg_candidate in "$_user_cfg" "$_bundled_cfg"; do
+    _val=$(_read_data_dir "$_cfg_candidate")
+    if [ -n "$_val" ]; then
+        _data_dir_raw="$_val"
+        break
+    fi
+done
+
+# Default to legacy layout if nothing found.
+_data_dir_raw="${_data_dir_raw:-.remember}"
+
+REMEMBER_DIR=$(_resolve_remember_dir "$_data_dir_raw" "$PROJECT_DIR")
+export REMEMBER_DIR
+
+# ── Pass 2: layered config merge ─────────────────────────────────────────────
+# Now that REMEMBER_DIR is known, merge all three layers.
+
+_project_cfg="${REMEMBER_DIR}/config.json"
+SYS_TMPDIR="${TMPDIR:-/tmp}"
+_merged_cfg="${SYS_TMPDIR}/remember-config-$$.json"
+
+# Build an array of files that actually exist.
+_cfg_sources=()
+[ -f "$_bundled_cfg"  ] && _cfg_sources+=("$_bundled_cfg")
+[ -f "$_user_cfg"     ] && _cfg_sources+=("$_user_cfg")
+[ -f "$_project_cfg"  ] && _cfg_sources+=("$_project_cfg")
+
+if [ "${#_cfg_sources[@]}" -gt 0 ] && command -v jq >/dev/null 2>&1; then
+    # Deep-merge: later files override earlier ones.
+    jq -s 'reduce .[] as $x ({}; . * $x)' "${_cfg_sources[@]}" > "$_merged_cfg" 2>/dev/null \
+        || cp "$_bundled_cfg" "$_merged_cfg" 2>/dev/null
+else
+    # No jq, or no config files — fall back to the bundled defaults.
+    cp "$_bundled_cfg" "$_merged_cfg" 2>/dev/null || echo '{}' > "$_merged_cfg"
+fi
+
+REMEMBER_CONFIG="$_merged_cfg"
+export REMEMBER_CONFIG
+
+# Register cleanup of the tmp file when the outermost script exits.
+# Use a subshell-safe append to avoid overwriting any existing trap.
+_existing_trap=$(trap -p EXIT 2>/dev/null | sed "s/trap -- '//;s/' EXIT//")
+if [ -n "$_existing_trap" ]; then
+    # shellcheck disable=SC2064
+    trap "${_existing_trap}; rm -f ${_merged_cfg}" EXIT
+else
+    # shellcheck disable=SC2064
+    trap "rm -f ${_merged_cfg}" EXIT
+fi
+unset _existing_trap
+
+# Clean up local variables to avoid polluting the caller's namespace.
+unset _bundled_cfg _user_cfg _project_cfg _cfg_sources _data_dir_raw _val _merged_cfg _cfg_candidate

--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -15,10 +15,12 @@
 #   config ".cooldowns.save_seconds" 120
 #
 # ENVIRONMENT
-#   PROJECT_DIR   Project root (default: .)
+#   PROJECT_DIR   Project root — must be set before sourcing
+#   PIPELINE_DIR  Plugin root  — must be set before sourcing
+#   REMEMBER_DIR  Memory data dir — set by lib-memory-dir.sh (sourced here)
 #
 # OUTPUT
-#   .remember/logs/memory-YYYY-MM-DD.log
+#   $REMEMBER_DIR/logs/memory-YYYY-MM-DD.log
 #   Format: HH:MM:SS [component] message
 #
 # DEPENDENCIES
@@ -34,16 +36,27 @@
 #
 # ============================================================================
 
-REMEMBER_LOG_DIR="${PROJECT_DIR:-.}/.remember/logs"
+# Ensure PIPELINE_DIR is set. Should be set by resolve-paths.sh before
+# sourcing this file. Falls back to local-install convention if unset.
+PIPELINE_DIR="${PIPELINE_DIR:-${PROJECT_DIR:-.}/.claude/remember}"
+
+# Resolve REMEMBER_DIR and the merged REMEMBER_CONFIG (lib-memory-dir.sh is a
+# no-op if already loaded via the _LIB_MEMORY_DIR_LOADED guard).
+_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_LIB_DIR/lib-memory-dir.sh"
+unset _LIB_DIR
+
+# ── Logging setup ─────────────────────────────────────────────────────────────
+
+REMEMBER_LOG_DIR="${REMEMBER_DIR}/logs"
 if ! mkdir -p "$REMEMBER_LOG_DIR" 2>/dev/null; then
     echo "FATAL: cannot create $REMEMBER_LOG_DIR" >&2
     return 1 2>/dev/null || true
 fi
 
-# Read .timezone from config.json BEFORE computing MEMORY_LOG_DATE — otherwise
+# Read .timezone from config BEFORE computing MEMORY_LOG_DATE — otherwise
 # TZ="" falls back to UTC on macOS/BSD and produces next-day filenames after
 # ~20:00 local in zones west of UTC.
-REMEMBER_CONFIG="${PIPELINE_DIR:-${PROJECT_DIR:-.}/.claude/remember}/config.json"
 config() {
     local key="$1"
     local default="$2"
@@ -131,39 +144,6 @@ safe_eval() {
     done
 }
 
-# Read a configuration value from config.json using jq.
-#
-# Falls back to the provided default if config.json is missing,
-# jq is not installed, or the key doesn't exist.
-#
-# Args:
-#   $1 — jq key path (e.g., ".cooldowns.save_seconds")
-#   $2 — default value if key is absent or jq unavailable
-#
-# Output:
-#   Prints the resolved value to stdout.
-#
-# Usage:
-#   SAVE_COOLDOWN=$(config ".cooldowns.save_seconds" 120)
-
-# Ensure PIPELINE_DIR is set. Should be set by resolve-paths.sh before
-# sourcing this file. Falls back to local-install convention if unset.
-PIPELINE_DIR="${PIPELINE_DIR:-${PROJECT_DIR:-.}/.claude/remember}"
-
-REMEMBER_CONFIG="$PIPELINE_DIR/config.json"
-config() {
-    local key="$1"
-    local default="$2"
-    if [ -f "$REMEMBER_CONFIG" ] && command -v jq >/dev/null 2>&1; then
-        local val
-        val=$(jq -r "$key // empty" "$REMEMBER_CONFIG" 2>/dev/null)
-        [ -n "$val" ] && echo "$val" || echo "$default"
-    else
-        echo "$default"
-    fi
-}
-
-REMEMBER_TZ=$(config ".timezone" "")
 # Dispatch a lifecycle event to all registered hooks.
 #
 # Runs every executable in hooks.d/<event>/, passing the project path

--- a/scripts/post-tool-hook.sh
+++ b/scripts/post-tool-hook.sh
@@ -29,15 +29,15 @@
 
 # --- Resolve paths ---
 source "$(dirname "$0")/resolve-paths.sh"
-source "$(dirname "$0")/bootstrap-dirs.sh"
 source "$(dirname "$0")/detect-tools.sh"
+source "$(dirname "$0")/bootstrap-dirs.sh"
 PLUGIN_ROOT="$PIPELINE_DIR"
 PROJECT="$PROJECT_DIR"
 source "$PLUGIN_ROOT/scripts/log.sh" 2>/dev/null
-log "hook" "post-tool: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR PYTHON=$PYTHON"
+log "hook" "post-tool: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR PYTHON=$PYTHON REMEMBER_DIR=$REMEMBER_DIR"
 SAVE_SCRIPT="$PLUGIN_ROOT/scripts/save-session.sh"
-LAST_SAVE_FILE="$PROJECT/.remember/tmp/last-save.json"
-PID_FILE="$PROJECT/.remember/tmp/save-session.pid"
+LAST_SAVE_FILE="$REMEMBER_DIR/tmp/last-save.json"
+PID_FILE="$REMEMBER_DIR/tmp/save-session.pid"
 SESSION_DIR="$HOME/.claude/projects/$(session_dir_slug "$PROJECT")"
 
 [ -f "$SAVE_SCRIPT" ] || exit 0
@@ -89,8 +89,8 @@ if [ "$DELTA" -gt "$DELTA_THRESHOLD" ]; then
     fi
 
     if [ "$ALREADY_RUNNING" = false ]; then
-        mkdir -p "$PROJECT/.remember/logs/autonomous"
-        nohup "$SAVE_SCRIPT" "$SESSION_ID" > "$PROJECT/.remember/logs/autonomous/save-$(_remember_date +%H%M%S).log" 2>&1 &
+        mkdir -p "$REMEMBER_DIR/logs/autonomous"
+        nohup "$SAVE_SCRIPT" "$SESSION_ID" > "$REMEMBER_DIR/logs/autonomous/save-$(_remember_date +%H%M%S).log" 2>&1 &
         echo $! > "$PID_FILE"
         SAVE_TRIGGERED="true"
     fi

--- a/scripts/run-consolidation.sh
+++ b/scripts/run-consolidation.sh
@@ -37,12 +37,13 @@ set -e
 
 source "$(dirname "$0")/resolve-paths.sh"
 source "$(dirname "$0")/detect-tools.sh"
+source "$(dirname "$0")/bootstrap-dirs.sh"
 source "$(dirname "$0")/log.sh"
-log "hook" "run-consolidation: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR PYTHON=$PYTHON"
+log "hook" "run-consolidation: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR PYTHON=$PYTHON REMEMBER_DIR=$REMEMBER_DIR"
 rotate_logs
 
 # --- Lock (atomic via noclobber) ---
-LOCK_FILE="${PROJECT_DIR}/.remember/tmp/consolidation.lock"
+LOCK_FILE="${REMEMBER_DIR}/tmp/consolidation.lock"
 if ! ( set -o noclobber; echo $$ > "$LOCK_FILE" ) 2>/dev/null; then
     LOCK_PID=$(cat "$LOCK_FILE" 2>/dev/null)
     if kill -0 "$LOCK_PID" 2>/dev/null; then
@@ -53,7 +54,7 @@ if ! ( set -o noclobber; echo $$ > "$LOCK_FILE" ) 2>/dev/null; then
 fi
 trap 'rm -f "$LOCK_FILE"' EXIT
 
-STAGING_DIR="${PROJECT_DIR}/.remember"
+STAGING_DIR="${REMEMBER_DIR}"
 RECENT_FILE="${STAGING_DIR}/recent.md"
 ARCHIVE_FILE="${STAGING_DIR}/archive.md"
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -94,6 +94,16 @@ for script in save-session.sh run-consolidation.sh log.sh; do
     fi
 done
 
+for hook in "$PIPELINE_DIR"/hooks.d/**/*.sh; do
+    [ -f "$hook" ] || continue
+    rel="${hook#"$PIPELINE_DIR/"}"
+    if bash -n "$hook" 2>/dev/null; then
+        pass "$rel"
+    else
+        fail "$rel" "syntax error"
+    fi
+done
+
 echo ""
 
 # ── 3. Python unit tests ─────────────────────────────────────────────────

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -56,20 +56,16 @@ trap 'log "error" "FAILED at line $LINENO (exit $?)"' ERR
 
 source "$(dirname "$0")/resolve-paths.sh"
 source "$(dirname "$0")/detect-tools.sh"
+source "$(dirname "$0")/bootstrap-dirs.sh"
 source "$(dirname "$0")/log.sh"
-log "hook" "save-session: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR PYTHON=$PYTHON"
+log "hook" "save-session: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR PYTHON=$PYTHON REMEMBER_DIR=$REMEMBER_DIR"
 
-REMEMBER_DATA="${PROJECT_DIR}/.remember"
-LOCK_FILE="${REMEMBER_DATA}/tmp/save.lock"
-MEMORY_FILE="${REMEMBER_DATA}/now.md"
-LAST_SAVE_FILE="${REMEMBER_DATA}/tmp/last-save.json"
-COOLDOWN_MARKER="${REMEMBER_DATA}/tmp/last-save-ts"
+LOCK_FILE="${REMEMBER_DIR}/tmp/save.lock"
+MEMORY_FILE="${REMEMBER_DIR}/now.md"
+LAST_SAVE_FILE="${REMEMBER_DIR}/tmp/last-save.json"
+COOLDOWN_MARKER="${REMEMBER_DIR}/tmp/last-save-ts"
 TODAY_DATE=$(TZ="$REMEMBER_TZ" date +%Y-%m-%d)
 CLEANUP_FILES=()
-
-# Auto-create data dir + gitignore on first run
-mkdir -p "${REMEMBER_DATA}/tmp"
-[ -f "${REMEMBER_DATA}/.gitignore" ] || echo '*' > "${REMEMBER_DATA}/.gitignore"
 
 # Remove lock file and all accumulated temp files on exit.
 cleanup() { rm -f "$LOCK_FILE" "${CLEANUP_FILES[@]}"; }
@@ -154,7 +150,8 @@ fi
 BRANCH=$(cd "$PROJECT_DIR" && git branch --show-current 2>/dev/null || echo "unknown")
 TIME_FORMAT=$(config ".time_format" "24h")
 if [ "$TIME_FORMAT" = "12h" ]; then
-    CURRENT_TIME=$(TZ="$REMEMBER_TZ" date '+%-I:%M %p')
+    # Force uppercase AM/PM: %p is locale-dependent (lowercase on many Linux systems).
+    CURRENT_TIME=$(TZ="$REMEMBER_TZ" date '+%-I:%M %p' | tr '[:lower:]' '[:upper:]')
 else
     CURRENT_TIME=$(TZ="$REMEMBER_TZ" date '+%H:%M')
 fi
@@ -216,7 +213,7 @@ log "write" "position → $POSITION"
 dispatch "after_save"
 
 # --- Step 8: NDC compression (1h cooldown, background) ---
-NDC_MARKER="${PROJECT_DIR}/.remember/tmp/last-ndc.ts"
+NDC_MARKER="${REMEMBER_DIR}/tmp/last-ndc.ts"
 RUN_NDC=true
 if [ -f "$NDC_MARKER" ]; then
     NDC_MOD=$(cat "$NDC_MARKER" 2>/dev/null || echo 0)
@@ -224,7 +221,7 @@ if [ -f "$NDC_MARKER" ]; then
     [ $(( $(date +%s) - NDC_MOD )) -lt "$NDC_COOLDOWN" ] && RUN_NDC=false
 fi
 
-TODAY_FILE="${PROJECT_DIR}/.remember/today-${TODAY_DATE}.md"
+TODAY_FILE="${REMEMBER_DIR}/today-${TODAY_DATE}.md"
 
 if [ "$RUN_NDC" = true ]; then
     log "ndc" "now.md → today-${TODAY_DATE}.md"
@@ -269,5 +266,5 @@ if [ "$RUN_NDC" = true ]; then
     fi
 
     # Housekeeping: remove empty autonomous logs
-    find "${PROJECT_DIR}/.remember/logs/autonomous" -name "*.log" -empty -delete 2>/dev/null
+    find "${REMEMBER_DIR}/logs/autonomous" -name "*.log" -empty -delete 2>/dev/null
 fi

--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -32,31 +32,31 @@
 #
 # OUTPUT
 #   Prints memory content to stdout for injection into session context.
-#   Sections: === MEMORY ===, === MEMORY CONSOLIDATION ===
+#   Sections: === HANDOFF ===, === MEMORY ===, === MEMORY CONSOLIDATION ===
 #   hooks.d/ listeners may add their own (e.g., === TEAM ===).
 #
 # ============================================================================
 
 source "$(dirname "$0")/resolve-paths.sh"
-source "$(dirname "$0")/bootstrap-dirs.sh"
 source "$(dirname "$0")/detect-tools.sh"
+source "$(dirname "$0")/bootstrap-dirs.sh"
 PLUGIN_ROOT="$PIPELINE_DIR"
 PROJECT="$PROJECT_DIR"
 source "$PLUGIN_ROOT/scripts/log.sh" 2>/dev/null
 TODAY=$(TZ="$REMEMBER_TZ" date '+%Y-%m-%d')
-log "hook" "session-start: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR"
+log "hook" "session-start: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR REMEMBER_DIR=$REMEMBER_DIR"
 
 # ── Dispatch: before_session_start ────────────────────────────────────────
 dispatch "before_session_start"
 
 # ── Cleanup + health check ─────────────────────────────────────────────────
-rm -f "$PROJECT/.remember/tmp/save-session.pid"
+rm -f "$REMEMBER_DIR/tmp/save-session.pid"
 
 # ── Recovery: save the most recent missed session ──────────────────────────
 if [ "$(config '.features.recovery' true)" = "true" ]; then
 PROJECT_PATH_SLUG="$(session_dir_slug "$PROJECT")"
 SESSIONS_DIR="$HOME/.claude/projects/${PROJECT_PATH_SLUG}"
-LAST_SAVE_FILE="$PROJECT/.remember/tmp/last-save.json"
+LAST_SAVE_FILE="$REMEMBER_DIR/tmp/last-save.json"
 
 if [ -d "$SESSIONS_DIR" ] && [ -f "$LAST_SAVE_FILE" ]; then
     SAVED_ID=$($JQ -r '.session // ""' "$LAST_SAVE_FILE" 2>/dev/null)
@@ -70,13 +70,25 @@ if [ -d "$SESSIONS_DIR" ] && [ -f "$LAST_SAVE_FILE" ]; then
 fi
 fi
 
-IDENTITY_FILE="$PLUGIN_ROOT/identity.md"
-CORE_MEMORIES="$PROJECT/.remember/core-memories.md"
-REMEMBER_RECENT="$PROJECT/.remember/recent.md"
-REMEMBER_ARCHIVE="$PROJECT/.remember/archive.md"
-REMEMBER_HANDOFF="$PROJECT/.remember/remember.md"
-REMEMBER_NOW="$PROJECT/.remember/now.md"
-REMEMBER_TODAY_FILE="$PROJECT/.remember/today-${TODAY}.md"
+# ── Identity: project-first fallback to plugin-bundled ────────────────────
+if [ -f "$REMEMBER_DIR/identity.md" ]; then
+    IDENTITY_FILE="$REMEMBER_DIR/identity.md"
+else
+    IDENTITY_FILE="$PLUGIN_ROOT/identity.md"
+fi
+
+CORE_MEMORIES="$REMEMBER_DIR/core-memories.md"
+REMEMBER_RECENT="$REMEMBER_DIR/recent.md"
+REMEMBER_ARCHIVE="$REMEMBER_DIR/archive.md"
+REMEMBER_HANDOFF="$REMEMBER_DIR/remember.md"
+REMEMBER_NOW="$REMEMBER_DIR/now.md"
+REMEMBER_TODAY_FILE="$REMEMBER_DIR/today-${TODAY}.md"
+
+# ── Handoff path hint (consumed by the /remember skill) ───────────────────
+# Emitted unconditionally so the skill always knows the correct write target.
+echo "=== HANDOFF ==="
+echo "Write next handoff to: $REMEMBER_HANDOFF"
+echo ""
 
 # ── History hint ───────────────────────────────────────────────────────────
 cat "$PLUGIN_ROOT/prompts/session-history-hint.txt" 2>/dev/null
@@ -109,7 +121,7 @@ fi
 
 # ── Consolidation trigger ─────────────────────────────────────────────────
 # If past-day staging files exist, compress them in the background.
-STAGING_COUNT=$(ls "$PROJECT/.remember/today-"*.md 2>/dev/null | grep -v "today-${TODAY}.md" | grep -v "\.done\.md" | wc -l | tr -d ' ')
+STAGING_COUNT=$(ls "$REMEMBER_DIR/today-"*.md 2>/dev/null | grep -v "today-${TODAY}.md" | grep -v "\.done\.md" | wc -l | tr -d ' ')
 if [ "$STAGING_COUNT" -gt 0 ]; then
     echo "=== MEMORY CONSOLIDATION ==="
     echo "$STAGING_COUNT day(s) of memory to compress. Running consolidation in background..."

--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -70,9 +70,14 @@ if [ -d "$SESSIONS_DIR" ] && [ -f "$LAST_SAVE_FILE" ]; then
 fi
 fi
 
-# ── Identity: project-first fallback to plugin-bundled ────────────────────
+# ── Identity: per-project → user-global → plugin-bundled ──────────────────
+# User-global tier: <REMEMBER_ROOT>/identity.md (external mode only).
+# In legacy mode REMEMBER_ROOT == PROJECT_DIR, so we skip it there.
+REMEMBER_ROOT=$(dirname "$REMEMBER_DIR")
 if [ -f "$REMEMBER_DIR/identity.md" ]; then
     IDENTITY_FILE="$REMEMBER_DIR/identity.md"
+elif [ -f "$REMEMBER_ROOT/identity.md" ] && [ "$REMEMBER_ROOT" != "$PROJECT_DIR" ]; then
+    IDENTITY_FILE="$REMEMBER_ROOT/identity.md"
 else
     IDENTITY_FILE="$PLUGIN_ROOT/identity.md"
 fi

--- a/skills/remember/SKILL.md
+++ b/skills/remember/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Write
 
 Write a handoff note so the next session can continue cleanly. Use your knowledge of the current session — you were here. Write in first person ("I").
 
-**Path:** `{project_root}/.remember/remember.md` (overwrite). This is at the PROJECT ROOT, NOT relative to this skill file. If the project root is `/Users/foo/myproject`, the file goes to `/Users/foo/myproject/.remember/remember.md`.
+**Path:** Use the path from the most recent `=== HANDOFF ===` block in this session's context (e.g., `Write next handoff to: /home/user/.remember/myproject-slug/remember.md`). If no `=== HANDOFF ===` block is present, fall back to `{project_root}/.remember/remember.md`. This is at the PROJECT ROOT, NOT relative to this skill file.
 
 **If the file already exists, Read it first before Writing.** The Write tool enforces a read-before-write check on existing files; without a prior Read, the first Write call will fail with "File has not been read yet." A 1-line Read is enough to satisfy the check.
 

--- a/tests/test_external_data_dir.py
+++ b/tests/test_external_data_dir.py
@@ -1,0 +1,218 @@
+"""End-to-end tests for external data_dir mode.
+
+Verifies that when data_dir points outside the project:
+  - REMEMBER_DIR is created at the expected path
+  - .gitignore is NOT written inside REMEMBER_DIR
+  - Per-project identity.md overrides the plugin-bundled one
+  - === HANDOFF === with the correct absolute path appears in session-start output
+"""
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DETECT_SCRIPT = REPO_ROOT / "scripts" / "detect-tools.sh"
+BOOTSTRAP_SCRIPT = REPO_ROOT / "scripts" / "bootstrap-dirs.sh"
+SESSION_START_SCRIPT = REPO_ROOT / "scripts" / "session-start-hook.sh"
+BUNDLED_IDENTITY = REPO_ROOT / "identity.example.md"
+
+
+def _slug(path: str) -> str:
+    """Reproduce the session_dir_slug logic in Python for assertion."""
+    import re
+    return re.sub(r"[^a-zA-Z0-9]", "-", path)
+
+
+def _make_plugin_dir(tmp_path: Path, data_dir_value: str) -> Path:
+    """Create a minimal plugin directory with a config.json."""
+    plugin = tmp_path / "plugin"
+    plugin.mkdir(parents=True)
+    (plugin / "scripts").mkdir()
+    (plugin / "pipeline").mkdir()
+    (plugin / "pipeline" / "haiku.py").write_text("# marker\n")
+    (plugin / "config.json").write_text(json.dumps({
+        "data_dir": data_dir_value,
+        "cooldowns": {"save_seconds": 120, "ndc_seconds": 3600},
+        "thresholds": {"min_human_messages": 3, "delta_lines_trigger": 50},
+        "features": {"ndc_compression": True, "recovery": False},
+    }))
+    (plugin / "identity.md").write_text("Bundled identity.\n")
+    (plugin / "prompts").mkdir()
+    (plugin / "prompts" / "session-history-hint.txt").write_text("")
+    (plugin / "hooks.d").mkdir()
+    return plugin
+
+
+def _run_bootstrap(project_dir: str, pipeline_dir: str, home_dir: str) -> dict:
+    script = f"""
+    set -e
+    export PROJECT_DIR={project_dir}
+    export PIPELINE_DIR={pipeline_dir}
+    export HOME={home_dir}
+    source {DETECT_SCRIPT}
+    source {BOOTSTRAP_SCRIPT}
+    echo "REMEMBER_DIR=$REMEMBER_DIR"
+    """
+    result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, f"bootstrap failed:\n{result.stderr}"
+    parsed: dict = {}
+    for line in result.stdout.strip().splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            parsed[k] = v
+    return parsed
+
+
+class TestExternalMode:
+
+    def test_remember_dir_created_at_external_path(self, tmp_path):
+        """REMEMBER_DIR is created at the external path, not inside PROJECT_DIR."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        home = tmp_path / "home"
+        home.mkdir()
+        ext_base = tmp_path / "ext-mem"
+        plugin = _make_plugin_dir(tmp_path, str(ext_base) + "/{slug}")
+
+        result = _run_bootstrap(str(project), str(plugin), str(home))
+        remember_dir = Path(result["REMEMBER_DIR"])
+
+        assert remember_dir.exists(), "REMEMBER_DIR not created"
+        assert str(remember_dir).startswith(str(ext_base)), "REMEMBER_DIR not under ext_base"
+        assert not str(remember_dir).startswith(str(project)), "REMEMBER_DIR is inside project"
+
+    def test_no_gitignore_in_external_mode(self, tmp_path):
+        """No .gitignore is written when REMEMBER_DIR is outside PROJECT_DIR."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        home = tmp_path / "home"
+        home.mkdir()
+        ext_base = tmp_path / "ext-mem"
+        plugin = _make_plugin_dir(tmp_path, str(ext_base) + "/{slug}")
+
+        result = _run_bootstrap(str(project), str(plugin), str(home))
+        remember_dir = Path(result["REMEMBER_DIR"])
+
+        assert not (remember_dir / ".gitignore").exists(), ".gitignore must not be written in external mode"
+
+    def test_gitignore_written_in_legacy_mode(self, tmp_path):
+        """Sanity: .gitignore IS written when REMEMBER_DIR is inside PROJECT_DIR."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        home = tmp_path / "home"
+        home.mkdir()
+        plugin = _make_plugin_dir(tmp_path, ".remember")  # legacy default
+
+        result = _run_bootstrap(str(project), str(plugin), str(home))
+        remember_dir = Path(result["REMEMBER_DIR"])
+
+        assert (remember_dir / ".gitignore").exists(), ".gitignore must be written in legacy mode"
+
+    def test_slug_matches_project_path(self, tmp_path):
+        """The slug in REMEMBER_DIR matches the session_dir_slug of PROJECT_DIR."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        home = tmp_path / "home"
+        home.mkdir()
+        ext_base = tmp_path / "ext-mem"
+        plugin = _make_plugin_dir(tmp_path, str(ext_base) + "/{slug}")
+
+        result = _run_bootstrap(str(project), str(plugin), str(home))
+        remember_dir = result["REMEMBER_DIR"]
+
+        expected_slug = _slug(str(project))
+        assert remember_dir.endswith(expected_slug), (
+            f"Expected REMEMBER_DIR to end with slug '{expected_slug}', got: {remember_dir}"
+        )
+
+
+class TestHandoffEmission:
+
+    def test_session_start_emits_handoff_block(self, tmp_path):
+        """session-start-hook.sh emits === HANDOFF === with the absolute REMEMBER_DIR path.
+
+        Uses the real plugin scripts from REPO_ROOT; sets external mode via
+        user-global ~/.remember/config.json so no fake plugin dir is needed.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        home = tmp_path / "home"
+        (home / ".remember").mkdir(parents=True)
+        ext_base = tmp_path / "ext-mem"
+
+        # Activate external mode via user-global config.
+        (home / ".remember" / "config.json").write_text(
+            json.dumps({"data_dir": str(ext_base) + "/{slug}", "features": {"recovery": False}})
+        )
+
+        # session-start reads from ~/.claude/projects/<slug>/ — create an empty one.
+        slug = _slug(str(project))
+        sessions_dir = home / ".claude" / "projects" / slug
+        sessions_dir.mkdir(parents=True)
+
+        # Run as a standalone script (not sourced) so $0 is set correctly.
+        env = {
+            **os.environ,
+            "CLAUDE_PROJECT_DIR": str(project),
+            "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
+            "HOME": str(home),
+        }
+        result = subprocess.run(
+            ["bash", str(SESSION_START_SCRIPT)], env=env, capture_output=True, text=True
+        )
+        output = result.stdout
+
+        assert "=== HANDOFF ===" in output, (
+            f"=== HANDOFF === block missing from session-start output.\nstderr: {result.stderr[:500]}"
+        )
+        assert "remember.md" in output, "handoff path missing remember.md"
+        assert str(ext_base) in output, (
+            f"handoff path does not reference external base.\noutput: {output}\nstderr: {result.stderr[:300]}"
+        )
+
+
+class TestIdentityFallback:
+
+    def test_project_identity_overrides_bundled(self, tmp_path):
+        """Per-project identity.md in REMEMBER_DIR takes precedence over bundled."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        home = tmp_path / "home"
+        (home / ".remember").mkdir(parents=True)
+        ext_base = tmp_path / "ext-mem"
+
+        # Activate external mode.
+        (home / ".remember" / "config.json").write_text(
+            json.dumps({"data_dir": str(ext_base) + "/{slug}", "features": {"recovery": False}})
+        )
+
+        # Bootstrap first to learn REMEMBER_DIR path.
+        result = _run_bootstrap(
+            str(project),
+            str(REPO_ROOT),   # real plugin
+            str(home),
+        )
+        remember_dir = Path(result["REMEMBER_DIR"])
+        (remember_dir / "identity.md").write_text("Project-specific identity.\n")
+
+        slug = _slug(str(project))
+        sessions_dir = home / ".claude" / "projects" / slug
+        sessions_dir.mkdir(parents=True)
+
+        env = {
+            **os.environ,
+            "CLAUDE_PROJECT_DIR": str(project),
+            "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
+            "HOME": str(home),
+        }
+        result = subprocess.run(
+            ["bash", str(SESSION_START_SCRIPT)], env=env, capture_output=True, text=True
+        )
+        output = result.stdout
+
+        assert "Project-specific identity." in output, (
+            f"project-specific identity not injected.\nstderr: {result.stderr[:500]}"
+        )

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -142,6 +142,39 @@ def test_get_last_save_line_different_session():
         assert get_last_save_line("new-session", project_dir=d) == 0
 
 
+# ─── External-mode: remember_dir parameter ───────────────────────────────────
+
+def test_last_save_path_explicit_remember_dir():
+    """remember_dir override takes precedence over project_dir default."""
+    path = _last_save_path("/some/project", remember_dir="/ext/mem")
+    assert path == "/ext/mem/tmp/last-save.json"
+
+
+def test_last_save_path_env_var_fallback(monkeypatch):
+    """REMEMBER_DIR env var is honoured when remember_dir is None."""
+    monkeypatch.setenv("REMEMBER_DIR", "/env/mem")
+    path = _last_save_path("/some/project")
+    assert path == "/env/mem/tmp/last-save.json"
+
+
+def test_last_save_path_project_fallback(monkeypatch):
+    """Falls back to project-relative path when nothing else is set."""
+    monkeypatch.delenv("REMEMBER_DIR", raising=False)
+    path = _last_save_path("/some/project")
+    assert path == "/some/project/.remember/tmp/last-save.json"
+
+
+def test_get_last_save_line_with_external_remember_dir():
+    """get_last_save_line reads from remember_dir, not project_dir/.remember."""
+    with tempfile.TemporaryDirectory() as ext:
+        save_dir = os.path.join(ext, "tmp")
+        os.makedirs(save_dir)
+        with open(os.path.join(save_dir, "last-save.json"), "w") as f:
+            json.dump({"session": "ext-session", "line": 77}, f)
+        # project_dir has no .remember; the data lives in ext/
+        assert get_last_save_line("ext-session", project_dir="/nonexistent", remember_dir=ext) == 77
+
+
 def test_extract_messages_corrupt_lines():
     with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
         f.write('{"type":"user","message":{"role":"user","content":"hello"}}\n')

--- a/tests/test_git_backup_hook.py
+++ b/tests/test_git_backup_hook.py
@@ -1,0 +1,360 @@
+"""Tests for hooks.d/after_save/50-git-backup.sh.
+
+Each test sets up a temp home with ~/.remember/ as its own git repo backed by a
+bare remote.  The hook is invoked via subprocess with the env vars that
+save-session.sh would normally provide.  _LIB_MEMORY_DIR_LOADED=1 prevents
+lib-memory-dir.sh from overriding the REMEMBER_DIR we set explicitly.
+"""
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOK = REPO_ROOT / "hooks.d" / "after_save" / "50-git-backup.sh"
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def wait_for_lock_release(lock_path: Path, timeout: float = 10, interval: float = 0.1) -> bool:
+    """Poll until lock_path disappears or timeout expires."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not lock_path.exists():
+            return True
+        time.sleep(interval)
+    raise TimeoutError(f"Lock not released within {timeout}s: {lock_path}")
+
+
+def _git(repo: Path, args: list) -> None:
+    subprocess.run(["git", "-C", str(repo)] + args, check=True, capture_output=True)
+
+
+def make_external_remember_repo(tmp_path: Path):
+    """Create home/.remember/ as a git repo with a bare remote."""
+    home = tmp_path / "home"
+    remember = home / ".remember"
+    remote = home / ".remember-remote.git"
+    remember.mkdir(parents=True)
+    _git(remember, ["init", "-q", "-b", "main"])
+    _git(remember, ["config", "user.email", "test@test"])
+    _git(remember, ["config", "user.name", "Test"])
+    subprocess.run(["git", "init", "-q", "--bare", str(remote)], check=True, capture_output=True)
+    _git(remember, ["remote", "add", "origin", str(remote)])
+    gitignore = remember / ".gitignore"
+    gitignore.write_text(".git-backup.lock\n.last-git-backup-ts\n*/logs/\n*/tmp/\n")
+    _git(remember, ["add", ".gitignore"])
+    _git(remember, ["commit", "-q", "-m", "init"])
+    _git(remember, ["push", "-q", "-u", "origin", "main"])
+    return home, remember, remote
+
+
+def _make_config(tmp_path: Path, cooldown: int = 900) -> Path:
+    """Write a minimal REMEMBER_CONFIG with the given git_backup_seconds cooldown."""
+    cfg = tmp_path / "remember-config.json"
+    cfg.write_text(f'{{"cooldowns": {{"git_backup_seconds": {cooldown}}}}}')
+    return cfg
+
+
+def _run_hook(
+    slug_dir: Path,
+    project_dir: Path,
+    home_dir: Path,
+    extra_env: dict = None,
+    config_path: Path = None,
+) -> subprocess.CompletedProcess:
+    """Run the git-backup hook with the environment save-session.sh would provide."""
+    env = {
+        **os.environ,
+        "HOME": str(home_dir),
+        "PROJECT_DIR": str(project_dir),
+        "PIPELINE_DIR": str(REPO_ROOT),
+        "REMEMBER_DIR": str(slug_dir),
+        # Prevent lib-memory-dir.sh from overriding REMEMBER_DIR.
+        "_LIB_MEMORY_DIR_LOADED": "1",
+        "REMEMBER_PROJECT": str(project_dir),
+        # Ensure git commits work regardless of the user's global config.
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@test",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@test",
+    }
+    if config_path is not None:
+        env["REMEMBER_CONFIG"] = str(config_path)
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(["bash", str(HOOK)], env=env, capture_output=True, text=True)
+
+
+def _commit_log(repo: Path) -> list[str]:
+    """Return oneline commit log for a repo (newest first). Empty list if no commits yet."""
+    result = subprocess.run(
+        ["git", "-C", str(repo), "log", "--oneline"],
+        capture_output=True, text=True,
+    )
+    if result.returncode not in (0, 128):
+        raise RuntimeError(f"git log failed (rc={result.returncode}): {result.stderr}")
+    return [l for l in result.stdout.strip().splitlines() if l]
+
+
+def _files_in_commit(repo: Path, ref: str = "HEAD") -> list[str]:
+    """Return list of files changed in a commit."""
+    result = subprocess.run(
+        ["git", "-C", str(repo), "diff-tree", "--no-commit-id", "-r", "--name-only", ref],
+        capture_output=True, text=True, check=True,
+    )
+    return [l for l in result.stdout.strip().splitlines() if l]
+
+
+# ── Test cases ────────────────────────────────────────────────────────────────
+
+
+class TestGitBackupHook:
+
+    def test_no_op_when_not_a_git_repo(self, tmp_path):
+        """No-op when REPO_ROOT is not a git repo — no lock, no marker created."""
+        home = tmp_path / "home"
+        home.mkdir()
+        remember = home / ".remember"
+        remember.mkdir()
+        slug_dir = remember / "test-slug"
+        slug_dir.mkdir()
+        project = tmp_path / "project"
+        project.mkdir()
+
+        result = _run_hook(slug_dir, project, home)
+
+        assert result.returncode == 0
+        assert not (remember / ".git-backup.lock").exists()
+        assert not (remember / ".last-git-backup-ts").exists()
+
+    def test_no_op_in_legacy_mode(self, tmp_path):
+        """No-op when REMEMBER_DIR is inside PROJECT_DIR — project repo is untouched."""
+        project = tmp_path / "project"
+        project.mkdir()
+        _git(project, ["init", "-q"])
+        _git(project, ["config", "user.email", "t@t"])
+        _git(project, ["config", "user.name", "T"])
+        remember_dir = project / ".remember"
+        remember_dir.mkdir()
+
+        result = _run_hook(remember_dir, project, tmp_path / "home")
+
+        assert result.returncode == 0
+        assert _commit_log(project) == []
+
+    def test_no_op_when_not_at_git_toplevel(self, tmp_path):
+        """No-op when REPO_ROOT is a subdir of a git repo (not its own toplevel)."""
+        home = tmp_path / "home"
+        home.mkdir()
+        outer = home / "repos" / "some-repo"
+        outer.mkdir(parents=True)
+        _git(outer, ["init", "-q"])
+        _git(outer, ["config", "user.email", "t@t"])
+        _git(outer, ["config", "user.name", "T"])
+        # .remember is nested inside the outer repo — not its own git toplevel.
+        remember = outer / ".remember"
+        remember.mkdir()
+        slug_dir = remember / "test-slug"
+        slug_dir.mkdir()
+        project = tmp_path / "project"
+        project.mkdir()
+
+        result = _run_hook(slug_dir, project, home)
+
+        assert result.returncode == 0
+        assert _commit_log(outer) == []
+
+    def test_happy_path_first_run(self, tmp_path):
+        """First run: commits slug subtree with auto: message; marker and push succeed."""
+        home, remember, _ = make_external_remember_repo(tmp_path)
+        slug = "test-project-slug"
+        slug_dir = remember / slug
+        slug_dir.mkdir()
+        (slug_dir / "now.md").write_text("## 10:00 | test\nSome memory.\n")
+
+        project = tmp_path / "project"
+        project.mkdir()
+        cfg = _make_config(tmp_path, cooldown=0)
+
+        result = _run_hook(slug_dir, project, home, config_path=cfg)
+        assert result.returncode == 0
+
+        wait_for_lock_release(remember / ".git-backup.lock")
+
+        commits = _commit_log(remember)
+        assert len(commits) == 2  # init + auto commit
+        commit_msg = commits[0].split(" ", 1)[1]
+        assert commit_msg.startswith(f"auto: {slug}")
+
+        changed = _files_in_commit(remember)
+        assert changed, "Expected at least one file in commit"
+        assert all(f.startswith(f"{slug}/") for f in changed)
+
+        assert (remember / ".last-git-backup-ts").exists()
+        assert not (remember / ".git-backup.lock").exists()
+
+    def test_nothing_to_commit_no_op(self, tmp_path):
+        """Second run with no new changes: no commit added, cooldown marker unchanged."""
+        home, remember, _ = make_external_remember_repo(tmp_path)
+        slug = "test-slug"
+        slug_dir = remember / slug
+        slug_dir.mkdir()
+        (slug_dir / "now.md").write_text("## 10:00 | test\nMemory.\n")
+
+        project = tmp_path / "project"
+        project.mkdir()
+        cfg = _make_config(tmp_path, cooldown=0)
+
+        # First run — commits and sets the marker.
+        _run_hook(slug_dir, project, home, config_path=cfg)
+        wait_for_lock_release(remember / ".git-backup.lock")
+
+        # Backdate the marker to 0 so the cooldown check is definitely cleared.
+        cooldown_marker = remember / ".last-git-backup-ts"
+        cooldown_marker.write_text("0")
+        marker_mtime_before = cooldown_marker.stat().st_mtime
+
+        # Second run — no files changed.
+        _run_hook(slug_dir, project, home, config_path=cfg)
+        wait_for_lock_release(remember / ".git-backup.lock")
+
+        assert len(_commit_log(remember)) == 2  # init + first auto commit only
+
+        # Cooldown marker must NOT be updated when nothing was committed.
+        assert cooldown_marker.stat().st_mtime == marker_mtime_before
+
+    def test_cooldown_respected(self, tmp_path):
+        """Second invocation within the cooldown window exits early; marker stays unchanged."""
+        home, remember, _ = make_external_remember_repo(tmp_path)
+        slug = "test-slug"
+        slug_dir = remember / slug
+        slug_dir.mkdir()
+        (slug_dir / "now.md").write_text("## 10:00 | test\nMemory.\n")
+
+        project = tmp_path / "project"
+        project.mkdir()
+        # 2s cooldown — first run sets the marker, second run fires before 2s elapse.
+        cfg = _make_config(tmp_path, cooldown=2)
+
+        _run_hook(slug_dir, project, home, config_path=cfg)
+        wait_for_lock_release(remember / ".git-backup.lock")
+
+        cooldown_marker = remember / ".last-git-backup-ts"
+        assert cooldown_marker.exists()
+        marker_mtime_before = cooldown_marker.stat().st_mtime
+
+        # Modify a file so there would be something to commit if not for cooldown.
+        (slug_dir / "now.md").write_text("## 10:05 | test\nMore memory.\n")
+
+        # Second run fires immediately — cooldown still active.
+        _run_hook(slug_dir, project, home, config_path=cfg)
+        # Cooldown exits before acquiring the lock, so no subshell to wait for.
+
+        assert len(_commit_log(remember)) == 2  # init + first auto only
+
+        # Cooldown marker must NOT be reset by the skipped run.
+        assert cooldown_marker.stat().st_mtime == marker_mtime_before
+
+    def test_per_slug_isolation(self, tmp_path):
+        """Each slug gets its own commit containing only that slug's paths."""
+        home, remember, _ = make_external_remember_repo(tmp_path)
+        slug_a = remember / "slug-a"
+        slug_b = remember / "slug-b"
+        slug_a.mkdir()
+        slug_b.mkdir()
+        (slug_a / "now.md").write_text("memory A\n")
+        (slug_b / "now.md").write_text("memory B\n")
+
+        project = tmp_path / "project"
+        project.mkdir()
+        cfg = _make_config(tmp_path, cooldown=0)
+
+        _run_hook(slug_a, project, home, config_path=cfg)
+        wait_for_lock_release(remember / ".git-backup.lock")
+
+        _run_hook(slug_b, project, home, config_path=cfg)
+        wait_for_lock_release(remember / ".git-backup.lock")
+
+        commits = _commit_log(remember)
+        assert len(commits) == 3  # init + slug-a + slug-b
+
+        files_a = _files_in_commit(remember, "HEAD~1")
+        assert files_a and all(f.startswith("slug-a/") for f in files_a)
+
+        files_b = _files_in_commit(remember, "HEAD")
+        assert files_b and all(f.startswith("slug-b/") for f in files_b)
+
+    def test_lock_contention_skips(self, tmp_path):
+        """Hook exits silently without committing when lock is held by a live process."""
+        home, remember, _ = make_external_remember_repo(tmp_path)
+        slug_dir = remember / "test-slug"
+        slug_dir.mkdir()
+        (slug_dir / "now.md").write_text("memory\n")
+        project = tmp_path / "project"
+        project.mkdir()
+        cfg = _make_config(tmp_path, cooldown=0)
+
+        lock_file = remember / ".git-backup.lock"
+        # Use the test runner's own PID — guaranteed to be alive.
+        lock_file.write_text(str(os.getpid()))
+
+        _run_hook(slug_dir, project, home, config_path=cfg)
+
+        assert len(_commit_log(remember)) == 1  # init only
+        # Lock must not be stolen from a live process.
+        assert lock_file.exists()
+        assert lock_file.read_text().strip() == str(os.getpid())
+
+    def test_stale_lock_takeover(self, tmp_path):
+        """Hook takes over a lock held by a dead PID and commits successfully."""
+        home, remember, _ = make_external_remember_repo(tmp_path)
+        slug_dir = remember / "test-slug"
+        slug_dir.mkdir()
+        (slug_dir / "now.md").write_text("memory\n")
+        project = tmp_path / "project"
+        project.mkdir()
+        cfg = _make_config(tmp_path, cooldown=0)
+
+        lock_file = remember / ".git-backup.lock"
+        # 999999 is an almost-certainly-dead PID on Linux.
+        lock_file.write_text("999999")
+
+        result = _run_hook(slug_dir, project, home, config_path=cfg)
+        assert result.returncode == 0
+
+        wait_for_lock_release(lock_file)
+
+        commits = _commit_log(remember)
+        assert len(commits) == 2
+        assert "auto:" in commits[0]
+        assert not lock_file.exists()
+
+    def test_push_failure_tolerated(self, tmp_path):
+        """Local commit succeeds when push fails; log records 'push deferred'."""
+        home, remember, _ = make_external_remember_repo(tmp_path)
+        slug = "test-slug"
+        slug_dir = remember / slug
+        slug_dir.mkdir()
+        (slug_dir / "now.md").write_text("memory\n")
+        project = tmp_path / "project"
+        project.mkdir()
+        cfg = _make_config(tmp_path, cooldown=0)
+
+        # Break the remote URL so push will fail.
+        _git(remember, ["remote", "set-url", "origin", "/nonexistent/path.git"])
+
+        _run_hook(slug_dir, project, home, config_path=cfg)
+        wait_for_lock_release(remember / ".git-backup.lock")
+
+        # Local commit was made despite push failure.
+        assert len(_commit_log(remember)) == 2
+
+        log_files = list((slug_dir / "logs").glob("memory-*.log"))
+        assert log_files, "Expected a log file in slug/logs/"
+        log_content = log_files[0].read_text()
+        assert "push deferred" in log_content

--- a/tests/test_layered_config.py
+++ b/tests/test_layered_config.py
@@ -1,0 +1,170 @@
+"""Tests for the lib-memory-dir.sh layered config merge.
+
+Verifies that per-project > user-global > plugin-bundled precedence is
+honoured, that missing layers are silently skipped, and that REMEMBER_DIR
+resolves correctly for both legacy and external data_dir values.
+"""
+
+import json
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LIB_SCRIPT = REPO_ROOT / "scripts" / "lib-memory-dir.sh"
+DETECT_SCRIPT = REPO_ROOT / "scripts" / "detect-tools.sh"
+BUNDLED_CONFIG = REPO_ROOT / "config.example.json"
+
+
+def _run_lib(project_dir: str, pipeline_dir: str, home_dir: str, env_extra: dict | None = None) -> dict:
+    """Source lib-memory-dir.sh and return the exported variables."""
+    script = f"""
+    set -e
+    export PROJECT_DIR={project_dir}
+    export PIPELINE_DIR={pipeline_dir}
+    export HOME={home_dir}
+    source {DETECT_SCRIPT}
+    source {LIB_SCRIPT}
+    echo "REMEMBER_DIR=$REMEMBER_DIR"
+    echo "REMEMBER_CONFIG=$REMEMBER_CONFIG"
+    # Dump a key from the merged config to verify merge
+    if [ -f "$REMEMBER_CONFIG" ] && command -v jq >/dev/null 2>&1; then
+        SAVE_SEC=$(jq -r '.cooldowns.save_seconds // "absent"' "$REMEMBER_CONFIG")
+        DATA_DIR=$(jq -r '.data_dir // "absent"' "$REMEMBER_CONFIG")
+        echo "MERGED_SAVE_SECONDS=$SAVE_SEC"
+        echo "MERGED_DATA_DIR=$DATA_DIR"
+    fi
+    """
+    env = {**os.environ, **(env_extra or {})}
+    result = subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True)
+    assert result.returncode == 0, f"lib-memory-dir.sh failed:\n{result.stderr}"
+    parsed: dict = {}
+    for line in result.stdout.strip().splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            parsed[k] = v
+    return parsed
+
+
+class TestRememberDirResolution:
+
+    def test_legacy_default_no_config_override(self, tmp_path):
+        """No data_dir override → legacy ${PROJECT_DIR}/.remember."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        pipeline = tmp_path / "plugin"
+        pipeline.mkdir()
+        home = tmp_path / "home"
+        home.mkdir()
+
+        # Write a minimal bundled config with no data_dir override
+        (pipeline / "config.json").write_text(json.dumps({"cooldowns": {"save_seconds": 120}}))
+
+        result = _run_lib(str(project), str(pipeline), str(home))
+        assert result["REMEMBER_DIR"] == str(project / ".remember")
+
+    def test_user_global_sets_external_data_dir(self, tmp_path):
+        """User-global config sets data_dir → REMEMBER_DIR uses external path."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        pipeline = tmp_path / "plugin"
+        pipeline.mkdir()
+        home = tmp_path / "home"
+        (home / ".remember").mkdir(parents=True)
+
+        (pipeline / "config.json").write_text(json.dumps({"cooldowns": {"save_seconds": 120}}))
+        (home / ".remember" / "config.json").write_text(
+            json.dumps({"data_dir": str(home / "ext-mem" / "{slug}")})
+        )
+
+        result = _run_lib(str(project), str(pipeline), str(home))
+        assert result["REMEMBER_DIR"].startswith(str(home / "ext-mem" / ""))
+        assert "{slug}" not in result["REMEMBER_DIR"]
+
+    def test_legacy_relative_data_dir(self, tmp_path):
+        """Relative data_dir (no leading / or ~) is resolved against PROJECT_DIR."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        pipeline = tmp_path / "plugin"
+        pipeline.mkdir()
+        home = tmp_path / "home"
+        home.mkdir()
+
+        (pipeline / "config.json").write_text(json.dumps({"data_dir": "my-memory"}))
+
+        result = _run_lib(str(project), str(pipeline), str(home))
+        assert result["REMEMBER_DIR"] == str(project / "my-memory")
+
+
+class TestLayeredConfigMerge:
+
+    def test_bundled_only(self, tmp_path):
+        """Only bundled config → its values are used."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        pipeline = tmp_path / "plugin"
+        pipeline.mkdir()
+        home = tmp_path / "home"
+        home.mkdir()
+
+        (pipeline / "config.json").write_text(json.dumps({"cooldowns": {"save_seconds": 99}}))
+
+        result = _run_lib(str(project), str(pipeline), str(home))
+        assert result.get("MERGED_SAVE_SECONDS") == "99"
+
+    def test_user_global_overrides_bundled(self, tmp_path):
+        """User-global config overrides bundled cooldown."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        pipeline = tmp_path / "plugin"
+        pipeline.mkdir()
+        home = tmp_path / "home"
+        (home / ".remember").mkdir(parents=True)
+
+        (pipeline / "config.json").write_text(json.dumps({"cooldowns": {"save_seconds": 99}}))
+        (home / ".remember" / "config.json").write_text(
+            json.dumps({"cooldowns": {"save_seconds": 200}})
+        )
+
+        result = _run_lib(str(project), str(pipeline), str(home))
+        assert result.get("MERGED_SAVE_SECONDS") == "200"
+
+    def test_per_project_overrides_user_global(self, tmp_path):
+        """Per-project config wins over user-global."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        pipeline = tmp_path / "plugin"
+        pipeline.mkdir()
+        home = tmp_path / "home"
+        (home / ".remember").mkdir(parents=True)
+
+        # REMEMBER_DIR is project-relative (default), so per-project cfg lives there
+        remember = project / ".remember"
+        remember.mkdir()
+
+        (pipeline / "config.json").write_text(json.dumps({"cooldowns": {"save_seconds": 99}}))
+        (home / ".remember" / "config.json").write_text(
+            json.dumps({"cooldowns": {"save_seconds": 200}})
+        )
+        (remember / "config.json").write_text(
+            json.dumps({"cooldowns": {"save_seconds": 999}})
+        )
+
+        result = _run_lib(str(project), str(pipeline), str(home))
+        assert result.get("MERGED_SAVE_SECONDS") == "999"
+
+    def test_missing_user_global_skipped(self, tmp_path):
+        """Missing user-global file does not cause an error; bundled values are used."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        pipeline = tmp_path / "plugin"
+        pipeline.mkdir()
+        home = tmp_path / "home"
+        home.mkdir()
+        # No ~/.remember/config.json
+
+        (pipeline / "config.json").write_text(json.dumps({"cooldowns": {"save_seconds": 55}}))
+
+        result = _run_lib(str(project), str(pipeline), str(home))
+        assert result.get("MERGED_SAVE_SECONDS") == "55"

--- a/tests/test_log_sh.py
+++ b/tests/test_log_sh.py
@@ -110,7 +110,7 @@ def test_log_sh_log_function_produces_filename_matching_configured_tz(tmp_path):
     """
     subprocess.run(
         ["bash", "-c", script],
-        env={**os.environ, "TZ": "UTC"},
+        env={**os.environ, "TZ": "UTC", "HOME": str(tmp_path)},
         check=True,
         capture_output=True,
     )
@@ -214,7 +214,7 @@ def test_log_sh_timestamp_inside_file_uses_configured_tz(tmp_path):
     """
     subprocess.run(
         ["bash", "-c", script],
-        env={**os.environ, "TZ": "UTC"},
+        env={**os.environ, "TZ": "UTC", "HOME": str(tmp_path)},
         check=True,
         capture_output=True,
     )

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,138 @@
+"""Tests for one-shot legacy .remember migration in bootstrap-dirs.sh.
+
+When external mode is active (REMEMBER_DIR != ${PROJECT_DIR}/.remember),
+bootstrap-dirs.sh should migrate any existing legacy data directory to the
+new location on first run and leave a MIGRATED-TO.txt marker behind.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BOOTSTRAP_SCRIPT = REPO_ROOT / "scripts" / "bootstrap-dirs.sh"
+DETECT_SCRIPT = REPO_ROOT / "scripts" / "detect-tools.sh"
+LIB_SCRIPT = REPO_ROOT / "scripts" / "lib-memory-dir.sh"
+
+
+def _source_bootstrap(project_dir: str, pipeline_dir: str, home_dir: str) -> subprocess.CompletedProcess:
+    """Source bootstrap-dirs.sh and return the completed process."""
+    script = f"""
+    set -e
+    export PROJECT_DIR={project_dir}
+    export PIPELINE_DIR={pipeline_dir}
+    export HOME={home_dir}
+    source {DETECT_SCRIPT}
+    source {BOOTSTRAP_SCRIPT}
+    echo "REMEMBER_DIR=$REMEMBER_DIR"
+    """
+    return subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+
+
+def _make_legacy_dir(project_dir: Path) -> None:
+    """Create a legacy .remember/ with sample files."""
+    legacy = project_dir / ".remember"
+    (legacy / "tmp").mkdir(parents=True)
+    (legacy / "logs").mkdir(parents=True)
+    (legacy / "now.md").write_text("## 10:00 | master\nSome work.\n")
+    (legacy / "tmp" / "last-save.json").write_text('{"session":"abc","line":5}')
+
+
+class TestMigration:
+
+    def test_migration_moves_legacy_to_external(self, tmp_path):
+        """Legacy .remember/ is moved to external REMEMBER_DIR on first run."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        pipeline = tmp_path / "plugin"
+        pipeline.mkdir()
+        home = tmp_path / "home"
+        (home / ".remember").mkdir(parents=True)
+
+        _make_legacy_dir(project)
+        legacy = project / ".remember"
+
+        # External data_dir pointing to a slug-based path under home
+        ext_base = tmp_path / "ext"
+        (pipeline / "config.json").write_text(
+            f'{{"data_dir": "{ext_base}/{{{{slug}}}}"}}'
+        )
+
+        result = _source_bootstrap(str(project), str(pipeline), str(home))
+        assert result.returncode == 0, f"bootstrap failed:\n{result.stderr}"
+
+        remember_dir = result.stdout.strip().split("REMEMBER_DIR=")[-1].strip()
+
+        # Files must be at new location
+        assert (Path(remember_dir) / "now.md").exists(), "now.md not migrated"
+        assert (Path(remember_dir) / "tmp" / "last-save.json").exists(), "last-save.json not migrated"
+
+        # Marker must exist in the old location
+        assert (legacy / "MIGRATED-TO.txt").exists(), "MIGRATED-TO.txt not created"
+        marker_text = (legacy / "MIGRATED-TO.txt").read_text()
+        assert remember_dir in marker_text, "marker doesn't reference new location"
+
+    def test_migration_idempotent_when_target_exists(self, tmp_path):
+        """Migration is skipped when REMEMBER_DIR already exists."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        pipeline = tmp_path / "plugin"
+        pipeline.mkdir()
+        home = tmp_path / "home"
+        (home / ".remember").mkdir(parents=True)
+
+        _make_legacy_dir(project)
+
+        ext_base = tmp_path / "ext"
+        (pipeline / "config.json").write_text(
+            f'{{"data_dir": "{ext_base}/{{{{slug}}}}"}}'
+        )
+
+        # First run: migrate
+        result1 = _source_bootstrap(str(project), str(pipeline), str(home))
+        assert result1.returncode == 0
+
+        # Second run: no error, marker still present
+        result2 = _source_bootstrap(str(project), str(pipeline), str(home))
+        assert result2.returncode == 0
+        assert (project / ".remember" / "MIGRATED-TO.txt").exists()
+
+    def test_no_migration_when_legacy_absent(self, tmp_path):
+        """No migration when there is no legacy .remember/ to move."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        pipeline = tmp_path / "plugin"
+        pipeline.mkdir()
+        home = tmp_path / "home"
+        (home / ".remember").mkdir(parents=True)
+
+        ext_base = tmp_path / "ext"
+        (pipeline / "config.json").write_text(
+            f'{{"data_dir": "{ext_base}/{{{{slug}}}}"}}'
+        )
+
+        result = _source_bootstrap(str(project), str(pipeline), str(home))
+        assert result.returncode == 0
+        # No legacy dir → no marker
+        assert not (project / ".remember" / "MIGRATED-TO.txt").exists()
+
+    def test_no_migration_in_legacy_mode(self, tmp_path):
+        """Migration does not run when REMEMBER_DIR is inside PROJECT_DIR."""
+        project = tmp_path / "proj"
+        project.mkdir()
+        pipeline = tmp_path / "plugin"
+        pipeline.mkdir()
+        home = tmp_path / "home"
+        home.mkdir()
+
+        _make_legacy_dir(project)
+        legacy = project / ".remember"
+
+        # No data_dir override → legacy mode
+        (pipeline / "config.json").write_text("{}")
+
+        result = _source_bootstrap(str(project), str(pipeline), str(home))
+        assert result.returncode == 0
+        # now.md must still be in the original location
+        assert (legacy / "now.md").exists()
+        assert not (legacy / "MIGRATED-TO.txt").exists()

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -1528,6 +1528,7 @@ class TestFreshProjectBootstrap:
                if k not in ("CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT")}
         env["CLAUDE_PROJECT_DIR"] = project
         env["CLAUDE_PLUGIN_ROOT"] = plugin
+        env["HOME"] = str(tmp_path)
 
         result = subprocess.run(
             ["bash", os.path.join(plugin, "scripts", "session-start-hook.sh")],
@@ -1566,6 +1567,7 @@ class TestFreshProjectBootstrap:
                if k not in ("CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT")}
         env["CLAUDE_PROJECT_DIR"] = project
         env["CLAUDE_PLUGIN_ROOT"] = plugin
+        env["HOME"] = str(tmp_path)
 
         result = subprocess.run(
             ["bash", os.path.join(plugin, "scripts", "post-tool-hook.sh")],
@@ -1619,6 +1621,7 @@ class TestFreshProjectBootstrap:
                if k not in ("CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT")}
         env["CLAUDE_PROJECT_DIR"] = project
         env["CLAUDE_PLUGIN_ROOT"] = plugin
+        env["HOME"] = str(tmp_path)
 
         result = subprocess.run(
             ["bash", os.path.join(plugin, "scripts", "session-start-hook.sh")],
@@ -1645,6 +1648,7 @@ class TestFreshProjectBootstrap:
                if k not in ("CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT")}
         env["CLAUDE_PROJECT_DIR"] = project
         env["CLAUDE_PLUGIN_ROOT"] = plugin
+        env["HOME"] = str(tmp_path)
 
         result = subprocess.run(
             ["bash", os.path.join(plugin, "scripts", "session-start-hook.sh")],
@@ -1671,6 +1675,7 @@ class TestFreshProjectBootstrap:
                if k not in ("CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT")}
         env["CLAUDE_PROJECT_DIR"] = project
         env["CLAUDE_PLUGIN_ROOT"] = plugin
+        env["HOME"] = str(tmp_path)
 
         result = subprocess.run(
             ["bash", os.path.join(plugin, "scripts", "session-start-hook.sh")],
@@ -1699,6 +1704,7 @@ class TestFreshProjectBootstrap:
                if k not in ("CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT")}
         env["CLAUDE_PROJECT_DIR"] = project
         env["CLAUDE_PLUGIN_ROOT"] = plugin
+        env["HOME"] = str(tmp_path)
 
         result = subprocess.run(
             ["bash", os.path.join(plugin, "scripts", "session-start-hook.sh")],
@@ -1724,6 +1730,7 @@ class TestFreshProjectBootstrap:
                if k not in ("CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT")}
         env["CLAUDE_PROJECT_DIR"] = project
         env["CLAUDE_PLUGIN_ROOT"] = plugin
+        env["HOME"] = str(tmp_path)
 
         result = subprocess.run(
             ["bash", os.path.join(plugin, "scripts", "session-start-hook.sh")],
@@ -1801,6 +1808,7 @@ class TestFreshProjectBootstrap:
                if k not in ("CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT")}
         env["CLAUDE_PROJECT_DIR"] = project
         env["CLAUDE_PLUGIN_ROOT"] = plugin
+        env["HOME"] = str(tmp_path)
 
         # Run three times in succession
         for i in range(3):
@@ -1842,6 +1850,7 @@ class TestFreshProjectBootstrap:
         # Claude Code sets CLAUDE_PROJECT_DIR to the worktree
         env["CLAUDE_PROJECT_DIR"] = worktree
         env["CLAUDE_PLUGIN_ROOT"] = plugin
+        env["HOME"] = str(tmp_path)
 
         result = subprocess.run(
             ["bash", os.path.join(plugin, "scripts", "session-start-hook.sh")],
@@ -1877,6 +1886,7 @@ class TestFreshProjectBootstrap:
                if k not in ("CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT")}
         env["CLAUDE_PROJECT_DIR"] = project
         env["CLAUDE_PLUGIN_ROOT"] = plugin
+        env["HOME"] = str(tmp_path)
 
         script = os.path.join(plugin, "scripts", "session-start-hook.sh")
 
@@ -3165,6 +3175,7 @@ echo "TZ=$REMEMBER_TZ"
 #!/bin/bash
 export PROJECT_DIR="{project}"
 export PIPELINE_DIR="{plugin}"
+export HOME="{tmp_path}"
 source "{self.LOG_SH}" 2>/dev/null
 echo "LOG_DIR=$REMEMBER_LOG_DIR"
 """
@@ -3552,6 +3563,7 @@ echo "DISPATCH_COMPLETED=true"
                if k not in ("CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT")}
         env["CLAUDE_PROJECT_DIR"] = project
         env["CLAUDE_PLUGIN_ROOT"] = plugin
+        env["HOME"] = str(tmp_path)
 
         result = subprocess.run(
             ["bash", os.path.join(plugin, "scripts", "session-start-hook.sh")],

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -1978,12 +1978,13 @@ class TestFreshProjectBootstrap:
                             f"Use $SYS_TMPDIR instead. Line: {line.strip()}"
                         )
 
-    def test_bootstrap_before_detect_tools(self):
-        """bootstrap-dirs.sh must be sourced BEFORE detect-tools.sh.
+    def test_detect_before_bootstrap(self):
+        """detect-tools.sh must be sourced BEFORE bootstrap-dirs.sh.
 
-        The order matters: resolve-paths → bootstrap-dirs → detect-tools.
-        bootstrap needs PROJECT_DIR (from resolve-paths) but nothing else.
-        detect-tools may write to logs, which need the dirs from bootstrap.
+        The order matters: resolve-paths → detect-tools → bootstrap-dirs.
+        bootstrap sources lib-memory-dir.sh which calls session_dir_slug,
+        defined by detect-tools. detect-tools only needs the python/jq
+        binaries and never writes to the memory directory.
         """
         repo_root = os.path.join(os.path.dirname(__file__), "..")
         for script_name in ("session-start-hook.sh", "post-tool-hook.sh"):
@@ -1992,10 +1993,10 @@ class TestFreshProjectBootstrap:
                 content = f.read()
             bootstrap_pos = content.find("bootstrap-dirs.sh")
             detect_pos = content.find("detect-tools.sh")
-            assert bootstrap_pos < detect_pos, (
-                f"{script_name}: bootstrap-dirs.sh must come before "
-                f"detect-tools.sh (bootstrap at {bootstrap_pos}, "
-                f"detect at {detect_pos})"
+            assert detect_pos < bootstrap_pos, (
+                f"{script_name}: detect-tools.sh must come before "
+                f"bootstrap-dirs.sh (detect at {detect_pos}, "
+                f"bootstrap at {bootstrap_pos})"
             )
 
 
@@ -2223,9 +2224,12 @@ class TestTimeFormatConfig:
         )
 
     def test_12h_format_produces_ampm(self):
-        """12h format should produce h:MM AM/PM (e.g., 2:32 PM)."""
+        """12h format should produce h:MM AM/PM (e.g., 2:32 PM).
+
+        Uses tr to uppercase %p, which is locale-dependent on Linux.
+        """
         result = subprocess.run(
-            ["bash", "-c", 'TZ=UTC date "+%-I:%M %p"'],
+            ["bash", "-c", "TZ=UTC date \"+%-I:%M %p\" | tr '[:lower:]' '[:upper:]'"],
             capture_output=True, text=True,
         )
         time_str = result.stdout.strip()
@@ -2309,23 +2313,21 @@ class TestMarketplacePathResolution:
 
     # -- Source guards: verify scripts use the right patterns --
 
-    def test_log_sh_config_uses_pipeline_dir(self):
-        """log.sh REMEMBER_CONFIG must reference PIPELINE_DIR."""
+    def test_log_sh_sources_lib_memory_dir(self):
+        """log.sh must source lib-memory-dir.sh (which sets REMEMBER_CONFIG).
+
+        REMEMBER_CONFIG is now produced by the layered-merge helper rather
+        than being set to a bare PIPELINE_DIR path. Verify the delegation.
+        """
         log_path = os.path.join(
             os.path.dirname(__file__), "..", "scripts", "log.sh"
         )
         with open(log_path) as f:
             content = f.read()
 
-        for line in content.split("\n"):
-            stripped = line.strip()
-            if stripped.startswith("REMEMBER_CONFIG="):
-                assert "PIPELINE_DIR" in stripped, (
-                    f"REMEMBER_CONFIG should use PIPELINE_DIR. Line: {stripped}"
-                )
-                break
-        else:
-            assert False, "REMEMBER_CONFIG assignment not found in log.sh"
+        assert "lib-memory-dir.sh" in content, (
+            "log.sh must source lib-memory-dir.sh to get the merged REMEMBER_CONFIG"
+        )
 
     def test_log_sh_hooks_dir_uses_pipeline_dir(self):
         """log.sh REMEMBER_HOOKS_DIR must reference PIPELINE_DIR."""
@@ -2530,6 +2532,11 @@ echo "PIPELINE_DIR=$PIPELINE_DIR"
 echo "REMEMBER_CONFIG=$REMEMBER_CONFIG"
 echo "REMEMBER_HOOKS_DIR=$REMEMBER_HOOKS_DIR"
 echo "REMEMBER_TZ=$REMEMBER_TZ"
+# Dump merged config values inline so Python can read them even after this process exits.
+if [ -f "$REMEMBER_CONFIG" ] && command -v jq >/dev/null 2>&1; then
+    echo "MERGED_TIMEZONE=$(jq -r '.timezone // empty' "$REMEMBER_CONFIG" 2>/dev/null)"
+    echo "MERGED_SAVE_SECONDS=$(jq -r '.cooldowns.save_seconds // empty' "$REMEMBER_CONFIG" 2>/dev/null)"
+fi
 """
         wrapper = os.path.join(str(tmp_path), "test-wrapper.sh")
         with open(wrapper, "w") as f:
@@ -2549,24 +2556,37 @@ echo "REMEMBER_TZ=$REMEMBER_TZ"
         return resolved
 
     def test_marketplace_pipeline_dir_used_for_config(self, tmp_path):
-        """When PIPELINE_DIR is set (marketplace), config reads from plugin dir."""
+        """When PIPELINE_DIR is set (marketplace), merged config contains plugin values."""
+        import json as json_mod
         plugin = os.path.join(str(tmp_path), "plugin")
         project = os.path.join(str(tmp_path), "project")
         os.makedirs(plugin)
         os.makedirs(project)
+
+        with open(os.path.join(plugin, "config.json"), "w") as f:
+            json_mod.dump({"timezone": "Pacific/Auckland"}, f)
 
         result = self._source_log_sh({
             "PROJECT_DIR": project,
             "PIPELINE_DIR": plugin,
         }, tmp_path)
 
-        assert result["REMEMBER_CONFIG"] == f"{plugin}/config.json"
+        # Merged config values are dumped inline by the test script.
+        assert result.get("MERGED_TIMEZONE") == "Pacific/Auckland", (
+            f"Merged config must include plugin's timezone value. Got: {result}"
+        )
         assert result["REMEMBER_HOOKS_DIR"] == f"{plugin}/hooks.d"
 
     def test_local_install_fallback(self, tmp_path):
         """When PIPELINE_DIR is unset, falls back to PROJECT_DIR/.claude/remember/."""
+        import json as json_mod
         project = os.path.join(str(tmp_path), "project")
         os.makedirs(project)
+
+        local_plugin = os.path.join(project, ".claude", "remember")
+        os.makedirs(local_plugin, exist_ok=True)
+        with open(os.path.join(local_plugin, "config.json"), "w") as f:
+            json_mod.dump({"timezone": "America/Chicago"}, f)
 
         result = self._source_log_sh({
             "PROJECT_DIR": project,
@@ -2575,7 +2595,9 @@ echo "REMEMBER_TZ=$REMEMBER_TZ"
 
         expected = f"{project}/.claude/remember"
         assert result["PIPELINE_DIR"] == expected
-        assert result["REMEMBER_CONFIG"] == f"{expected}/config.json"
+        assert result.get("MERGED_TIMEZONE") == "America/Chicago", (
+            f"Merged config must include local-install timezone. Got: {result}"
+        )
         assert result["REMEMBER_HOOKS_DIR"] == f"{expected}/hooks.d"
 
     def test_timezone_reads_from_config(self, tmp_path):
@@ -2729,14 +2751,18 @@ set +e  # don't exit on errors — we just want the variables
 export CLAUDE_PROJECT_DIR="{project}"
 export CLAUDE_PLUGIN_ROOT="{plugin}"
 source "{plugin}/scripts/resolve-paths.sh" 2>/dev/null
-source "{plugin}/scripts/bootstrap-dirs.sh" 2>/dev/null
 [ -f "{plugin}/scripts/detect-tools.sh" ] && source "{plugin}/scripts/detect-tools.sh" 2>/dev/null
+source "{plugin}/scripts/bootstrap-dirs.sh" 2>/dev/null
 source "{plugin}/scripts/log.sh" 2>/dev/null
 echo "PIPELINE_DIR=$PIPELINE_DIR"
 echo "PROJECT_DIR=$PROJECT_DIR"
 echo "REMEMBER_CONFIG=$REMEMBER_CONFIG"
 echo "REMEMBER_HOOKS_DIR=$REMEMBER_HOOKS_DIR"
 echo "REMEMBER_TZ=$REMEMBER_TZ"
+# Dump merged config values inline so Python can read them after process exit.
+if [ -f "$REMEMBER_CONFIG" ] && command -v jq >/dev/null 2>&1; then
+    echo "MERGED_TIMEZONE=$(jq -r '.timezone // empty' "$REMEMBER_CONFIG" 2>/dev/null)"
+fi
 """
         wrapper = os.path.join(str(tmp_path), f"test-{hook_script}")
         with open(wrapper, "w") as f:
@@ -2767,11 +2793,13 @@ echo "REMEMBER_TZ=$REMEMBER_TZ"
 
     @pytest.mark.parametrize("hook", HOOKS)
     def test_hook_config_points_to_plugin(self, hook, tmp_path):
-        """REMEMBER_CONFIG must be in the plugin dir."""
+        """Merged config must include the plugin's timezone value."""
         project, plugin = self._setup_marketplace(tmp_path)
         result = self._source_hook_and_dump_vars(hook, project, plugin, tmp_path)
-        assert result["REMEMBER_CONFIG"] == f"{plugin}/config.json", (
-            f"{hook}: REMEMBER_CONFIG={result['REMEMBER_CONFIG']}"
+        # MERGED_TIMEZONE is dumped inline by the test helper script.
+        assert result.get("MERGED_TIMEZONE") == "Pacific/Auckland", (
+            f"{hook}: merged config missing plugin timezone. REMEMBER_TZ={result.get('REMEMBER_TZ')}, "
+            f"MERGED_TIMEZONE={result.get('MERGED_TIMEZONE')}"
         )
 
     @pytest.mark.parametrize("hook", HOOKS)


### PR DESCRIPTION
Closes #59

### Summary

- Adds opt-in **external storage mode**: memory resolves to `~/.remember/<slug>/` (or any absolute path) instead of `<project>/.remember/`, keeping repos clean without per-project gitignore entries.
- Introduces **three-tier config merge** (plugin defaults → user-global `~/.remember/config.json` → per-project override), so settings no longer need to be repeated across projects.
- Adds a **background git backup hook** (`hooks.d/after_save/50-git-backup.sh`) that auto-commits memory after each save, with cooldown, locking, and per-project isolation.
- **Fully backward-compatible**: legacy mode remains the default.

### Limitations

The git backup is designed as a **single-machine backup**, not a sync mechanism. There is no pull or rebase before pushing — if another machine has pushed commits to the same remote, the push will fail with a non-fast-forward error and silently defer (indistinguishable from a network failure). Local commits accumulate safely, but the divergence must be resolved manually. Cross-machine sync is out of scope for this implementation.

### Changes

**New files**
- `scripts/lib-memory-dir.sh` — `REMEMBER_DIR` resolution + config merge
- `hooks.d/after_save/50-git-backup.sh` — async git backup
- `config.user.example.json` — template for user-global config
- `tests/test_external_data_dir.py`, `tests/test_migration.py`, `tests/test_layered_config.py`, `tests/test_git_backup_hook.py`

**Modified files**
- `scripts/bootstrap-dirs.sh` — auto-migration, gitignore guard
- `scripts/session-start-hook.sh` — identity tiers, handoff path signalling, `REMEMBER_DIR`-aware throughout
- `pipeline/extract.py`, `pipeline/shell.py` — accept `REMEMBER_DIR` param
- `skills/remember/SKILL.md` — read `=== HANDOFF ===` block instead of hardcoded path
- `README.md`, `config.example.json` — document new options