### PR TITLE
harden: follow-ups for merged contributor PRs #90 and #99

### DIFF
--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -43,6 +43,15 @@ source "$(dirname "$0")/bootstrap-dirs.sh"
 PLUGIN_ROOT="$PIPELINE_DIR"
 PROJECT="$PROJECT_DIR"
 source "$PLUGIN_ROOT/scripts/log.sh" 2>/dev/null
+# log.sh is sourced with stderr suppressed; a silent failure (e.g. read-only
+# mount where log.sh `return 1`s) would leave _remember_date / log / dispatch
+# undefined, crashing later with a cryptic `command not found`. Surface a clear
+# diagnostic up front. Exit 127 (command-missing) to match the degraded-env
+# contract that tolerates rc in (0, 127), not a bare 1.
+if ! command -v _remember_date >/dev/null 2>&1; then
+    echo "session-start-hook: ERROR — failed to source $PLUGIN_ROOT/scripts/log.sh" >&2
+    exit 127
+fi
 TODAY=$(_remember_date '+%Y-%m-%d')
 log "hook" "session-start: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR REMEMBER_DIR=$REMEMBER_DIR"
 

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -1803,6 +1803,50 @@ class TestFreshProjectBootstrap:
             # Restore permissions for cleanup
             os.chmod(project, 0o755)
 
+    def test_unsourceable_log_sh_fails_loudly_not_silently(self, tmp_path):
+        """If log.sh sources but does not define _remember_date, the hook must
+        fail loudly (rc=127 + diagnostic), not silently produce an empty TODAY.
+
+        Without the guard, the hook would call `_remember_date` (command not
+        found, empty TODAY) and continue to exit 0 — a silent corruption. The
+        guard converts that into an explicit, debuggable failure. rc=127 keeps
+        it inside the degraded-env contract that tolerates (0, 127).
+        """
+        project = os.path.join(str(tmp_path), "project")
+        plugin = os.path.join(str(tmp_path), "cache", "org", "remember", "0.5.0")
+        os.makedirs(project)
+        os.makedirs(os.path.join(plugin, "scripts"))
+        _create_full_plugin_copy(plugin)
+        _create_full_project(project)
+
+        # Replace log.sh with a stub that sources cleanly but omits
+        # _remember_date — isolating the guard from the real log.sh.
+        with open(os.path.join(plugin, "scripts", "log.sh"), "w") as f:
+            f.write("#!/bin/bash\n# stub: intentionally omits _remember_date\n:\n")
+
+        env = {k: v for k, v in os.environ.items()
+               if k not in ("CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT")}
+        env["CLAUDE_PROJECT_DIR"] = project
+        env["CLAUDE_PLUGIN_ROOT"] = plugin
+
+        result = subprocess.run(
+            ["bash", os.path.join(plugin, "scripts", "session-start-hook.sh")],
+            capture_output=True, text=True, env=env, timeout=10,
+        )
+
+        assert result.returncode == 127, (
+            f"Expected loud rc=127 on missing _remember_date, got {result.returncode}. "
+            f"stderr={result.stderr[:300]}"
+        )
+        # bootstrap-dirs.sh redirects stderr to hook-errors.log before log.sh is
+        # sourced, so the guard's diagnostic lands there, not in captured stderr.
+        # The message is unique to the guard — its presence proves the guard fired.
+        errlog = os.path.join(project, ".remember", "logs", "hook-errors.log")
+        log_text = open(errlog).read() if os.path.exists(errlog) else ""
+        assert "failed to source" in log_text, (
+            f"Expected guard diagnostic in {errlog}, got: {log_text[:300]!r}"
+        )
+
     # ── Idempotency ──────────────────────────────────────────────────────
 
     def test_bootstrap_idempotent_multiple_runs(self, tmp_path):

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -284,6 +284,32 @@ def test_cmd_consolidate_with_staging_files(capsys):
                 os.unlink(path)
 
 
+def test_cmd_consolidate_skip_emits_status_and_no_output_paths(capsys):
+    """When consolidate() raises ConsolidationSkipped (refusal/non-conforming),
+    cmd_consolidate must emit CONSOLIDATION_STATUS=skip and NO output-path vars,
+    so run-consolidation.sh leaves recent/archive and staging files untouched (#90)."""
+    from pipeline.consolidate import ConsolidationSkipped
+
+    with tempfile.TemporaryDirectory() as d:
+        past_file = os.path.join(d, "today-2020-01-01.md")
+        with open(past_file, "w") as f:
+            f.write("old entry")
+
+        with patch(
+            "pipeline.consolidate.consolidate",
+            side_effect=ConsolidationSkipped("refusal"),
+        ):
+            cmd_consolidate(staging_dir=d, recent_file="/nonexistent", archive_file="/nonexistent")
+
+        output = capsys.readouterr().out
+        assert "STAGING_COUNT=1" in output
+        assert "CONSOLIDATION_STATUS=skip" in output
+        # No write/rename must be signalled to the shell on skip.
+        assert "RECENT_OUT=" not in output
+        assert "ARCHIVE_OUT=" not in output
+        assert "STAGING_PATHS_FILE=" not in output
+
+
 def test_cmd_consolidate_staging_paths_file_handles_special_chars(capsys):
     """STAGING_PATHS_FILE correctly encodes filenames with single quotes and spaces."""
     fake_tokens = TokenUsage(input=10, output=5, cache=0, cost_usd=0.0)


### PR DESCRIPTION
## Context

Two review findings on the just-merged contributor PRs were correct but not blocking, so the PRs were merged as-is and the fixes split out here (keeping the original authors' history clean). Both are defensive/test-coverage items — no behavior change to the happy path.

## #99 follow-up — fail loudly on a broken log.sh source

`session-start-hook.sh` sources `log.sh` with `2>/dev/null`. #99 made `_remember_date` load-critical there; a silent sourcing failure would leave it undefined and the hook would continue with an empty `TODAY`. Added a `command -v _remember_date` guard that exits **127** (stays inside the degraded-env contract `(0, 127)` the read-only test relies on) with a clear diagnostic to `hook-errors.log`.

## #90 follow-up — cover the shell-level skip path

#90's key invariant (on `ConsolidationSkipped`: emit `CONSOLIDATION_STATUS=skip`, no output-path vars, so nothing is written and no staging file is retired) had zero automated coverage. Added a `cmd_consolidate` test asserting exactly that.

## Tests

- `test_unsourceable_log_sh_fails_loudly_not_silently` — red without the guard, green with (verified by neutering the guard).
- `test_cmd_consolidate_skip_emits_status_and_no_output_paths`.
- Full suite: **406 passed, 1 skipped**.

🤖 Generated by Max