### PR TITLE
feat(haiku): isolate one-shot subprocess (Tier-1 from #87)

### DIFF
--- a/pipeline/haiku.py
+++ b/pipeline/haiku.py
@@ -57,6 +57,8 @@ def call_haiku(
         "claude",
         "-p", prompt,
         "--output-format", "json",
+        "--no-session-persistence",
+        "--exclude-dynamic-system-prompt-sections",
         "--model", "haiku",
         "--max-turns", "1",
         "--allowedTools", ",".join(tools) if tools else "",

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -175,6 +175,7 @@ CLEANUP_FILES+=("$HAIKU_STDERR")
 HAIKU_JSON=$(cd /tmp && env -u CLAUDECODE claude -p \
     --model haiku --allowedTools "" --max-turns 1 \
     --output-format json \
+    --no-session-persistence --exclude-dynamic-system-prompt-sections \
     --mcp-config '{"mcpServers":{}}' --strict-mcp-config \
     2>"$HAIKU_STDERR" < "$TMP_PROMPT")
 HAIKU_EXIT=$?
@@ -241,6 +242,7 @@ if [ "$RUN_NDC" = true ]; then
             NDC_JSON=$(cd /tmp && env -u CLAUDECODE claude -p \
                 --allowedTools "" --model haiku --max-turns 1 \
                 --output-format json \
+                --no-session-persistence --exclude-dynamic-system-prompt-sections \
                 --mcp-config '{"mcpServers":{}}' --strict-mcp-config \
                 2>"$NDC_ERR" < "$NDC_PROMPT")
 

--- a/tests/test_haiku.py
+++ b/tests/test_haiku.py
@@ -126,6 +126,9 @@ def test_call_haiku_success(mock_run):
     assert "claude" in cmd
     assert "--model" in cmd
     assert "haiku" in cmd
+    # One-shot summarization subprocess: never resume these, never write to disk
+    assert "--no-session-persistence" in cmd
+    assert "--exclude-dynamic-system-prompt-sections" in cmd
     # CLAUDECODE must be stripped from env
     env = args[1]["env"]
     assert "CLAUDECODE" not in env


### PR DESCRIPTION
Implements the highest-confidence **Tier-1 "pure wins"** from #87 — isolates the one-shot summarization/consolidation subprocess so it stops doing work it never needs.

## What changed

Adds two `--print`-compatible, no-auth-change flags to all three `claude -p` call sites (`scripts/save-session.sh` haiku + ndc, and `pipeline/haiku.py`):

| Flag | Why |
| --- | --- |
| `--no-session-persistence` | The summarization call is one-shot and never resumed, but it currently writes a session record to disk on every run. On a 24/7 setup those records sync into the desktop app's **Recents** list and flood it — hundreds per day on busy interactive days, all landing in `-private-tmp` / `-private-var-folders-…-T` project dirs (the `cd /tmp`). Pure win. |
| `--exclude-dynamic-system-prompt-sections` | Moves the dynamic preamble (cwd, env, git status, OS) out of the static system prompt — input the summarization call doesn't need. |

I deliberately left the other Tier-1 items out to keep this tight and unambiguous:
- `--strict-mcp-config` already landed in `save-session.sh`.
- `--setting-sources project` is caveated as partial in #87 and `project` is the wrong scope for a `/tmp` cwd with no project — needs a decision.
- `--max-budget-usd` needs a value choice — maintainer call.

## Verification

- Both flags verified against `claude --help` on **Claude Code v2.1.163**.
- Smoke-tested the exact production invocation (`--model haiku --max-turns 1 --output-format json --no-session-persistence --exclude-dynamic-system-prompt-sections --mcp-config '{}' --strict-mcp-config`): JSON output intact (`is_error: false`), and **zero** new session records written to `~/.claude/projects/`.
- Added test assertions for both flags in `tests/test_haiku.py`.
- Full suite green: `396 passed, 1 skipped`. `bash -n` clean on `save-session.sh`.

Refs #87.
