### PR TITLE
security: tighten trust boundary on git push and hooks.d exec (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ git remote add origin git@github.com:youruser/remember-backup.git  # private rep
 cat > .gitignore <<'EOF'
 .git-backup.lock
 .last-git-backup-ts
+.git-backup-remote
 */logs/
 */tmp/
 EOF

--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ Look at the `version` field in `.claude-plugin/plugin.json`. The plugin location
 
 **The story behind it:** [I built a memory system I'll never remember building](https://max.dp.tools/posts/134-i-built-a-memory-system-ill-never-remember-building.php) — by Max, the AI that designed it and doesn't remember.
 
+## Trust Model
+
+This plugin runs with your full shell privileges. Before installing or upgrading, understand what you're trusting:
+
+- **`~/.remember/config.json`** — Any process that can write this file can redirect the git backup remote to an attacker-controlled URL, causing all memory to be silently exfiltrated on every session save.
+- **`hooks.d/` directory** — Any process that can write an executable file here gets arbitrary code execution on every session save and start. This includes the plugin cache directory (`~/.claude/plugins/cache/`), which is user-writable by design.
+- **The configured git backup remote** — Anyone who controls the remote repository receives a copy of everything you discuss with Claude Code: project paths, summaries, identity files, and anything else in memory.
+
+**Recommended mitigations:**
+- Keep `~/.remember/` and the plugin cache under tight permissions (`chmod 700 ~/.remember ~/.claude/plugins/cache`).
+- Point the git backup remote at a repository you own and review push targets when you change it.
+- The plugin now validates the remote URL on every push and aborts if it changes — see the `git_backup.allow_remote_change` config option to update it intentionally.
+
 ### Changelog
 
 **v0.7.1** — Windows portability fixes

--- a/hooks.d/after_save/50-git-backup.sh
+++ b/hooks.d/after_save/50-git-backup.sh
@@ -101,12 +101,49 @@ fi
         exit 0
     fi
 
-    # Push, but tolerate any error (no remote, no network, auth, etc.).
-    # GIT_TERMINAL_PROMPT=0 ensures missing credentials fail fast, not hang.
-    if GIT_TERMINAL_PROMPT=0 git -C "$REPO_ROOT" push >/dev/null 2>&1; then
-        log "git-backup" "pushed $SLUG"
+    # ── Remote URL validation ─────────────────────────────────────────────────
+    # On first push, record the remote URL. On subsequent pushes, abort if the
+    # URL changed — a changed URL could mean a poisoned config.json pointing to
+    # an attacker-controlled remote. Set git_backup.allow_remote_change=true to
+    # override (e.g. when intentionally re-pointing to a new private repo).
+    REMOTE_STATE_FILE="$REPO_ROOT/.git-backup-remote"
+    CURRENT_REMOTE=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || true)
+    ALLOW_REMOTE_CHANGE=$(config ".git_backup.allow_remote_change" "false")
+
+    if [ -z "$CURRENT_REMOTE" ]; then
+        log "git-backup" "no remote configured, skipping push"
+    elif [ ! -f "$REMOTE_STATE_FILE" ]; then
+        # First push — record the URL and proceed.
+        echo "$CURRENT_REMOTE" > "$REMOTE_STATE_FILE"
+        log "git-backup" "git backup configured to push to: $CURRENT_REMOTE"
+        if GIT_TERMINAL_PROMPT=0 git -C "$REPO_ROOT" push >/dev/null 2>&1; then
+            log "git-backup" "pushed $SLUG"
+        else
+            log "git-backup" "push deferred (will retry next backup)"
+        fi
     else
-        log "git-backup" "push deferred (will retry next backup)"
+        RECORDED_REMOTE=$(cat "$REMOTE_STATE_FILE" 2>/dev/null || true)
+        if [ "$CURRENT_REMOTE" != "$RECORDED_REMOTE" ]; then
+            if [ "$ALLOW_REMOTE_CHANGE" = "true" ]; then
+                # Explicit override — update state file and push.
+                echo "$CURRENT_REMOTE" > "$REMOTE_STATE_FILE"
+                log "git-backup" "remote URL changed (allow_remote_change=true): $CURRENT_REMOTE"
+                if GIT_TERMINAL_PROMPT=0 git -C "$REPO_ROOT" push >/dev/null 2>&1; then
+                    log "git-backup" "pushed $SLUG"
+                else
+                    log "git-backup" "push deferred (will retry next backup)"
+                fi
+            else
+                log "git-backup" "ERROR: remote URL changed from '$RECORDED_REMOTE' to '$CURRENT_REMOTE' — push aborted (set git_backup.allow_remote_change=true to override)"
+            fi
+        else
+            # Remote matches recorded URL — safe to push.
+            if GIT_TERMINAL_PROMPT=0 git -C "$REPO_ROOT" push >/dev/null 2>&1; then
+                log "git-backup" "pushed $SLUG"
+            else
+                log "git-backup" "push deferred (will retry next backup)"
+            fi
+        fi
     fi
 ) </dev/null >/dev/null 2>&1 &
 disown $! 2>/dev/null || true

