### PR TITLE
feat(save-session): honor $REMEMBER_BRANCH env var when $PROJECT_DIR is not a git repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`REMEMBER_BRANCH` env var override** — `scripts/save-session.sh` now honors `$REMEMBER_BRANCH` when computing the `## HH:MM | <branch>` identity slot of each daily-log entry. Falls back to the existing `git branch --show-current` lookup, then the literal `"unknown"` if no git repo is present. Use case: running Claude Code from `$HOME` (or any non-git directory) collapses the identity slot to `unknown` on every entry, which makes log entries indistinguishable across instances. Export `REMEMBER_BRANCH=laptop` / `cloud` / `staging` / `$HOSTNAME` in your shell rc and the slot becomes a useful per-instance tag. Documented in `README.md` Configuration → Environment variables.
+
+### Tests
+
+- New `tests/test_save_session_branch_override.py` — pins the four-case truth table for the `BRANCH=` line in `save-session.sh`: env-set + git-repo (env wins), env-unset + git-repo (git wins), env-unset + no-git (`unknown` fallback), env-set-to-empty + no-git (`:-` treats empty as unset, falls back to `unknown`). Snapshots the line out of the live `save-session.sh` rather than re-asserting a copy, so the test fails loudly if the line is ever edited without updating the test.
+
 ## [0.7.3] — Windows save pipeline shell↔Python bridge
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -220,6 +220,16 @@ Put cross-project preferences (timezone, cooldowns) in `~/.remember/config.json`
 | `time_format`                    | `24h`            | `24h` or `12h` — controls timestamp format in log files (e.g. `14:30:00` vs `2:30:00 PM`)                                                                                                                                              |
 | `debug`                          | `false`          | Verbose logging for cooldowns and locks                                                                                                                                                                                                |
 
+### Environment variables
+
+A few runtime overrides aren't in `config.json` because they're per-shell rather than per-project.
+
+| Env var            | Effect                                                                                                                                                                                                                                                                                                                                                                                |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `REMEMBER_BRANCH`  | Overrides the `\| <branch>` identity field in each `## HH:MM \| <branch>` memory header. Useful when Claude Code runs from a non-git directory (`$HOME`, a scratch dir) — without it the header falls back to the literal string `unknown`, which collapses the identity slot for every entry. Set to a meaningful tag (e.g. `laptop`, `cloud`, `staging`, an instance name) in your shell rc. |
+| `REMEMBER_DEBUG`   | `1` (default) emits verbose hook/cooldown lines to logs; `0` silences them.                                                                                                                                                                                                                                                                                                            |
+| `REMEMBER_TZ`      | Set automatically by `log.sh` from `config.json` → `timezone`. Don't set this manually unless you're debugging.                                                                                                                                                                                                                                                                       |
+
 ## External storage mode
 
 By default, memory data lives in `.remember/` inside each project directory. This works but has a drawback: it pollutes `git status` and siloes memory per repo clone.

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -147,7 +147,11 @@ else
 fi
 
 # --- Step 3: Build prompt ---
-BRANCH=$(cd "$PROJECT_DIR" && git branch --show-current 2>/dev/null || echo "unknown")
+# $REMEMBER_BRANCH wins when set, so users running Claude Code from a non-git
+# directory (e.g., $HOME) can supply a meaningful identity for the today-*.md
+# header instead of the literal "unknown" fallback. Empty string is treated as
+# unset so an accidental `export REMEMBER_BRANCH=` doesn't propagate.
+BRANCH="${REMEMBER_BRANCH:-$(cd "$PROJECT_DIR" && git branch --show-current 2>/dev/null || echo "unknown")}"
 TIME_FORMAT=$(config ".time_format" "24h")
 if [ "$TIME_FORMAT" = "12h" ]; then
     # Force uppercase AM/PM: %p is locale-dependent (lowercase on many Linux systems).

