### PR TITLE
fix: resolve empty timezone to system-local, never bare TZ="" (UTC)

### DIFF
--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -64,7 +64,7 @@ LOCK_FILE="${REMEMBER_DIR}/tmp/save.lock"
 MEMORY_FILE="${REMEMBER_DIR}/now.md"
 LAST_SAVE_FILE="${REMEMBER_DIR}/tmp/last-save.json"
 COOLDOWN_MARKER="${REMEMBER_DIR}/tmp/last-save-ts"
-TODAY_DATE=$(TZ="$REMEMBER_TZ" date +%Y-%m-%d)
+TODAY_DATE=$(_remember_date +%Y-%m-%d)
 CLEANUP_FILES=()
 
 # Remove lock file and all accumulated temp files on exit.
@@ -155,9 +155,9 @@ BRANCH="${REMEMBER_BRANCH:-$(cd "$PROJECT_DIR" && git branch --show-current 2>/d
 TIME_FORMAT=$(config ".time_format" "24h")
 if [ "$TIME_FORMAT" = "12h" ]; then
     # Force uppercase AM/PM: %p is locale-dependent (lowercase on many Linux systems).
-    CURRENT_TIME=$(TZ="$REMEMBER_TZ" date '+%-I:%M %p' | tr '[:lower:]' '[:upper:]')
+    CURRENT_TIME=$(_remember_date '+%-I:%M %p' | tr '[:lower:]' '[:upper:]')
 else
-    CURRENT_TIME=$(TZ="$REMEMBER_TZ" date '+%H:%M')
+    CURRENT_TIME=$(_remember_date '+%H:%M')
 fi
 TMP_PROMPT=$(mktemp "${TMPDIR:-/tmp}"/remember-prompt-XXXXXX)
 CLEANUP_FILES+=("$TMP_PROMPT")

--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -43,7 +43,7 @@ source "$(dirname "$0")/bootstrap-dirs.sh"
 PLUGIN_ROOT="$PIPELINE_DIR"
 PROJECT="$PROJECT_DIR"
 source "$PLUGIN_ROOT/scripts/log.sh" 2>/dev/null
-TODAY=$(TZ="$REMEMBER_TZ" date '+%Y-%m-%d')
+TODAY=$(_remember_date '+%Y-%m-%d')
 log "hook" "session-start: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR REMEMBER_DIR=$REMEMBER_DIR"
 
 # ── Dispatch: before_session_start ────────────────────────────────────────

--- a/scripts/user-prompt-hook.sh
+++ b/scripts/user-prompt-hook.sh
@@ -39,13 +39,13 @@ if [ -f "$CTX_PCT_FILE" ]; then
   CTX_PCT=$(cat "$CTX_PCT_FILE" 2>/dev/null)
 fi
 if [ -n "$CTX_PCT" ]; then
-  TIMESTAMP="[$(TZ="$REMEMBER_TZ" date '+%H:%M %Z') — $(whoami) — ${CTX_PCT}%]"
+  TIMESTAMP="[$(_remember_date '+%H:%M %Z') — $(whoami) — ${CTX_PCT}%]"
   echo "$TIMESTAMP"
   if [ "$CTX_PCT" -ge 95 ] 2>/dev/null; then
     echo "WARNING: Context at ${CTX_PCT}%. Run /remember to save session state before context death."
   fi
 else
-  echo "[$(TZ="$REMEMBER_TZ" date '+%H:%M %Z') — $(whoami)]"
+  echo "[$(_remember_date '+%H:%M %Z') — $(whoami)]"
 fi
 
 # ── Dispatch: after_user_prompt ─────────────────────────────────────────


### PR DESCRIPTION
## Problem

The date-resolution sites in `save-session.sh`, `session-start-hook.sh`, and
`user-prompt-hook.sh` use the unguarded pattern:

```sh
TZ="$REMEMBER_TZ" date +%Y-%m-%d
```

When `REMEMBER_TZ` is empty - the default when no `timezone` is set in config, which is
the common case - this expands to `TZ="" date`. On macOS/BSD an empty `TZ` resolves to
**UTC**, not system-local. So an unconfigured user west of UTC gets daily/rotating files
that roll at the wrong local midnight: a write just after local midnight lands in the
previous day's file. It is silent and only visible during the local-to-UTC offset
window, so it survives casual testing.

`log.sh` already solved this correctly with the `_remember_date` helper:

```sh
_remember_date() {
  if [ -n "$REMEMBER_TZ" ]; then TZ="$REMEMBER_TZ" date "$@"; else date "$@"; fi
}
```

...but three scripts that `source log.sh` still call the raw pattern instead of the
helper.

## Fix

Re-point every unguarded `TZ="$REMEMBER_TZ" date` call at the existing `_remember_date`
helper (already in scope in each of these files via `source log.sh`). Empty timezone now
falls back to system-local; an explicit `timezone` override still works unchanged. No
behaviour change for users who have set a timezone.

- `scripts/save-session.sh` (3 sites)
- `scripts/session-start-hook.sh` (1 site)
- `scripts/user-prompt-hook.sh` (2 sites)

`log.sh`'s own helper body is intentionally untouched (its `TZ="$REMEMBER_TZ" date` is
the correct non-empty branch).

## Verify

With no `timezone` configured, run an affected path during the local-to-UTC offset
window and confirm it prints the host-local date, not UTC.