--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -160,8 +160,22 @@ dispatch() {
     local event="$1"
     local event_dir="$REMEMBER_HOOKS_DIR/$event"
     [ -d "$event_dir" ] || return 0
+    local current_uid
+    current_uid=$(id -u)
     for hook in "$event_dir"/*; do
         [ -x "$hook" ] || continue
+        # Ownership check: skip hooks not owned by the current user.
+        local hook_uid
+        hook_uid=$(stat -f %u "$hook" 2>/dev/null || stat -c %u "$hook" 2>/dev/null || echo "")
+        if [ -z "$hook_uid" ] || [ "$hook_uid" != "$current_uid" ]; then
+            log "dispatch" "WARNING: skipping hook not owned by current user: $event/$(basename "$hook")"
+            continue
+        fi
+        # World-writable check: skip hooks writable by others.
+        if [ -n "$(find "$hook" -maxdepth 0 -perm -002 2>/dev/null)" ]; then
+            log "dispatch" "WARNING: skipping world-writable hook: $event/$(basename "$hook")"
+            continue
+        fi
         REMEMBER_PROJECT="${PROJECT_DIR:-.}" "$hook" 2>/dev/null \
             || log "dispatch" "hook failed: $event/$(basename "$hook")"
     done

--- a/tests/test_git_backup_hook.py
+++ b/tests/test_git_backup_hook.py
@@ -358,3 +358,162 @@ class TestGitBackupHook:
         assert log_files, "Expected a log file in slug/logs/"
         log_content = log_files[0].read_text()
         assert "push deferred" in log_content
+
+
+class TestGitBackupRemoteValidation:
+    """Tests for the remote URL validation introduced in #67."""
+
+    def test_first_push_records_remote_url(self, tmp_path):
+        """First push writes the remote URL to .git-backup-remote and logs it prominently."""
+        home, remember, remote = make_external_remember_repo(tmp_path)
+        slug = "test-slug"
+        slug_dir = remember / slug
+        slug_dir.mkdir()
+        (slug_dir / "now.md").write_text("## 10:00 | test\nMemory.\n")
+
+        project = tmp_path / "project"
+        project.mkdir()
+        cfg = _make_config(tmp_path, cooldown=0)
+
+        result = _run_hook(slug_dir, project, home, config_path=cfg)
+        assert result.returncode == 0
+        wait_for_lock_release(remember / ".git-backup.lock")
+
+        state_file = remember / ".git-backup-remote"
+        assert state_file.exists(), ".git-backup-remote state file should be created on first push"
+        recorded = state_file.read_text().strip()
+        assert recorded == str(remote), f"Expected remote {remote!r}, got {recorded!r}"
+
+        log_files = list((slug_dir / "logs").glob("memory-*.log"))
+        assert log_files
+        log_content = log_files[0].read_text()
+        assert "git backup configured to push to:" in log_content
+
+    def test_second_push_to_same_remote_succeeds(self, tmp_path):
+        """Second push with unchanged remote URL commits and pushes without error."""
+        home, remember, remote = make_external_remember_repo(tmp_path)
+        slug = "test-slug"
+        slug_dir = remember / slug
+        slug_dir.mkdir()
+        (slug_dir / "now.md").write_text("## 10:00 | test\nFirst memory.\n")
+
+        project = tmp_path / "project"
+        project.mkdir()
+        cfg = _make_config(tmp_path, cooldown=0)
+
+        # First run — records remote URL.
+        _run_hook(slug_dir, project, home, config_path=cfg)
+        wait_for_lock_release(remember / ".git-backup.lock")
+
+        # Backdate cooldown marker so second run isn't skipped.
+        (remember / ".last-git-backup-ts").write_text("0")
+
+        # Write new content so there's something to commit.
+        (slug_dir / "now.md").write_text("## 10:05 | test\nSecond memory.\n")
+
+        _run_hook(slug_dir, project, home, config_path=cfg)
+        wait_for_lock_release(remember / ".git-backup.lock")
+
+        # Both auto commits should exist (init + first + second = 3 total).
+        commits = _commit_log(remember)
+        assert len(commits) == 3
+
+        # No error in logs about remote change.
+        log_files = list((slug_dir / "logs").glob("memory-*.log"))
+        assert log_files
+        log_content = log_files[0].read_text()
+        assert "remote URL changed" not in log_content
+        assert "push aborted" not in log_content
+
+    def test_push_to_changed_remote_aborts(self, tmp_path):
+        """Push is aborted when the remote URL changed and allow_remote_change is false."""
+        home, remember, remote = make_external_remember_repo(tmp_path)
+        slug = "test-slug"
+        slug_dir = remember / slug
+        slug_dir.mkdir()
+        (slug_dir / "now.md").write_text("## 10:00 | test\nMemory.\n")
+
+        project = tmp_path / "project"
+        project.mkdir()
+        cfg = _make_config(tmp_path, cooldown=0)
+
+        # First run — records remote URL.
+        _run_hook(slug_dir, project, home, config_path=cfg)
+        wait_for_lock_release(remember / ".git-backup.lock")
+
+        # Simulate attacker changing the remote URL.
+        evil_remote = tmp_path / "evil.git"
+        subprocess.run(["git", "init", "-q", "--bare", str(evil_remote)], check=True, capture_output=True)
+        _git(remember, ["remote", "set-url", "origin", str(evil_remote)])
+
+        # Backdate cooldown marker and add new content.
+        (remember / ".last-git-backup-ts").write_text("0")
+        (slug_dir / "now.md").write_text("## 10:05 | test\nMore memory.\n")
+
+        _run_hook(slug_dir, project, home, config_path=cfg)
+        wait_for_lock_release(remember / ".git-backup.lock")
+
+        # Local commit was made (no push, but commit still happens).
+        commits = _commit_log(remember)
+        assert len(commits) == 3  # init + first auto + second auto
+
+        # Evil remote should have received nothing — verify it has no commits.
+        evil_log = subprocess.run(
+            ["git", "-C", str(evil_remote), "log", "--oneline"],
+            capture_output=True, text=True,
+        )
+        assert evil_log.stdout.strip() == "", "Evil remote should not have received any commits"
+
+        # Error should be logged.
+        log_files = list((slug_dir / "logs").glob("memory-*.log"))
+        assert log_files
+        log_content = log_files[0].read_text()
+        assert "remote URL changed" in log_content
+        assert "push aborted" in log_content
+
+    def test_push_to_changed_remote_allowed_when_override_set(self, tmp_path):
+        """When allow_remote_change=true, a changed remote URL is accepted and push proceeds."""
+        home, remember, remote = make_external_remember_repo(tmp_path)
+        slug = "test-slug"
+        slug_dir = remember / slug
+        slug_dir.mkdir()
+        (slug_dir / "now.md").write_text("## 10:00 | test\nMemory.\n")
+
+        project = tmp_path / "project"
+        project.mkdir()
+        cfg = _make_config(tmp_path, cooldown=0)
+
+        # First run — records remote URL.
+        _run_hook(slug_dir, project, home, config_path=cfg)
+        wait_for_lock_release(remember / ".git-backup.lock")
+
+        # Set up a new (legitimate) remote and change the URL.
+        new_remote = tmp_path / "new-remote.git"
+        subprocess.run(["git", "init", "-q", "--bare", str(new_remote)], check=True, capture_output=True)
+        _git(remember, ["remote", "set-url", "origin", str(new_remote)])
+        # Push current history to new remote so it accepts the push.
+        _git(remember, ["push", "-q", "-u", str(new_remote), "main"])
+        _git(remember, ["remote", "set-url", "origin", str(new_remote)])
+
+        # Backdate cooldown marker and add new content.
+        (remember / ".last-git-backup-ts").write_text("0")
+        (slug_dir / "now.md").write_text("## 10:05 | test\nMore memory.\n")
+
+        # Override config: allow_remote_change = true.
+        override_cfg = tmp_path / "override-config.json"
+        override_cfg.write_text('{"cooldowns": {"git_backup_seconds": 0}, "git_backup": {"allow_remote_change": true}}')
+
+        _run_hook(slug_dir, project, home, config_path=override_cfg)
+        wait_for_lock_release(remember / ".git-backup.lock")
+
+        # State file should now point to the new remote.
+        state_file = remember / ".git-backup-remote"
+        recorded = state_file.read_text().strip()
+        assert recorded == str(new_remote), f"State file should be updated to new remote, got {recorded!r}"
+
+        # Log should mention the change with allow note, not an error.
+        log_files = list((slug_dir / "logs").glob("memory-*.log"))
+        assert log_files
+        log_content = log_files[0].read_text()
+        assert "allow_remote_change=true" in log_content
+        assert "push aborted" not in log_content

--- a/tests/test_git_backup_hook.py
+++ b/tests/test_git_backup_hook.py
@@ -46,7 +46,7 @@ def make_external_remember_repo(tmp_path: Path):
     subprocess.run(["git", "init", "-q", "--bare", str(remote)], check=True, capture_output=True)
     _git(remember, ["remote", "add", "origin", str(remote)])
     gitignore = remember / ".gitignore"
-    gitignore.write_text(".git-backup.lock\n.last-git-backup-ts\n*/logs/\n*/tmp/\n")
+    gitignore.write_text(".git-backup.lock\n.last-git-backup-ts\n.git-backup-remote\n*/logs/\n*/tmp/\n")
     _git(remember, ["add", ".gitignore"])
     _git(remember, ["commit", "-q", "-m", "init"])
     _git(remember, ["push", "-q", "-u", "origin", "main"])

--- a/tests/test_log_sh.py
+++ b/tests/test_log_sh.py
@@ -252,3 +252,108 @@ def test_config_example_json_is_valid():
     )
     # time_format should still be present (from PR #34)
     assert parsed.get("time_format") == "24h"
