### PR TITLE
refactor: one claude call site (fixes CC 2.x max-turns #98/#100 + mcp drift #94)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 .pytest_cache/
 identity.md
 .DS_Store
+.max/
+.remember/

--- a/pipeline/haiku.py
+++ b/pipeline/haiku.py
@@ -30,20 +30,24 @@ HAIKU_CACHE_PRICE = 0.08 / 1_000_000
 
 # CC 2.x counts prompt-delivery as turn 1, so a cap of 1 exits error_max_turns
 # before the model replies (#98/#100). Default 4 clears that plus a Stop-hook
-# turn, with margin; overridable via REMEMBER_MAX_TURNS.
+# turn, with margin; overridable via REMEMBER_MAX_TURNS (1..MAX_ALLOWED_TURNS).
 DEFAULT_MAX_TURNS = "4"
+MAX_ALLOWED_TURNS = 20
 
 
 def _resolve_max_turns() -> str:
-    """REMEMBER_MAX_TURNS if it is a positive integer, else the safe default.
+    """REMEMBER_MAX_TURNS if it is an integer in [1, MAX_ALLOWED_TURNS], else
+    the safe default.
 
-    A bad value (0, negative, non-numeric, empty) must not flow through as a
-    garbage ``--max-turns`` arg — that would break ``claude -p`` the same way
-    the original hardcoded ``1`` did.
+    A bad value (0, negative, non-numeric, empty) or an absurd one must not
+    flow through as a garbage ``--max-turns`` arg — that would break
+    ``claude -p`` the same way the original hardcoded ``1`` did. The upper
+    bound keeps a misconfiguration bounded instead of opening an unbounded run.
+    Returns the normalized form (leading zeros stripped).
     """
     raw = os.environ.get("REMEMBER_MAX_TURNS", "").strip()
-    if raw.isdigit() and int(raw) >= 1:
-        return raw
+    if raw.isdigit() and 1 <= int(raw) <= MAX_ALLOWED_TURNS:
+        return str(int(raw))
     return DEFAULT_MAX_TURNS
 
 

--- a/pipeline/haiku.py
+++ b/pipeline/haiku.py
@@ -5,8 +5,8 @@ Handles subprocess management, CLAUDECODE env stripping, JSON parsing,
 token counting, and cost estimation.
 
 The CLI is invoked in a sandboxed configuration: ``cwd=tempdir``, no tools
-by default, ``max-turns 1``, and the ``CLAUDECODE`` env var is stripped
-to allow nested Claude sessions.
+by default, ``max-turns`` configurable via ``REMEMBER_MAX_TURNS`` (default 4),
+and the ``CLAUDECODE`` env var is stripped to allow nested Claude sessions.
 
 Module-level constants:
     HAIKU_INPUT_PRICE: USD cost per input token.
@@ -27,6 +27,24 @@ from .types import HaikuResult, TokenUsage
 HAIKU_INPUT_PRICE = 0.80 / 1_000_000
 HAIKU_OUTPUT_PRICE = 4.00 / 1_000_000
 HAIKU_CACHE_PRICE = 0.08 / 1_000_000
+
+# CC 2.x counts prompt-delivery as turn 1, so a cap of 1 exits error_max_turns
+# before the model replies (#98/#100). Default 4 clears that plus a Stop-hook
+# turn, with margin; overridable via REMEMBER_MAX_TURNS.
+DEFAULT_MAX_TURNS = "4"
+
+
+def _resolve_max_turns() -> str:
+    """REMEMBER_MAX_TURNS if it is a positive integer, else the safe default.
+
+    A bad value (0, negative, non-numeric, empty) must not flow through as a
+    garbage ``--max-turns`` arg — that would break ``claude -p`` the same way
+    the original hardcoded ``1`` did.
+    """
+    raw = os.environ.get("REMEMBER_MAX_TURNS", "").strip()
+    if raw.isdigit() and int(raw) >= 1:
+        return raw
+    return DEFAULT_MAX_TURNS
 
 
 def call_haiku(
@@ -60,8 +78,11 @@ def call_haiku(
         "--no-session-persistence",
         "--exclude-dynamic-system-prompt-sections",
         "--model", "haiku",
-        "--max-turns", "1",
+        "--max-turns", _resolve_max_turns(),
         "--allowedTools", ",".join(tools) if tools else "",
+        # Sandbox MCP: no servers + strict, so the nested session inherits none (#94)
+        "--mcp-config", '{"mcpServers":{}}',
+        "--strict-mcp-config",
     ]
 
     # CLAUDECODE env var blocks nested sessions — must strip it

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -156,9 +156,18 @@ def cmd_parse_haiku(output_file: str = "") -> None:
         HAIKU_TEXT_FILE (path to temp file), IS_SKIP (true/false),
         TK_IN, TK_OUT, TK_CACHE, TK_COST.
     """
-    import tempfile
     raw = sys.stdin.read()
-    r = _parse_response(raw)
+    _emit_haiku_result(_parse_response(raw), output_file)
+
+
+def _emit_haiku_result(r, output_file: str = "") -> None:
+    """Write Haiku text to a temp file and print the shell vars bash consumes.
+
+    Shared by ``parse-haiku`` (parse pre-fetched JSON) and ``call-haiku``
+    (invoke + parse), so both emit an identical contract:
+    HAIKU_TEXT_FILE, IS_SKIP, TK_IN/OUT/CACHE/COST.
+    """
+    import tempfile
 
     # Write text to temp file (can contain newlines, quotes, anything)
     fd, text_file = tempfile.mkstemp(prefix="remember-haiku-text-", suffix=".txt")
@@ -175,6 +184,26 @@ def cmd_parse_haiku(output_file: str = "") -> None:
     if output_file:
         with open(output_file, "w", encoding="utf-8") as f:
             f.write(r.text)
+
+
+def cmd_call_haiku(prompt_file: str, output_file: str = "") -> None:
+    """Invoke Haiku on the prompt in ``prompt_file`` and print the shell vars.
+
+    The single entry point bash uses to run the summarizer subprocess: the
+    ``claude -p`` invocation itself lives only in ``haiku.call_haiku`` (one
+    place — no inline duplicate that could drift, #94/#98/#100). On failure,
+    prints the error to stderr and exits 1 so the caller aborts the save.
+    """
+    from .haiku import call_haiku
+
+    with open(prompt_file, encoding="utf-8") as f:
+        prompt = f.read()
+    try:
+        r = call_haiku(prompt)
+    except RuntimeError as e:
+        print(f"call-haiku error: {e}", file=sys.stderr)
+        sys.exit(1)
+    _emit_haiku_result(r, output_file)
 
 
 def cmd_save_position(last_save_file: str, session_id: str, position: int) -> None:
@@ -310,6 +339,9 @@ def main() -> None:
     elif cmd == "parse-haiku":
         output_file = sys.argv[2] if len(sys.argv) > 2 else ""
         cmd_parse_haiku(output_file=output_file)
+    elif cmd == "call-haiku":
+        output_file = sys.argv[3] if len(sys.argv) > 3 else ""
+        cmd_call_haiku(prompt_file=sys.argv[2], output_file=output_file)
     elif cmd == "save-position":
         cmd_save_position(
             last_save_file=sys.argv[2],

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -18,6 +18,7 @@ Available subcommands::
     build-prompt    Build save-summary prompt file
     build-ndc-prompt Build NDC compression prompt file
     parse-haiku     Parse Haiku JSON response from stdin
+    call-haiku      Invoke Haiku on a prompt file (sandbox + parse in one)
     save-position   Write position to last-save.json
     consolidate     Run full consolidation pipeline
 
@@ -186,21 +187,25 @@ def _emit_haiku_result(r, output_file: str = "") -> None:
             f.write(r.text)
 
 
-def cmd_call_haiku(prompt_file: str, output_file: str = "") -> None:
+def cmd_call_haiku(prompt_file: str, output_file: str = "", timeout: int = 120) -> None:
     """Invoke Haiku on the prompt in ``prompt_file`` and print the shell vars.
 
     The single entry point bash uses to run the summarizer subprocess: the
     ``claude -p`` invocation itself lives only in ``haiku.call_haiku`` (one
-    place — no inline duplicate that could drift, #94/#98/#100). On failure,
-    prints the error to stderr and exits 1 so the caller aborts the save.
+    place — no inline duplicate that could drift, #94/#98/#100). ``timeout``
+    is forwarded to ``call_haiku`` (NDC compresses a whole now.md and needs a
+    longer budget than the per-session summary). On any failure — a missing
+    prompt file (OSError) or a claude error (RuntimeError) — prints the error
+    to stderr and exits 1 so the caller aborts; never leaks a traceback to
+    stdout, which the bash caller captures as the shell-var payload.
     """
     from .haiku import call_haiku
 
-    with open(prompt_file, encoding="utf-8") as f:
-        prompt = f.read()
     try:
-        r = call_haiku(prompt)
-    except RuntimeError as e:
+        with open(prompt_file, encoding="utf-8") as f:
+            prompt = f.read()
+        r = call_haiku(prompt, timeout=timeout)
+    except (OSError, RuntimeError) as e:
         print(f"call-haiku error: {e}", file=sys.stderr)
         sys.exit(1)
     _emit_haiku_result(r, output_file)
@@ -341,7 +346,8 @@ def main() -> None:
         cmd_parse_haiku(output_file=output_file)
     elif cmd == "call-haiku":
         output_file = sys.argv[3] if len(sys.argv) > 3 else ""
-        cmd_call_haiku(prompt_file=sys.argv[2], output_file=output_file)
+        timeout = int(sys.argv[4]) if len(sys.argv) > 4 else 120
+        cmd_call_haiku(prompt_file=sys.argv[2], output_file=output_file, timeout=timeout)
     elif cmd == "save-position":
         cmd_save_position(
             last_save_file=sys.argv[2],

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -232,9 +232,11 @@ if [ "$RUN_NDC" = true ]; then
     if [ -s "$NDC_PROMPT" ]; then
         (set +e  # don't inherit set -e — a haiku non-zero exit must not kill the subshell
             NDC_ERR=$(mktemp "${TMPDIR:-/tmp}"/remember-ndc-err-XXXXXX)
-            NDC_VARS=$(cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell call-haiku "$NDC_PROMPT" 2>"$NDC_ERR")
+            # 180s (not the 120s default): NDC compresses a whole now.md.
+            NDC_VARS=$(cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell call-haiku "$NDC_PROMPT" "" 180 2>"$NDC_ERR")
+            NDC_EXIT=$?
 
-            if [ $? -ne 0 ]; then
+            if [ "$NDC_EXIT" -ne 0 ]; then
                 log "ndc" "ERROR: $(head -1 "$NDC_ERR" 2>/dev/null)"
             else
                 safe_eval <<< "$NDC_VARS"

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -43,7 +43,7 @@
 #     1. Extract exchanges from session JSONL
 #     2. Get last memory entry (for dedup context)
 #     3. Build summarization prompt
-#     4. Call Haiku (sandboxed: cwd=/tmp, no tools, max-turns 1)
+#     4. Call Haiku via `pipeline.shell call-haiku` (sandbox + parse in one)
 #     5. Parse response (detect SKIP vs. content)
 #     6. Append to now.md + save position
 #     7. NDC compression (hourly, background subshell)
@@ -65,10 +65,6 @@ MEMORY_FILE="${REMEMBER_DIR}/now.md"
 LAST_SAVE_FILE="${REMEMBER_DIR}/tmp/last-save.json"
 COOLDOWN_MARKER="${REMEMBER_DIR}/tmp/last-save-ts"
 TODAY_DATE=$(_remember_date +%Y-%m-%d)
-# CC 2.x counts prompt-delivery as turn 1, so a cap of one exits error_max_turns
-# before the model replies (#98). A user Stop hook eats a further turn (#100).
-# Default 4 clears both; override via REMEMBER_MAX_TURNS.
-MAX_TURNS="${REMEMBER_MAX_TURNS:-4}"
 CLEANUP_FILES=()
 
 # Remove lock file and all accumulated temp files on exit.
@@ -171,25 +167,18 @@ cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell build-prompt "$EXTRACT_FILE" "$T
 [ ! -s "$TMP_PROMPT" ] && { log "prompt" "ERROR: empty"; exit 1; }
 grep -q '{{TIME}}\|{{BRANCH}}\|{{LAST_ENTRY}}\|{{EXTRACT}}' "$TMP_PROMPT" && { log "prompt" "ERROR: unsubstituted placeholders in prompt"; exit 1; }
 
-# --- Step 4: Call Haiku ---
+# --- Step 4+5: Call Haiku (the claude -p invocation lives only in pipeline/haiku.py) ---
 log "haiku" "calling (branch: $BRANCH)"
 HAIKU_STDERR=$(mktemp "${TMPDIR:-/tmp}"/remember-haiku-err-XXXXXX)
 CLEANUP_FILES+=("$HAIKU_STDERR")
 
-HAIKU_JSON=$(cd /tmp && env -u CLAUDECODE claude -p \
-    --model haiku --allowedTools "" --max-turns "$MAX_TURNS" \
-    --output-format json \
-    --no-session-persistence --exclude-dynamic-system-prompt-sections \
-    --mcp-config '{"mcpServers":{}}' --strict-mcp-config \
-    2>"$HAIKU_STDERR" < "$TMP_PROMPT")
-HAIKU_EXIT=$?
+# `|| { ... }` (not a bare `if [ $? ]`) so a failure is handled under set -e
+# instead of tripping the ERR trap at the assignment.
+HAIKU_VARS=$(cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell call-haiku "$TMP_PROMPT" 2>"$HAIKU_STDERR") || {
+    log "haiku" "ERROR: $(head -1 "$HAIKU_STDERR")"; exit 1
+}
 
-if [ "$HAIKU_EXIT" -ne 0 ]; then
-    log "haiku" "ERROR: exit $HAIKU_EXIT — $(head -1 "$HAIKU_STDERR")"; exit 1
-fi
-
-# --- Step 5: Parse response ---
-safe_eval <<< "$(echo "$HAIKU_JSON" | (cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell parse-haiku))"
+safe_eval <<< "$HAIKU_VARS"
 CLEANUP_FILES+=("$HAIKU_TEXT_FILE")
 log_tokens "tokens" "$TK_IN" "$TK_OUT" "$TK_CACHE" "$TK_COST"
 
@@ -241,19 +230,14 @@ if [ "$RUN_NDC" = true ]; then
     cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell build-ndc-prompt "$MEMORY_FILE" "$NDC_PROMPT"
 
     if [ -s "$NDC_PROMPT" ]; then
-        (set +e  # don't inherit set -e — claude -p non-zero exit must not kill the subshell
+        (set +e  # don't inherit set -e — a haiku non-zero exit must not kill the subshell
             NDC_ERR=$(mktemp "${TMPDIR:-/tmp}"/remember-ndc-err-XXXXXX)
-            NDC_JSON=$(cd /tmp && env -u CLAUDECODE claude -p \
-                --allowedTools "" --model haiku --max-turns "$MAX_TURNS" \
-                --output-format json \
-                --no-session-persistence --exclude-dynamic-system-prompt-sections \
-                --mcp-config '{"mcpServers":{}}' --strict-mcp-config \
-                2>"$NDC_ERR" < "$NDC_PROMPT")
+            NDC_VARS=$(cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell call-haiku "$NDC_PROMPT" 2>"$NDC_ERR")
 
             if [ $? -ne 0 ]; then
-                log "ndc" "ERROR: haiku exit $? — $(head -1 "$NDC_ERR" 2>/dev/null)"
+                log "ndc" "ERROR: $(head -1 "$NDC_ERR" 2>/dev/null)"
             else
-                safe_eval <<< "$(echo "$NDC_JSON" | (cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell parse-haiku))"
+                safe_eval <<< "$NDC_VARS"
                 NDC_TEXT=$(cat "$HAIKU_TEXT_FILE")
                 if [ -n "$NDC_TEXT" ]; then
                     [ -s "$TODAY_FILE" ] && echo "" >> "$TODAY_FILE"

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -65,6 +65,10 @@ MEMORY_FILE="${REMEMBER_DIR}/now.md"
 LAST_SAVE_FILE="${REMEMBER_DIR}/tmp/last-save.json"
 COOLDOWN_MARKER="${REMEMBER_DIR}/tmp/last-save-ts"
 TODAY_DATE=$(_remember_date +%Y-%m-%d)
+# CC 2.x counts prompt-delivery as turn 1, so a cap of one exits error_max_turns
+# before the model replies (#98). A user Stop hook eats a further turn (#100).
+# Default 4 clears both; override via REMEMBER_MAX_TURNS.
+MAX_TURNS="${REMEMBER_MAX_TURNS:-4}"
 CLEANUP_FILES=()
 
 # Remove lock file and all accumulated temp files on exit.
@@ -173,7 +177,7 @@ HAIKU_STDERR=$(mktemp "${TMPDIR:-/tmp}"/remember-haiku-err-XXXXXX)
 CLEANUP_FILES+=("$HAIKU_STDERR")
 
 HAIKU_JSON=$(cd /tmp && env -u CLAUDECODE claude -p \
-    --model haiku --allowedTools "" --max-turns 1 \
+    --model haiku --allowedTools "" --max-turns "$MAX_TURNS" \
     --output-format json \
     --no-session-persistence --exclude-dynamic-system-prompt-sections \
     --mcp-config '{"mcpServers":{}}' --strict-mcp-config \
@@ -240,7 +244,7 @@ if [ "$RUN_NDC" = true ]; then
         (set +e  # don't inherit set -e — claude -p non-zero exit must not kill the subshell
             NDC_ERR=$(mktemp "${TMPDIR:-/tmp}"/remember-ndc-err-XXXXXX)
             NDC_JSON=$(cd /tmp && env -u CLAUDECODE claude -p \
-                --allowedTools "" --model haiku --max-turns 1 \
+                --allowedTools "" --model haiku --max-turns "$MAX_TURNS" \
                 --output-format json \
                 --no-session-persistence --exclude-dynamic-system-prompt-sections \
                 --mcp-config '{"mcpServers":{}}' --strict-mcp-config \

--- a/tests/test_haiku.py
+++ b/tests/test_haiku.py
@@ -5,6 +5,8 @@ import os
 import sys
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from pipeline.haiku import call_haiku, _parse_response, _extract_tokens
@@ -129,6 +131,10 @@ def test_call_haiku_success(mock_run):
     # One-shot summarization subprocess: never resume these, never write to disk
     assert "--no-session-persistence" in cmd
     assert "--exclude-dynamic-system-prompt-sections" in cmd
+    # Sandboxed MCP: no servers, strict (so the nested session can't inherit any) — #94
+    assert "--mcp-config" in cmd
+    assert cmd[cmd.index("--mcp-config") + 1] == '{"mcpServers":{}}'
+    assert "--strict-mcp-config" in cmd
     # CLAUDECODE must be stripped from env
     env = args[1]["env"]
     assert "CLAUDECODE" not in env
@@ -146,6 +152,43 @@ def test_call_haiku_with_tools(mock_run):
     assert "--allowedTools" in cmd
     idx = cmd.index("--allowedTools")
     assert cmd[idx + 1] == "Read,Write"
+
+
+def _max_turns_in(cmd: list[str]) -> str:
+    return cmd[cmd.index("--max-turns") + 1]
+
+
+@patch("pipeline.haiku.subprocess.run")
+def test_call_haiku_default_max_turns_clears_cc2x(mock_run, monkeypatch):
+    """Default must be >=2 — CC 2.x counts prompt-delivery as turn 1, so a cap
+    of 1 exits error_max_turns before the model replies (#98/#100). This is the
+    consolidation path (consolidate.py -> call_haiku), not just save-session.sh."""
+    monkeypatch.delenv("REMEMBER_MAX_TURNS", raising=False)
+    mock_run.return_value = MagicMock(
+        returncode=0, stdout=_mock_claude_response("x"), stderr="")
+    call_haiku("p")
+    assert _max_turns_in(mock_run.call_args[0][0]) == "4"
+
+
+@patch("pipeline.haiku.subprocess.run")
+def test_call_haiku_max_turns_env_override(mock_run, monkeypatch):
+    monkeypatch.setenv("REMEMBER_MAX_TURNS", "6")
+    mock_run.return_value = MagicMock(
+        returncode=0, stdout=_mock_claude_response("x"), stderr="")
+    call_haiku("p")
+    assert _max_turns_in(mock_run.call_args[0][0]) == "6"
+
+
+@pytest.mark.parametrize("bad", ["0", "-1", "banana", "", "3.5"])
+@patch("pipeline.haiku.subprocess.run")
+def test_call_haiku_invalid_max_turns_falls_back(mock_run, bad, monkeypatch):
+    """A bad REMEMBER_MAX_TURNS must not flow through as a garbage --max-turns
+    value (which would break claude -p the same way the original bug did)."""
+    monkeypatch.setenv("REMEMBER_MAX_TURNS", bad)
+    mock_run.return_value = MagicMock(
+        returncode=0, stdout=_mock_claude_response("x"), stderr="")
+    call_haiku("p")
+    assert _max_turns_in(mock_run.call_args[0][0]) == "4"
 
 
 @patch("pipeline.haiku.subprocess.run")

--- a/tests/test_haiku.py
+++ b/tests/test_haiku.py
@@ -179,16 +179,28 @@ def test_call_haiku_max_turns_env_override(mock_run, monkeypatch):
     assert _max_turns_in(mock_run.call_args[0][0]) == "6"
 
 
-@pytest.mark.parametrize("bad", ["0", "-1", "banana", "", "3.5"])
+@pytest.mark.parametrize("bad", ["0", "-1", "banana", "", "3.5", "21", "999999"])
 @patch("pipeline.haiku.subprocess.run")
 def test_call_haiku_invalid_max_turns_falls_back(mock_run, bad, monkeypatch):
-    """A bad REMEMBER_MAX_TURNS must not flow through as a garbage --max-turns
-    value (which would break claude -p the same way the original bug did)."""
+    """A bad/out-of-range REMEMBER_MAX_TURNS must not flow through as a garbage
+    --max-turns value (which would break claude -p the same way the original
+    bug did). Includes the upper-bound cap so a misconfig is bounded."""
     monkeypatch.setenv("REMEMBER_MAX_TURNS", bad)
     mock_run.return_value = MagicMock(
         returncode=0, stdout=_mock_claude_response("x"), stderr="")
     call_haiku("p")
     assert _max_turns_in(mock_run.call_args[0][0]) == "4"
+
+
+@pytest.mark.parametrize("raw,expected", [("2", "2"), ("20", "20"), ("007", "7")])
+@patch("pipeline.haiku.subprocess.run")
+def test_call_haiku_valid_max_turns_normalized(mock_run, raw, expected, monkeypatch):
+    """In-range values pass through, normalized (leading zeros stripped)."""
+    monkeypatch.setenv("REMEMBER_MAX_TURNS", raw)
+    mock_run.return_value = MagicMock(
+        returncode=0, stdout=_mock_claude_response("x"), stderr="")
+    call_haiku("p")
+    assert _max_turns_in(mock_run.call_args[0][0]) == expected
 
 
 @patch("pipeline.haiku.subprocess.run")

--- a/tests/test_save_session_max_turns.py
+++ b/tests/test_save_session_max_turns.py
@@ -1,79 +1,39 @@
-"""Guard the nested Haiku `claude -p` max-turns against Claude Code 2.x turn counting.
+"""save-session.sh must delegate the Haiku call to the single pipeline entry
+point (`pipeline.shell call-haiku`) — never inline its own `claude -p`.
 
-Regression context (#98, #100):
-  - CC 1.x: `--max-turns 1` = one full prompt→reply cycle.
-  - CC 2.1.x: turn 1 = prompt delivery, turn 2 = model reply. So `--max-turns 1`
-    now exits 1 with subtype `error_max_turns` *before* the model replies, and
-    save-session.sh aborts at the `exit 1` guard — no memory is ever written.
-  - #100: a user Stop hook consumes a further turn, so even 2 can be too tight;
-    the value must be configurable (REMEMBER_MAX_TURNS) with margin.
-
-Both `claude -p` call sites (the main Haiku call and the NDC compression call)
-must use the same configurable, >=2 value — never a hardcoded `--max-turns 1`.
+The inline duplication is exactly what let the CC-2.x `--max-turns 1` break
+(#98/#100) get half-fixed and the MCP-sandbox flags drift (#94): two call sites,
+two chances to diverge. The `claude` invocation now lives only in
+pipeline/haiku.py; max-turns / mcp-flag behaviour is covered there
+(tests/test_haiku.py).
 """
 
 from __future__ import annotations
 
-import re
-import shutil
-import subprocess
 from pathlib import Path
-
-import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = REPO_ROOT / "scripts" / "save-session.sh"
 
 
-@pytest.fixture(scope="module")
-def script_text() -> str:
-    return SCRIPT.read_text()
+def _code_lines(text: str) -> list[str]:
+    # Drop comment lines so prose that mentions `claude -p` doesn't trip checks.
+    return [ln for ln in text.splitlines() if not ln.lstrip().startswith("#")]
 
 
-def test_no_hardcoded_max_turns_1(script_text: str) -> None:
-    """The literal `--max-turns 1` is the bug — it must not appear anywhere."""
-    offenders = [
-        ln
-        for ln in script_text.splitlines()
-        if re.search(r"--max-turns\s+1\b", ln)
-    ]
-    assert not offenders, f"hardcoded `--max-turns 1` (breaks on CC 2.x): {offenders}"
+def test_no_inline_claude_invocation() -> None:
+    """The script must not invoke `claude` directly — that lives in haiku.py."""
+    offenders = [ln for ln in _code_lines(SCRIPT.read_text()) if "claude -p" in ln]
+    assert not offenders, f"inline claude invocation in save-session.sh: {offenders}"
 
 
-def test_both_claude_calls_use_configurable_max_turns(script_text: str) -> None:
-    """Every `claude -p` invocation must pass --max-turns "$MAX_TURNS"."""
-    flags = re.findall(r"--max-turns\s+(\S+)", script_text)
-    claude_calls = script_text.count("claude -p")
-    assert claude_calls >= 2, f"expected >=2 `claude -p` call sites, found {claude_calls}"
-    assert len(flags) >= 2, f"expected >=2 --max-turns flags, found {flags}"
-    for value in flags:
-        assert "MAX_TURNS" in value, f"--max-turns must reference $MAX_TURNS, got {value!r}"
+def test_both_haiku_calls_delegate_to_call_haiku() -> None:
+    """Main Haiku call + NDC compression both go through `call-haiku`."""
+    code = "\n".join(_code_lines(SCRIPT.read_text()))
+    n = code.count("pipeline.shell call-haiku")
+    assert n == 2, f"expected 2 call-haiku delegations (main + NDC), found {n}"
 
 
-def test_max_turns_defaults_to_at_least_2(script_text: str) -> None:
-    """REMEMBER_MAX_TURNS default must clear the CC 2.x prompt-delivery turn (>=2)."""
-    m = re.search(r'MAX_TURNS="?\$\{REMEMBER_MAX_TURNS:-(\d+)\}"?', script_text)
-    assert m, "expected `MAX_TURNS=\"${REMEMBER_MAX_TURNS:-N}\"` assignment"
-    assert int(m.group(1)) >= 2, f"default {m.group(1)} too low for CC 2.x turn counting"
-
-
-@pytest.mark.skipif(shutil.which("bash") is None, reason="bash required")
-def test_env_override_flows_through() -> None:
-    """REMEMBER_MAX_TURNS env override is honored at runtime; default applies otherwise."""
-    assign = next(
-        ln.strip()
-        for ln in SCRIPT.read_text().splitlines()
-        if ln.strip().startswith("MAX_TURNS=")
-    )
-    # Default (unset)
-    out = subprocess.run(
-        ["bash", "-c", f'unset REMEMBER_MAX_TURNS; {assign}; echo "$MAX_TURNS"'],
-        capture_output=True, text=True, check=True,
-    ).stdout.strip()
-    assert int(out) >= 2
-    # Override
-    out = subprocess.run(
-        ["bash", "-c", f'export REMEMBER_MAX_TURNS=7; {assign}; echo "$MAX_TURNS"'],
-        capture_output=True, text=True, check=True,
-    ).stdout.strip()
-    assert out == "7"
+def test_no_hardcoded_max_turns_in_script() -> None:
+    """No `--max-turns` literal survives in the shell — it's haiku.py's concern."""
+    assert "--max-turns" not in SCRIPT.read_text()

--- a/tests/test_save_session_max_turns.py
+++ b/tests/test_save_session_max_turns.py
@@ -1,0 +1,79 @@
+"""Guard the nested Haiku `claude -p` max-turns against Claude Code 2.x turn counting.
+
+Regression context (#98, #100):
+  - CC 1.x: `--max-turns 1` = one full prompt→reply cycle.
+  - CC 2.1.x: turn 1 = prompt delivery, turn 2 = model reply. So `--max-turns 1`
+    now exits 1 with subtype `error_max_turns` *before* the model replies, and
+    save-session.sh aborts at the `exit 1` guard — no memory is ever written.
+  - #100: a user Stop hook consumes a further turn, so even 2 can be too tight;
+    the value must be configurable (REMEMBER_MAX_TURNS) with margin.
+
+Both `claude -p` call sites (the main Haiku call and the NDC compression call)
+must use the same configurable, >=2 value — never a hardcoded `--max-turns 1`.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "save-session.sh"
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return SCRIPT.read_text()
+
+
+def test_no_hardcoded_max_turns_1(script_text: str) -> None:
+    """The literal `--max-turns 1` is the bug — it must not appear anywhere."""
+    offenders = [
+        ln
+        for ln in script_text.splitlines()
+        if re.search(r"--max-turns\s+1\b", ln)
+    ]
+    assert not offenders, f"hardcoded `--max-turns 1` (breaks on CC 2.x): {offenders}"
+
+
+def test_both_claude_calls_use_configurable_max_turns(script_text: str) -> None:
+    """Every `claude -p` invocation must pass --max-turns "$MAX_TURNS"."""
+    flags = re.findall(r"--max-turns\s+(\S+)", script_text)
+    claude_calls = script_text.count("claude -p")
+    assert claude_calls >= 2, f"expected >=2 `claude -p` call sites, found {claude_calls}"
+    assert len(flags) >= 2, f"expected >=2 --max-turns flags, found {flags}"
+    for value in flags:
+        assert "MAX_TURNS" in value, f"--max-turns must reference $MAX_TURNS, got {value!r}"
+
+
+def test_max_turns_defaults_to_at_least_2(script_text: str) -> None:
+    """REMEMBER_MAX_TURNS default must clear the CC 2.x prompt-delivery turn (>=2)."""
+    m = re.search(r'MAX_TURNS="?\$\{REMEMBER_MAX_TURNS:-(\d+)\}"?', script_text)
+    assert m, "expected `MAX_TURNS=\"${REMEMBER_MAX_TURNS:-N}\"` assignment"
+    assert int(m.group(1)) >= 2, f"default {m.group(1)} too low for CC 2.x turn counting"
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash required")
+def test_env_override_flows_through() -> None:
+    """REMEMBER_MAX_TURNS env override is honored at runtime; default applies otherwise."""
+    assign = next(
+        ln.strip()
+        for ln in SCRIPT.read_text().splitlines()
+        if ln.strip().startswith("MAX_TURNS=")
+    )
+    # Default (unset)
+    out = subprocess.run(
+        ["bash", "-c", f'unset REMEMBER_MAX_TURNS; {assign}; echo "$MAX_TURNS"'],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert int(out) >= 2
+    # Override
+    out = subprocess.run(
+        ["bash", "-c", f'export REMEMBER_MAX_TURNS=7; {assign}; echo "$MAX_TURNS"'],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert out == "7"

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -262,6 +262,29 @@ def test_cmd_call_haiku_error_exits_1(tmp_path):
     assert ei.value.code == 1
 
 
+def test_cmd_call_haiku_missing_prompt_file_exits_1_cleanly(tmp_path, capsys):
+    """A missing prompt file must exit 1 with a stderr diagnostic — not dump a
+    traceback to stdout (which the bash caller captures as HAIKU_VARS)."""
+    from pipeline.shell import cmd_call_haiku
+    with pytest.raises(SystemExit) as ei:
+        cmd_call_haiku(str(tmp_path / "does-not-exist.txt"))
+    assert ei.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""          # nothing on stdout to mis-eval
+    assert "call-haiku error" in captured.err
+
+
+def test_cmd_call_haiku_passes_timeout(tmp_path):
+    """call-haiku must forward its timeout to call_haiku (NDC needs 180, not 120)."""
+    from pipeline.shell import cmd_call_haiku
+    prompt = tmp_path / "p.txt"
+    prompt.write_text("x")
+    fake = HaikuResult(text="t", tokens=TokenUsage(input=1, output=1, cache=0, cost_usd=0.0), is_skip=False)
+    with patch("pipeline.haiku.call_haiku", return_value=fake) as mock_ch:
+        cmd_call_haiku(str(prompt), timeout=180)
+    assert mock_ch.call_args.kwargs.get("timeout") == 180
+
+
 # --- cmd_consolidate ---
 
 def test_cmd_consolidate_no_staging_files_prints_zero(capsys):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -222,6 +222,46 @@ def test_cmd_build_prompt_passes_correct_args():
         )
 
 
+# --- cmd_call_haiku ---
+
+def test_cmd_call_haiku_emits_vars_and_passes_prompt(capsys, tmp_path):
+    """call-haiku invokes haiku.call_haiku with the prompt file's content and
+    emits the same shell-var contract as parse-haiku (single claude call site)."""
+    from pipeline.shell import cmd_call_haiku
+    prompt = tmp_path / "p.txt"
+    prompt.write_text("summarize this")
+    fake = HaikuResult(
+        text="## 10:00 | did x",
+        tokens=TokenUsage(input=5, output=2, cache=1, cost_usd=0.0001),
+        is_skip=False,
+    )
+    with patch("pipeline.haiku.call_haiku", return_value=fake) as mock_ch:
+        cmd_call_haiku(str(prompt))
+
+    out = capsys.readouterr().out
+    assert "HAIKU_TEXT_FILE=" in out
+    assert "IS_SKIP=false" in out
+    assert "TK_IN=5" in out and "TK_OUT=2" in out and "TK_CACHE=1" in out
+    mock_ch.assert_called_once()
+    assert mock_ch.call_args[0][0] == "summarize this"
+    for line in out.splitlines():
+        if line.startswith("HAIKU_TEXT_FILE="):
+            p = line.split("=", 1)[1].strip("'")
+            assert open(p).read() == "## 10:00 | did x"
+            os.unlink(p)
+
+
+def test_cmd_call_haiku_error_exits_1(tmp_path):
+    """A claude failure (RuntimeError) must exit 1 so the bash caller aborts."""
+    from pipeline.shell import cmd_call_haiku
+    prompt = tmp_path / "p.txt"
+    prompt.write_text("x")
+    with patch("pipeline.haiku.call_haiku", side_effect=RuntimeError("boom")):
+        with pytest.raises(SystemExit) as ei:
+            cmd_call_haiku(str(prompt))
+    assert ei.value.code == 1
+
+
 # --- cmd_consolidate ---
 
 def test_cmd_consolidate_no_staging_files_prints_zero(capsys):


### PR DESCRIPTION
## Context

The Haiku summarizer's `claude -p` invocation lived in **two** places — `save-session.sh` inlined it twice (main + NDC), and `pipeline/haiku.py` had `call_haiku()` — and they'd already drifted: haiku.py was missing `--mcp-config`/`--strict-mcp-config` (#94), and the CC-2.x `--max-turns 1` break (#98/#100) could be half-fixed because there were two call sites. This unifies on **`haiku.py` as the single owner**.

## What changed

- **`haiku.py`** — the one claude call site. Adds `--mcp-config`/`--strict-mcp-config` (closes #94 drift). `--max-turns` configurable via `REMEMBER_MAX_TURNS` (`_resolve_max_turns`, default 4, validated to `[1,20]`, leading zeros normalized). CC 2.x counts prompt-delivery as turn 1, so a cap of 1 exits `error_max_turns` before the model replies.
- **`shell.py`** — new `call-haiku` subcommand (invoke + parse in one), sharing the emit contract with `parse-haiku` via `_emit_haiku_result`. Forwards a `timeout`; `open()` inside the try so a missing prompt file fails clean (stderr + exit 1, no traceback to stdout).
- **`save-session.sh`** — both Haiku calls delegate to `call-haiku`; the inline `claude -p` blocks and dead bash `MAX_TURNS` logic are gone. Main path uses `|| { ... }` so failures are handled under `set -e` (not swallowed by the ERR trap at the assignment); NDC passes `timeout=180` (compresses a whole now.md) and captures its exit immediately.

## Tests

- `test_haiku.py` — max-turns default/override/invalid/cap/normalize, mcp flags.
- `test_shell.py` — `call-haiku` success, claude-error exit, missing-file clean exit, timeout passthrough.
- `test_save_session_max_turns.py` — rewritten to the delegation contract (no inline `claude -p`, 2 delegations).
- **423 passed**; end-to-end smoke-tested with a stubbed `claude` binary (success / failure / timeout-arg / missing-file paths). Self-reviewed adversarially (Sonnet) — that pass caught the NDC timeout regression, now fixed.

🤖 Generated by Max