### PR TITLE
fix(haiku): pass prompt on stdin, not argv — saves of long sessions die with E2BIG

### DIFF
--- a/pipeline/haiku.py
+++ b/pipeline/haiku.py
@@ -97,9 +97,13 @@ def call_haiku(
         RuntimeError: If the subprocess times out or exits with a non-zero
             return code, or if the JSON response cannot be parsed.
     """
+    # Prompt goes on STDIN, not argv: a session extract can exceed Linux's
+    # MAX_ARG_STRLEN (128KB per single argument), which raises E2BIG ("Argument
+    # list too long") at exec time and silently kills saves of long sessions.
+    # `claude -p` with no positional prompt reads the prompt from stdin.
     cmd = [
         "claude",
-        "-p", prompt,
+        "-p",
         "--output-format", "json",
         "--no-session-persistence",
         "--exclude-dynamic-system-prompt-sections",
@@ -116,6 +120,7 @@ def call_haiku(
     try:
         result = subprocess.run(
             cmd,
+            input=prompt,
             capture_output=True,
             text=True,
             # claude emits UTF-8; without this, text=True decodes with the

--- a/tests/test_haiku.py
+++ b/tests/test_haiku.py
@@ -141,6 +141,26 @@ def test_call_haiku_success(mock_run):
 
 
 @patch("pipeline.haiku.subprocess.run")
+def test_call_haiku_sends_prompt_on_stdin_not_argv(mock_run):
+    """The prompt is delivered on STDIN, never as an argv string.
+
+    A session extract can exceed Linux's MAX_ARG_STRLEN (131072 bytes / 128KB
+    per single argument); the old ``claude -p <prompt>`` form fails at exec()
+    with OSError E2BIG ("Argument list too long"), silently losing the save.
+    Guard both halves so the regression can't silently return: the prompt must
+    arrive via ``input=`` and must NOT appear in the command argv (``-p`` is a
+    bare flag, immediately followed by the next option)."""
+    mock_run.return_value = MagicMock(
+        returncode=0, stdout=_mock_claude_response("ok"), stderr="")
+    call_haiku("the full prompt text")
+    args = mock_run.call_args
+    cmd = args[0][0]
+    assert args[1]["input"] == "the full prompt text"
+    assert "the full prompt text" not in cmd
+    assert cmd[cmd.index("-p") + 1] == "--output-format"
+
+
+@patch("pipeline.haiku.subprocess.run")
 def test_call_haiku_strips_parent_session_env(mock_run, monkeypatch):
     """The nested claude -p must not inherit the PARENT Claude Code session
     vars — else it looks like a resumable session to anything keying off them


### PR DESCRIPTION
## Summary
`call_haiku` passes the entire prompt as a single command-line argument (`claude -p <prompt>`). On Linux a single argv string is capped at `MAX_ARG_STRLEN` (131072 bytes = 128 KB = `PAGE_SIZE * 32`). When a session's extract reaches that size, `subprocess.run` fails at `exec()` with `OSError: [Errno 7] Argument list too long`, which surfaces as a `RuntimeError` and the save is lost.

The failure is silent (only a log line) and **permanent for that session** — the extract only grows, so every subsequent save fails the same way. It strikes exactly the sessions a memory tool most wants to capture: long ones, recovery of a missed session, or any accumulated delta over 128 KB.

## Root cause
`pipeline/haiku.py`:
```python
cmd = ["claude", "-p", prompt, ...]      # prompt is one argv string
subprocess.run(cmd, ...)                 # exec() → E2BIG when len(prompt) > 128KB
```

## Reproduction (no API call needed — it fails at exec)
```python
import subprocess
big = "x" * (128 * 1024)
subprocess.run(["/bin/true", big])       # OSError: [Errno 7] Argument list too long
subprocess.run(["/bin/cat"], input=big, text=True)  # fine — stdin has no argv limit
```
Threshold is exact: 131071 bytes argv → ok, 131072 bytes (128 KB) → E2BIG.

## Fix
`claude -p` reads the prompt from **stdin** when no positional prompt is given. Drop the positional and pipe via `input=`:
```python
cmd = ["claude", "-p", "--output-format", "json", ...]   # no positional prompt
subprocess.run(cmd, input=prompt, ...)                    # prompt on stdin, unbounded
```
stdin has no size limit, so prompts of any length deliver. No behavior change for normal-size prompts.

## Testing
- Adds `test_call_haiku_sends_prompt_on_stdin_not_argv` — asserts the prompt is passed via `input=` and is absent from the command argv. It passes on this change and **fails against the old argv form** (the existing tests were blind to it: they checked `cmd[0]` and `env`, never `input=`), so the regression can't silently return. `tests/test_haiku.py` now 31/31.
- Full suite: no new failures vs the pre-change baseline.
- Real-environment: a save whose extract was ~1.9 MB failed with `call-haiku error: [Errno 7] Argument list too long` before the change, and completed normally (Haiku returned a summary, entry written) after it.

## Risk
Minimal. `subprocess.run(..., input=, capture_output=True)` uses `communicate()` internally, so there is no stdin/stdout deadlock. `input` is a `str` consistent with `text=True`/`encoding="utf-8"`.

## Not changed
Scope is the single argv→stdin swap. No change to flags, parsing, env stripping, or token accounting.
