### PR TITLE
docs(readme): add tests/python/OS/license/version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ![12,500+ installs on the Anthropic Marketplace](docs/marketplace-12k-installs.png)
 
+[![Tests](https://github.com/Digital-Process-Tools/claude-remember/actions/workflows/tests.yml/badge.svg)](https://github.com/Digital-Process-Tools/claude-remember/actions/workflows/tests.yml)
+[![Python](https://img.shields.io/badge/python-3.9%2B-blue)](https://www.python.org/)
+[![OS](https://img.shields.io/badge/tested%20on-Linux%20%7C%20macOS%20%7C%20Windows-blue)](https://github.com/Digital-Process-Tools/claude-remember/actions/workflows/tests.yml)
+[![License](https://img.shields.io/badge/license-Community-brightgreen)](LICENSE)
+[![Version](https://img.shields.io/badge/version-0.7.2-orange)](.claude-plugin/plugin.json)
+
 Claude Code starts every session blank. It doesn't know what you worked on yesterday, what conventions your team follows, or what mistakes it already made. You re-explain everything, every time.
 
 Claude Remember fixes that. It hooks into Claude Code's lifecycle — saving sessions automatically, compressing them through Haiku into layered daily summaries, and loading them back into context on the next session start. No manual prompting, no copy-pasting notes. The agent starts every session with its history already present.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Continuous Memory for Claude Code
 
-![12,500+ installs on the Anthropic Marketplace](docs/marketplace-12k-installs.png)
+![claude-remember — continuous memory for Claude Code](docs/remember.png)
 
 [![Tests](https://github.com/Digital-Process-Tools/claude-remember/actions/workflows/tests.yml/badge.svg)](https://github.com/Digital-Process-Tools/claude-remember/actions/workflows/tests.yml)
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue)](https://www.python.org/)


### PR DESCRIPTION
docs(readme): add tests/python/OS/license/version badges

## Context

Mirrors the badge row from `claude-supertool`. The repo now has a 3-OS × 4-Python test matrix that actually passes — worth advertising. Drive-by parity move.

## Badges

- **Tests** — links to the workflow page, live status from latest main run.
- **Python 3.9+** — matches the matrix we test against.
- **Tested on Linux | macOS | Windows** — explicit cross-platform claim, links back to the workflow as proof.
- **License Community** — same as supertool.
- **Version 0.7.2** — current `plugin.json` version.

## Test plan

- [ ] Badges render correctly on the README page on GitHub.
- [ ] Tests badge turns green after this PR merges.
