### PR TITLE
fix: strip parent Claude Code session env from nested claude -p (#95)

### DIFF
--- a/pipeline/haiku.py
+++ b/pipeline/haiku.py
@@ -1,12 +1,15 @@
 """Claude CLI wrapper for calling Haiku and parsing structured JSON responses.
 
 Provides the single interface used by all pipeline stages to invoke Haiku.
-Handles subprocess management, CLAUDECODE env stripping, JSON parsing,
-token counting, and cost estimation.
+Handles subprocess management, parent-session env stripping (CLAUDECODE +
+CLAUDE_JOB_DIR + CLAUDE_CODE_*), JSON parsing, token counting, and cost
+estimation.
 
 The CLI is invoked in a sandboxed configuration: ``cwd=tempdir``, no tools
 by default, ``max-turns`` configurable via ``REMEMBER_MAX_TURNS`` (default 4),
-and the ``CLAUDECODE`` env var is stripped to allow nested Claude sessions.
+and the parent Claude Code session env vars are stripped (``CLAUDECODE`` to
+allow a nested session; ``CLAUDE_JOB_DIR`` / ``CLAUDE_CODE_*`` so the child
+doesn't masquerade as the parent's session, #95).
 
 Module-level constants:
     HAIKU_INPUT_PRICE: USD cost per input token.
@@ -51,6 +54,25 @@ def _resolve_max_turns() -> str:
     return DEFAULT_MAX_TURNS
 
 
+def _child_env() -> dict[str, str]:
+    """Environment for the nested ``claude -p`` with the PARENT session vars
+    stripped.
+
+    ``CLAUDECODE`` blocks nested sessions. ``CLAUDE_JOB_DIR`` and the
+    ``CLAUDE_CODE_*`` family (e.g. ``CLAUDE_CODE_SESSION_ID``) identify the
+    parent Claude Code session; if they leak into the subprocess it looks like
+    a resumable session to anything keying off them (#95). Everything else is
+    passed through unchanged.
+    """
+    return {
+        k: v
+        for k, v in os.environ.items()
+        if k != "CLAUDECODE"
+        and k != "CLAUDE_JOB_DIR"
+        and not k.startswith("CLAUDE_CODE_")
+    }
+
+
 def call_haiku(
     prompt: str,
     tools: list[str] | None = None,
@@ -89,8 +111,7 @@ def call_haiku(
         "--strict-mcp-config",
     ]
 
-    # CLAUDECODE env var blocks nested sessions — must strip it
-    env = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+    env = _child_env()
 
     try:
         result = subprocess.run(

--- a/tests/test_haiku.py
+++ b/tests/test_haiku.py
@@ -141,6 +141,28 @@ def test_call_haiku_success(mock_run):
 
 
 @patch("pipeline.haiku.subprocess.run")
+def test_call_haiku_strips_parent_session_env(mock_run, monkeypatch):
+    """The nested claude -p must not inherit the PARENT Claude Code session
+    vars — else it looks like a resumable session to anything keying off them
+    (#95). Strip CLAUDECODE, CLAUDE_JOB_DIR, and all CLAUDE_CODE_*; keep the
+    rest of the environment intact."""
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("CLAUDE_JOB_DIR", "/some/job/dir")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "abc-123")
+    monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "cli")
+    monkeypatch.setenv("PATH", "/usr/bin")  # an unrelated var must survive
+    mock_run.return_value = MagicMock(
+        returncode=0, stdout=_mock_claude_response("x"), stderr="")
+    call_haiku("p")
+    env = mock_run.call_args[1]["env"]
+    assert "CLAUDECODE" not in env
+    assert "CLAUDE_JOB_DIR" not in env
+    assert "CLAUDE_CODE_SESSION_ID" not in env
+    assert "CLAUDE_CODE_ENTRYPOINT" not in env
+    assert env.get("PATH") == "/usr/bin"
+
+
+@patch("pipeline.haiku.subprocess.run")
 def test_call_haiku_with_tools(mock_run):
     mock_run.return_value = MagicMock(
         returncode=0,


### PR DESCRIPTION
## Context

The Haiku summarizer subprocess stripped only `CLAUDECODE`, so the parent session's `CLAUDE_JOB_DIR` and `CLAUDE_CODE_SESSION_ID` (and the rest of the `CLAUDE_CODE_*` family) **leaked into the nested `claude -p`** — making it look like the parent's resumable session to anything keying off those vars (#95).

#93's `--no-session-persistence` removed the visible symptom (no persisted record / Recents flood) but not the inherited env. This closes the underlying leak.

## Change

- `haiku.py`: extract `_child_env()` — strip `CLAUDECODE`, `CLAUDE_JOB_DIR`, and any `CLAUDE_CODE_*`; pass everything else through unchanged.
- Docstrings updated.

## Test

`test_call_haiku_strips_parent_session_env` (TDD, red→green): sets all three vars + `PATH`, asserts the session vars are gone from the child env and `PATH` survives. Full suite green (432 passed).

Closes #95.

🤖 Generated by Max