### PR TITLE
release: 0.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remember",
   "description": "Continuous memory for Claude Code. Extracts, summarizes, and compresses conversations into tiered daily logs. Claude remembers what you did yesterday.",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] — CC 2.x save fix, Windows reliability, unified Haiku call
+
 ### Added
 
 - **`REMEMBER_BRANCH` env var override** — `scripts/save-session.sh` now honors `$REMEMBER_BRANCH` when computing the `## HH:MM | <branch>` identity slot of each daily-log entry. Falls back to the existing `git branch --show-current` lookup, then the literal `"unknown"` if no git repo is present. Use case: running Claude Code from `$HOME` (or any non-git directory) collapses the identity slot to `unknown` on every entry, which makes log entries indistinguishable across instances. Export `REMEMBER_BRANCH=laptop` / `cloud` / `staging` / `$HOSTNAME` in your shell rc and the slot becomes a useful per-instance tag. Documented in `README.md` Configuration → Environment variables.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue)](https://www.python.org/)
 [![OS](https://img.shields.io/badge/tested%20on-Linux%20%7C%20macOS%20%7C%20Windows-blue)](https://github.com/Digital-Process-Tools/claude-remember/actions/workflows/tests.yml)
 [![License](https://img.shields.io/badge/license-Community-brightgreen)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.7.3-orange)](.claude-plugin/plugin.json)
+[![Version](https://img.shields.io/badge/version-0.8.0-orange)](.claude-plugin/plugin.json)
 
 Claude Code starts every session blank. It doesn't know what you worked on yesterday, what conventions your team follows, or what mistakes it already made. You re-explain everything, every time.
 


### PR DESCRIPTION
## Context

Version bump: `0.7.3` → `0.8.0`. Releases this session's merged work, which was sitting on `main` unreleased (users on 0.7.3 didn't have any of it). Bumps `plugin.json`, the README version badge, and promotes the CHANGELOG `[Unreleased]` section to `[0.8.0]`.

## Highlights

- **`--max-turns 1` broke every save on Claude Code 2.1.x** (#98, #100) — now configurable (`REMEMBER_MAX_TURNS`, default 4).
- **Single `claude -p` call site** (#94) — unified on `pipeline/haiku.py`, closing the mcp-flag drift.
- **Windows: mojibake + lone-surrogate save crash** (#91, #97) — every byte↔str boundary made UTF-8-safe.
- **Windows external-mode `data_dir` path doubling** (#79) — `C:/` drive paths now recognized as absolute.
- Subprocess isolation (#87), consolidation SKIP guard (#89), empty-TZ → local (#99), parent-session env leak (#95).
- Re-enabled Windows shell-subprocess test coverage (#79).

Three community contributors (@sergeclaesen, @Buzzwoo-Ecom-Team, @kristian-presso) landed in this release.

🤖 Generated by Max