--- a/tests/test_save_session_branch_override.py
+++ b/tests/test_save_session_branch_override.py
@@ -1,0 +1,170 @@
+"""Shell-level tests for the BRANCH= line in scripts/save-session.sh.
+
+The line defines the ``| <branch>`` identity slot of each
+``## HH:MM | <branch>`` memory header. It must satisfy a four-case truth
+table:
+
+  1. ``$REMEMBER_BRANCH`` is set       → use it (env wins).
+  2. ``$REMEMBER_BRANCH`` is unset, ``$PROJECT_DIR`` is a git repo
+                                       → use ``git branch --show-current``.
+  3. ``$REMEMBER_BRANCH`` is unset, no git repo
+                                       → fall back to the literal ``unknown``.
+  4. ``$REMEMBER_BRANCH`` is set to the empty string
+                                       → ``${VAR:-default}`` treats empty as
+                                         unset, so we still walk down to the
+                                         git/unknown fallback (NOT propagate
+                                         the empty string into the header).
+
+Tests source the exact ``BRANCH=`` line out of the live ``save-session.sh``
+file rather than reasserting a copy here — if the line ever changes
+without an intentional test update, these cases fail loudly.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash dispatch + git command form — not portable to Windows Git Bash without fixtures",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SAVE_SH = REPO_ROOT / "scripts" / "save-session.sh"
+
+
+def _extract_branch_line() -> str:
+    """Return the live `BRANCH=` line from save-session.sh.
+
+    Picking it out of the file (not asserting a hardcoded copy in the
+    test) means future edits to the line break this test on intent,
+    not on string-equality drift.
+    """
+    for raw in SAVE_SH.read_text().splitlines():
+        line = raw.strip()
+        if line.startswith("BRANCH="):
+            return line
+    raise AssertionError(f"No BRANCH= line found in {SAVE_SH}")
+
+
+def _eval_branch(project_dir: Path, env_overrides: dict[str, str | None]) -> str:
+    """Eval ONLY the patched BRANCH= line under controlled env, return the
+    resolved value."""
+    line = _extract_branch_line()
+    script = f"""
+set -e
+export PROJECT_DIR={project_dir}
+{line}
+printf '%s' "$BRANCH"
+"""
+    env = {k: v for k, v in os.environ.items() if v is not None}
+    # Strip any inherited REMEMBER_BRANCH so we start from a known state.
+    env.pop("REMEMBER_BRANCH", None)
+    for k, v in env_overrides.items():
+        if v is None:
+            env.pop(k, None)
+        else:
+            env[k] = v
+    result = subprocess.run(
+        ["bash", "-c", script], env=env, capture_output=True, text=True
+    )
+    assert result.returncode == 0, f"BRANCH eval failed: {result.stderr}"
+    return result.stdout
+
+
+def _make_git_repo(tmp_path: Path, branch_name: str = "feature/test-branch") -> Path:
+    """Initialize a tiny git repo on a known branch — git presence is what
+    the fallback chain checks for."""
+    project = tmp_path / "proj"
+    project.mkdir()
+    subprocess.run(
+        ["git", "-c", "init.defaultBranch=main", "init", "--quiet"],
+        cwd=project, check=True,
+    )
+    # Local config so the commit succeeds without relying on the host's
+    # user.email / user.name.
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=project, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=project, check=True)
+    (project / "README.md").write_text("test\n")
+    subprocess.run(["git", "add", "."], cwd=project, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "init", "--quiet"],
+        cwd=project, check=True,
+    )
+    subprocess.run(
+        ["git", "checkout", "-b", branch_name, "--quiet"],
+        cwd=project, check=True,
+    )
+    return project
+
+
+def test_env_var_wins_over_git_branch(tmp_path):
+    """Case 1: $REMEMBER_BRANCH set AND repo has a real branch → env wins."""
+    project = _make_git_repo(tmp_path, branch_name="feature/should-be-ignored")
+    branch = _eval_branch(project, {"REMEMBER_BRANCH": "laptop"})
+    assert branch == "laptop", (
+        f"REMEMBER_BRANCH should override git branch lookup; got {branch!r}"
+    )
+
+
+def test_git_branch_used_when_env_unset(tmp_path):
+    """Case 2: $REMEMBER_BRANCH unset + git repo present → git branch used."""
+    project = _make_git_repo(tmp_path, branch_name="release/2026-06")
+    branch = _eval_branch(project, {"REMEMBER_BRANCH": None})
+    assert branch == "release/2026-06", (
+        f"Expected git branch 'release/2026-06'; got {branch!r}"
+    )
+
+
+def test_unknown_fallback_when_no_git_and_no_env(tmp_path):
+    """Case 3: $REMEMBER_BRANCH unset + $PROJECT_DIR not a git repo →
+    literal 'unknown'.
+
+    This is the rot the env var was added to address — surfacing it
+    here so a future refactor of the fallback string doesn't silently
+    flip the behavior.
+    """
+    project = tmp_path / "not-a-repo"
+    project.mkdir()
+    branch = _eval_branch(project, {"REMEMBER_BRANCH": None})
+    assert branch == "unknown", (
+        f"Expected literal 'unknown' fallback; got {branch!r}"
+    )
+
+
+def test_empty_env_var_treated_as_unset(tmp_path):
+    """Case 4: $REMEMBER_BRANCH='' must NOT propagate the empty string.
+
+    Bash's ``${VAR:-default}`` (the ``:-`` form, not ``-``) treats an
+    empty value as unset. If someone accidentally exports
+    ``REMEMBER_BRANCH=`` (e.g., a malformed shell rc line), the header
+    must still fall back to git/unknown rather than write
+    ``## HH:MM | `` with a bare separator.
+    """
+    project = tmp_path / "not-a-repo"
+    project.mkdir()
+    branch = _eval_branch(project, {"REMEMBER_BRANCH": ""})
+    assert branch == "unknown", (
+        f"Empty REMEMBER_BRANCH should be treated as unset (`:-` form), "
+        f"falling back to 'unknown'; got {branch!r}"
+    )
+
+
+def test_branch_line_uses_safe_default_substitution_form():
+    """Guard the operator: the line MUST use ``:-`` (treats empty as
+    unset), not bare ``-`` (treats empty as set-to-empty).
+
+    A drift from ``${REMEMBER_BRANCH:-...}`` to ``${REMEMBER_BRANCH-...}``
+    would silently regress case 4. Pinning the operator here makes
+    that drift visible in code review even before tests run.
+    """
+    line = _extract_branch_line()
+    assert "${REMEMBER_BRANCH:-" in line, (
+        f"BRANCH= line must use ':-' default-substitution form (treats "
+        f"empty as unset); got: {line!r}"
+    )


### PR DESCRIPTION
## Summary

When Claude Code runs from a directory that isn't a git repo (e.g. `\$HOME`, a scratch dir, anywhere the user hasn't `cd`'d into a project first), the `## HH:MM | <branch>` identity slot in every `today-*.md` entry falls back to the literal string `unknown`. The slot collapses across all entries from that working directory — and across multiple Claude Code instances that each run from non-git CWDs, the daily log becomes indistinguishable per writer.

This PR adds `\$REMEMBER_BRANCH` as the highest-priority source for that slot. Backward compatible — zero behavior change when the env var is unset.

```diff
- BRANCH=\$(cd \"\$PROJECT_DIR\" && git branch --show-current 2>/dev/null || echo \"unknown\")
+ BRANCH=\"\${REMEMBER_BRANCH:-\$(cd \"\$PROJECT_DIR\" && git branch --show-current 2>/dev/null || echo \"unknown\")}\"
```

**Use case I hit:** a multi-instance memory protocol where `today-*.md` entries from two Claude Code instances (one on a laptop, one on a Lightsail box) get rsync'd into a shared `_inbox/`. Both ran Claude Code from `\$HOME` — neither was a git repo — so every entry's identity slot read `unknown`. With `export REMEMBER_BRANCH=laptop` / `export REMEMBER_BRANCH=cloud` in each shell rc, the slot becomes a who-wrote-this tag and the log becomes useful again.

## Changes

- `scripts/save-session.sh` — one-line change to the `BRANCH=` line (line 150) using `\${REMEMBER_BRANCH:-…}`. The `:-` form (not bare `-`) intentionally treats `REMEMBER_BRANCH=` as unset, so an accidental empty export in a shell rc doesn't propagate an empty header — it walks the existing git/unknown fallback chain.
- `tests/test_save_session_branch_override.py` — new test file pinning the four-case truth table (env-set + git-repo, env-unset + git-repo, env-unset + no-git, env-set-empty). Snapshots the live `BRANCH=` line out of `save-session.sh` rather than reasserting a copy, so future edits to the line fail this test on intent rather than on string-equality drift. Includes a guard that the line uses the safe `:-` operator, so a regression back to bare `-` (which would propagate the empty string) surfaces in code review even before tests run.
- `README.md` — new \"Environment variables\" subsection under Configuration documenting `REMEMBER_BRANCH`, `REMEMBER_DEBUG`, and `REMEMBER_TZ`.
- `CHANGELOG.md` — Unreleased entry.

## Test plan

- [x] `pytest` passes locally — **396 passed, 1 skipped** (was 391 + 5 new in this PR).
- [x] New behavior covered by a test — four-case truth table + the `:-`-operator guard, all in `tests/test_save_session_branch_override.py`.
- [x] Touched a hook (`scripts/save-session.sh`) — manually verified by applying the same one-line patch to the locally-cached plugin (`~/.claude/plugins/cache/claude-plugins-official/remember/0.7.3/scripts/save-session.sh`) and exporting `REMEMBER_BRANCH=laptop` in `~/.zshrc`. The local change is what motivated submitting this upstream so it survives plugin updates.
- [ ] Path resolution untouched — N/A.

**One transparency note:** I have not yet round-tripped a full `Stop → save-session → today-*.md write` against this exact branch after running `claude` in a fresh shell that picked up the new env var (the env var was set after this session started). The behavior is exercised by the new tests; the live round-trip is whatever the next session start does, which I'd verify post-merge.

## Checklist

- [x] Docs updated — env-var subsection added to `README.md` Configuration block; no new config key, hook, or skill was added (just a new env-var input to an existing hook).
- [ ] Version bumped in `.claude-plugin/plugin.json` — left to maintainer at release time.
- [x] Changelog entry — added to `CHANGELOG.md` (existing PRs touch CHANGELOG.md; the template wording mentions `README.md` but I followed the actual project convention).