+
+
+# ── dispatch() ownership / world-writable tests (#67) ────────────────────────
+
+def _make_dispatch_env(tmp_path: Path) -> dict:
+    """Return env vars for a dispatch() test run."""
+    project = _make_project(tmp_path, timezone_value=None)
+    return {
+        **os.environ,
+        "PROJECT_DIR": str(project),
+        "PIPELINE_DIR": str(REPO_ROOT),
+        "_LIB_MEMORY_DIR_LOADED": "1",
+        "REMEMBER_DIR": str(project / ".remember"),
+    }
+
+
+def _run_dispatch(tmp_path: Path, hooks_dir: Path, extra_env: dict = None) -> subprocess.CompletedProcess:
+    """Source log.sh and call dispatch("test_event") against a custom hooks dir."""
+    env = _make_dispatch_env(tmp_path)
+    if extra_env:
+        env.update(extra_env)
+    script = f"""
+set -e
+export PROJECT_DIR="{env['PROJECT_DIR']}"
+export PIPELINE_DIR="{env['PIPELINE_DIR']}"
+export _LIB_MEMORY_DIR_LOADED=1
+export REMEMBER_DIR="{env['REMEMBER_DIR']}"
+source {LOG_SH}
+# Override REMEMBER_HOOKS_DIR to point at our temp fixture.
+REMEMBER_HOOKS_DIR="{hooks_dir}"
+dispatch "test_event"
+"""
+    return subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True)
+
+
+def _write_hook(hooks_event_dir: Path, name: str, content: str, mode: int = 0o755) -> Path:
+    """Write an executable hook script and set permissions."""
+    hook = hooks_event_dir / name
+    hook.write_text(content)
+    hook.chmod(mode)
+    return hook
+
+
+class TestDispatchOwnershipChecks:
+    """Regression tests for the ownership + world-writable guards in dispatch() (#67)."""
+
+    def test_owned_not_world_writable_executes(self, tmp_path):
+        """A hook owned by the current user and not world-writable runs normally."""
+        hooks_dir = tmp_path / "hooks.d"
+        event_dir = hooks_dir / "test_event"
+        event_dir.mkdir(parents=True)
+        marker = tmp_path / "ran.txt"
+        _write_hook(event_dir, "10-ok.sh", f'#!/bin/bash\ntouch "{marker}"\n', mode=0o755)
+
+        result = _run_dispatch(tmp_path, hooks_dir)
+
+        assert result.returncode == 0, f"dispatch failed: {result.stderr}"
+        assert marker.exists(), "Owned, non-world-writable hook should have executed"
+
+    def test_world_writable_hook_is_skipped(self, tmp_path):
+        """A world-writable hook (mode 0o777) is skipped with a warning."""
+        hooks_dir = tmp_path / "hooks.d"
+        event_dir = hooks_dir / "test_event"
+        event_dir.mkdir(parents=True)
+        marker = tmp_path / "ran.txt"
+        _write_hook(event_dir, "10-ww.sh", f'#!/bin/bash\ntouch "{marker}"\n', mode=0o777)
+
+        result = _run_dispatch(tmp_path, hooks_dir)
+
+        assert result.returncode == 0, f"dispatch failed: {result.stderr}"
+        assert not marker.exists(), "World-writable hook should have been skipped"
+        assert "world-writable" in result.stderr or _dispatch_warned_in_log(tmp_path, "world-writable")
+
+    def test_unowned_hook_is_skipped(self, tmp_path):
+        """A hook whose UID doesn't match the current user is skipped with a warning.
+
+        We can't actually chown to another UID without root, so we fake the stat
+        output by patching the hook's stat call via a wrapper on PATH.
+        """
+        hooks_dir = tmp_path / "hooks.d"
+        event_dir = hooks_dir / "test_event"
+        event_dir.mkdir(parents=True)
+        marker = tmp_path / "ran.txt"
+        hook = _write_hook(event_dir, "10-other-owner.sh", f'#!/bin/bash\ntouch "{marker}"\n', mode=0o755)
+
+        # Create a fake stat binary that always returns UID 0 (root), regardless of file.
+        fake_bin = tmp_path / "bin"
+        fake_bin.mkdir()
+        fake_stat = fake_bin / "stat"
+        fake_stat.write_text('#!/bin/bash\necho 0\n')
+        fake_stat.chmod(0o755)
+
+        env_override = {"PATH": f"{fake_bin}:{os.environ.get('PATH', '')}"}
+        result = _run_dispatch(tmp_path, hooks_dir, extra_env=env_override)
+
+        assert result.returncode == 0, f"dispatch failed: {result.stderr}"
+        assert not marker.exists(), "Hook owned by different user should have been skipped"
+
+
+def _dispatch_warned_in_log(tmp_path: Path, keyword: str) -> bool:
+    """Check if any log file under tmp_path contains the keyword."""
+    for log_file in tmp_path.rglob("memory-*.log"):
+        if keyword in log_file.read_text():
+            return True
+    return False


