### PR TITLE
fix: stop consolidation/NDC from writing slop into memory files

### DIFF
--- a/pipeline/consolidate.py
+++ b/pipeline/consolidate.py
@@ -32,6 +32,24 @@ from .types import ConsolidationResult, TokenUsage
 _ENTRY_HEADER = re.compile(r"(?m)^## (\d{2}:\d{2}|Week of |\d{4}-\d{2}-\d{2})")
 
 
+def _strip_code_fences(text: str) -> str:
+    """Strip leading/trailing Markdown code-fence lines from a parsed section.
+
+    Haiku sometimes wraps its whole response in a ``` ... ``` block. Left in,
+    a leading fence pushes the real ``# Recent``/``# Archive`` header off the
+    first line, defeating the ``startswith`` check in
+    :func:`parse_consolidation_response` — so a second header gets prepended,
+    producing an orphan-fence + duplicate-heading artifact in the saved file.
+    Removing fence-only lines from both ends makes the header check robust.
+    """
+    lines = text.splitlines()
+    while lines and lines[0].strip().startswith("```"):
+        lines.pop(0)
+    while lines and lines[-1].strip().startswith("```"):
+        lines.pop()
+    return "\n".join(lines).strip()
+
+
 class ConsolidationSkipped(Exception):
     """Raised when Haiku declined (SKIP) or returned non-conforming output.
 
@@ -147,6 +165,10 @@ def parse_consolidation_response(text: str) -> tuple[str, str]:
     else:
         # Fallback: treat entire response as recent
         recent = text.strip()
+
+    # Strip stray code fences before the header check (see _strip_code_fences).
+    recent = _strip_code_fences(recent)
+    archive = _strip_code_fences(archive)
 
     # Ensure headers are present
     if recent and not recent.startswith("# Recent"):

--- a/prompts/compress-ndc.prompt.txt
+++ b/prompts/compress-ndc.prompt.txt
@@ -9,7 +9,7 @@ Apply maximum non-destructive compression. Rules:
 - Preserve ## timestamp | branch format
 - Maintain chronological order — entries must appear oldest to newest
 - Every verb, every object, every causal link must survive
-No preamble. Just the compressed output.
+No preamble, no trailer, no meta-commentary. Never describe, explain, or list your own compression decisions (no "Compression applied" section, no before→after notes, no summary of what you shortened). Output ONLY the compressed entries — nothing about how you produced them.
 
 Text:
 {{NOW_CONTENT}}

--- a/prompts/consolidate-staging.prompt.txt
+++ b/prompts/consolidate-staging.prompt.txt
@@ -36,17 +36,15 @@ Remove the rotated entries from recent.md.
 
 ### Step 3: Identity candidates
 
-If you notice a moment that seems identity-defining, add it at the END of the recent.md section as:
-```
-## Identity Candidates
-- IDENTITY CANDIDATE: [one-line description]
-```
+If you notice a moment that seems identity-defining, add it at the END of the recent.md section as a block of this form (no code fences):
+
+    ## Identity Candidates
+    - IDENTITY CANDIDATE: [one-line description]
 
 ## Output format
 
-Return EXACTLY this structure — no other text, no explanations:
+Return EXACTLY this structure as raw text — nothing before ===RECENT===, nothing after the archive section, no code fences, no explanations:
 
-```
 ===RECENT===
 # Recent
 
@@ -56,12 +54,11 @@ Return EXACTLY this structure — no other text, no explanations:
 # Archive
 
 [archive.md content here]
-```
 
 ## Rules
 
 - NEVER add content that wasn't in the source — you compress, you don't create
 - Keep recent section under 600 tokens total
 - Keep archive section under 400 tokens total
-- Preserve the `# Recent` and `# Archive` headers
+- Output EXACTLY ONE `# Recent` header and ONE `# Archive` header — do not repeat them inside the body
 - Apply non-destructive compression: shortest form preserving meaning. Common: conf, MR, perm, infra, docs, impl, dev, env, app, repo, auth, i18n, EM, entity, refactor.

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -12,6 +12,7 @@ from pipeline.consolidate import (
     parse_consolidation_response,
     consolidate,
     _is_valid_consolidation,
+    _strip_code_fences,
     ConsolidationSkipped,
 )
 from pipeline.types import HaikuResult, TokenUsage, ConsolidationResult
@@ -225,3 +226,36 @@ def test_consolidate_accepts_valid_envelope():
         )
     assert "2026-06-01" in result.recent
     assert "Old" in result.archive
+
+
+def test_parse_strips_wrapping_code_fences():
+    """Regression: Haiku sometimes wraps the whole envelope in a ``` fence.
+
+    Without fence-stripping, the recent section starts with ``` instead of
+    "# Recent", the startswith check fails, and a SECOND "# Recent" header is
+    prepended — producing a duplicate heading + orphan fence in recent.md.
+    """
+    text = (
+        "```\n"
+        "===RECENT===\n"
+        "# Recent\n\n"
+        "## 2026-03-12\nDid stuff.\n\n"
+        "===ARCHIVE===\n"
+        "# Archive\n\n"
+        "## Week of 2026-03-09\nOld stuff.\n"
+        "```"
+    )
+    recent, archive = parse_consolidation_response(text)
+    assert recent.count("# Recent") == 1
+    assert archive.count("# Archive") == 1
+    assert "```" not in recent
+    assert "```" not in archive
+    assert recent.startswith("# Recent")
+    assert archive.startswith("# Archive")
+
+
+def test_strip_code_fences_helper():
+    assert _strip_code_fences("```\n# Recent\n## 2026-03-12\nx\n```") == "# Recent\n## 2026-03-12\nx"
+    assert _strip_code_fences("```markdown\n# Recent\nx") == "# Recent\nx"
+    assert _strip_code_fences("# Recent\nno fences") == "# Recent\nno fences"
+    assert _strip_code_fences("") == ""


### PR DESCRIPTION
## What

Three defects let the Haiku consolidation/NDC pipeline write machine-noise into the long-lived memory files (`recent.md`, daily staging). All three were observed producing real artifacts in a live `~/.remember/` tree.

### 1. NDC compression appends a self-narration trailer
`prompts/compress-ndc.prompt.txt` ended with *"No preamble. Just the compressed output."* — it bans a **preamble** but not a **trailer**, so Haiku obeys literally and appends a `**Compression applied:**` block narrating what it shortened. Fixed by banning trailers/meta-commentary explicitly.

### 2. Consolidation leaks a code fence + a duplicate `# Recent`
- `prompts/consolidate-staging.prompt.txt` showed the required output envelope (and the Step-3 identity-candidate example) **wrapped in ``` code fences**. The model imitates the fence and emits a stray ``` as the first line of its output. Now shown as raw / indented text, with an explicit "no code fences, nothing before/after the delimiters" instruction.
- `pipeline/consolidate.py::parse_consolidation_response` did a naive `recent.startswith("# Recent")` check. With a leading stray fence, the check fails and a **second** `# Recent` is prepended → duplicate heading + orphan fence in `recent.md`. Now strips leading/trailing fence lines first (`_strip_code_fences`).
- Replaced the rule *"Preserve the `# Recent` and `# Archive` headers"* with *"output exactly one of each"* — the template and the parser already supply them; the old wording nudged a duplicate header into the body.

## Tests
Adds regression coverage for fence-wrapped envelopes (`test_parse_strips_wrapping_code_fences`, `test_strip_code_fences_helper`). Full suite: **450 passed, 41 skipped, 98% coverage** (was 448).

## Deliberately *not* changed (FYI)
The `else` fallback in `parse_consolidation_response`, combined with `_is_valid_consolidation` accepting entry-header-only output, can in principle write a delimiter-less response straight to `recent.md`. I left it untouched because your tests at `tests/test_consolidate.py:177-180` and `:135-143` assert this salvage behavior is intentional. Flagging in case the trade-off is worth revisiting — but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