### PR DESCRIPTION
## What this closes

Three security findings from the internal audit in #67:

**2.1 — Silent exfil via poisoned remote (High):** An attacker who writes to `~/.remember/config.json` could redirect `data_dir` to a repo with `origin = attacker-controlled`. Every session save would silently push all memory there. Fixed by recording the remote URL on first push (`~/.remember/.git-backup-remote`) and aborting if it changes. Set `git_backup.allow_remote_change = true` to re-point intentionally.

**2.2 — Dropped executable in hooks.d (Medium):** `dispatch()` ran any world-writable or foreign-owned file. Any process that can write to `~/.claude/plugins/cache/` got code execution on every save. Fixed by checking ownership (`stat -f %u` / `stat -c %u`, BSD/GNU portable) and the world-writable bit before executing each hook. Mismatched hooks are skipped with a logged warning.

**2.3 — Undocumented trust model:** README now has a `## Trust Model` section (after Install, before Changelog) stating plainly what write access to config/hooks/remote means.

## Backward compatibility

- Users with stable remotes and owned hooks: no behavior change.
- Users intentionally re-pointing their backup remote: set `git_backup.allow_remote_change = true` once, then set it back.
- The `.git-backup-remote` state file is written on the first push after upgrade — existing users see one extra log line: "git backup configured to push to: <url>".

## Tests added

- `TestGitBackupRemoteValidation` (4 tests): first push records URL; second push to same URL succeeds; push to changed URL aborts; `allow_remote_change=true` override works.
- `TestDispatchOwnershipChecks` (3 tests): owned+non-world-writable executes; world-writable skipped; unowned skipped.
- Total: 365 passed (up from 327).

## Trade-offs

- Ownership check uses a fake-stat approach in tests (can't `chown` without root); the production path is straightforward `stat` output comparison.
- World-writable check uses `find -maxdepth 0 -perm -002` — portable across BSD and GNU, avoids `stat` format inconsistencies for permission bits.
- The dry-run save failure (test 7 in `run-tests.sh`) is pre-existing on `main` and unrelated to this PR.
