### PR TITLE
feat: configurable model via REMEMBER_MODEL + refusal reject-gate

### DIFF
--- a/pipeline/haiku.py
+++ b/pipeline/haiku.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import tempfile
 
@@ -52,6 +53,22 @@ def _resolve_max_turns() -> str:
     if raw.isdigit() and 1 <= int(raw) <= MAX_ALLOWED_TURNS:
         return str(int(raw))
     return DEFAULT_MAX_TURNS
+
+
+DEFAULT_MODEL = "haiku"
+
+
+def _resolve_model() -> str:
+    """REMEMBER_MODEL env override, else the safe default ("haiku").
+
+    Memory consolidation is high-stakes (it writes the auto-injected memory
+    layer) but low-complexity (extract + compress). A more capable model
+    (e.g. "sonnet") improves salience and compression-cap compliance with no
+    interactive-latency cost, since this runs backgrounded. Kept as an env knob,
+    consistent with REMEMBER_MAX_TURNS / REMEMBER_TZ / REMEMBER_BRANCH.
+    """
+    raw = os.environ.get("REMEMBER_MODEL", "").strip()
+    return raw if raw else DEFAULT_MODEL
 
 
 def _child_env() -> dict[str, str]:
@@ -107,7 +124,7 @@ def call_haiku(
         "--output-format", "json",
         "--no-session-persistence",
         "--exclude-dynamic-system-prompt-sections",
-        "--model", "haiku",
+        "--model", _resolve_model(),
         "--max-turns", _resolve_max_turns(),
         "--allowedTools", ",".join(tools) if tools else "",
         # Sandbox MCP: no servers + strict, so the nested session inherits none (#94)
@@ -139,6 +156,24 @@ def call_haiku(
         raise RuntimeError(f"claude exited {result.returncode}: {stderr}")
 
     return _parse_response(result.stdout)
+
+
+# Reject-gate: a real memory entry starts with "##" (a header) or is exactly
+# SKIP. Conversational refusals / clarifications must NEVER reach the memory
+# layer (the audit found a model refusal stored verbatim as a memory). Anchored
+# at the START so dense legitimate summaries are never dropped.
+_NON_SUMMARY = re.compile(
+    r"^\s*(i (cannot|can't|can not|won't|will not|am unable|'m unable|"
+    r"don't have|do not have|need (you|the))|could you|do you want|"
+    r"please (provide|paste|share)|there (is|are) no|i'm sorry|sorry[,!]|"
+    r"unfortunately|i notice|it (seems|looks like|appears))",
+    re.I,
+)
+
+
+def _is_non_summary(text: str) -> bool:
+    """True if the output looks like a refusal/clarification, not a summary."""
+    return bool(_NON_SUMMARY.match(text or ""))
 
 
 def _parse_response(raw: str) -> HaikuResult:
@@ -185,7 +220,9 @@ def _parse_response(raw: str) -> HaikuResult:
         text = data.get("result") or ""
         tokens = _extract_tokens(data)
 
-    is_skip = text.strip().upper().startswith("SKIP")
+    # Drop SKIP (model found nothing worth saving) AND refusals/clarifications
+    # (the reject-gate) so neither is ever written to the memory layer.
+    is_skip = text.strip().upper().startswith("SKIP") or _is_non_summary(text)
 
     return HaikuResult(text=text, tokens=tokens, is_skip=is_skip)
 

--- a/tests/test_haiku.py
+++ b/tests/test_haiku.py
@@ -113,7 +113,8 @@ def test_parse_response_headerless_summary():
 
 
 @patch("pipeline.haiku.subprocess.run")
-def test_call_haiku_success(mock_run):
+def test_call_haiku_success(mock_run, monkeypatch):
+    monkeypatch.delenv("REMEMBER_MODEL", raising=False)  # assert the default model
     mock_run.return_value = MagicMock(
         returncode=0,
         stdout=_mock_claude_response("hello from haiku"),
@@ -311,3 +312,61 @@ def test_extract_tokens_nested_wins_over_flat():
     assert t.input == 42
     assert t.output == 7
     assert t.cache == 3
+
+
+# --- REMEMBER_MODEL env knob (mirrors REMEMBER_MAX_TURNS) --------------------
+from pipeline.haiku import _resolve_model
+
+
+def test_resolve_model_default(monkeypatch):
+    monkeypatch.delenv("REMEMBER_MODEL", raising=False)
+    assert _resolve_model() == "haiku"
+
+
+def test_resolve_model_env_override(monkeypatch):
+    monkeypatch.setenv("REMEMBER_MODEL", "sonnet")
+    assert _resolve_model() == "sonnet"
+
+
+def test_resolve_model_blank_falls_back(monkeypatch):
+    monkeypatch.setenv("REMEMBER_MODEL", "   ")
+    assert _resolve_model() == "haiku"
+
+
+@patch("pipeline.haiku.subprocess.run")
+def test_call_haiku_uses_resolved_model(mock_run, monkeypatch):
+    monkeypatch.setenv("REMEMBER_MODEL", "sonnet")
+    mock_run.return_value = MagicMock(returncode=0, stdout=_mock_claude_response("x"), stderr="")
+    call_haiku("p")
+    cmd = mock_run.call_args[0][0]
+    assert cmd[cmd.index("--model") + 1] == "sonnet"
+
+
+# --- reject-gate: refusals/clarifications never reach memory -----------------
+@pytest.mark.parametrize("refusal", [
+    "I cannot and will not invent timestamps or fabricate session details. Do you want to:",
+    "I can't summarize without the actual session text.",
+    "Could you paste the session text you want summarized?",
+    "Please provide the conversation to summarize.",
+    "I'm sorry, there is no content to summarize.",
+])
+def test_parse_response_rejects_refusal(refusal):
+    """A model refusal/clarification must be treated as skip so it is never
+    written to the memory layer (it was, historically: a refusal stored
+    verbatim as a memory entry)."""
+    result = _parse_response(_mock_claude_response(refusal))
+    assert result.is_skip is True
+
+
+@pytest.mark.parametrize("good", [
+    "## 10:30 | main\nFixed auth bug; deployed staging.",
+    "Fixed authentication bug in login flow and deployed to staging",
+    "[HUMAN] hello\n[ASSISTANT] hi there",
+    "===RECENT===\n# Recent\n## 2026-06-22 did things",
+])
+def test_parse_response_keeps_real_summaries(good):
+    """The reject-gate is anchored at the start and must not drop legitimate
+    summaries, including the headerless / raw-echo cases _parse_response is
+    deliberately permissive about (format validation stays the shell's job)."""
+    result = _parse_response(_mock_claude_response(good))
+    assert result.is_skip is False


### PR DESCRIPTION
## What

Two small, backward-compatible additions to `pipeline/haiku.py` (the single model call site):

**1. `REMEMBER_MODEL` env knob** (default `haiku`, behavior unchanged). Point summarization/consolidation at a more capable tier without editing code, mirroring the existing `REMEMBER_MAX_TURNS` / `REMEMBER_TZ` / `REMEMBER_BRANCH` env pattern:

```json
"env": { "REMEMBER_MODEL": "sonnet" }
```

**2. Reject-gate in `_parse_response`.** Output that begins like a refusal or clarification (`I cannot...`, `Could you...`, `Please paste...`) is treated as `SKIP` and never written to the memory layer.

## Why

Consolidation writes the auto-injected `recent.md` / `archive.md`. On real sessions I compared the current `haiku` against `sonnet` using the plugin's exact invocation and real prompt templates:

| axis | haiku | sonnet |
|---|---|---|
| compression caps (recent<600 / archive<400 tok) | busted archive ~3-4x | complied |
| salience under noise (a real fact buried in a poisoned staging file) | dropped the whole entry | preserved the fact, dropped the refusal |
| format | added a stray code fence | clean |

The cost delta (~3.6x) is negligible in absolute terms, and the call is backgrounded, so there is no interactive-latency cost.

The reject-gate addresses a real failure: a model refusal (`I cannot and will not invent timestamps... Do you want to:`) was stored verbatim as a memory entry. It sits next to the existing `SKIP` detection because both signal "no usable entry", and it is anchored at the start of the output, so the headerless-summary and raw-conversation-echo cases `_parse_response` is deliberately permissive about are unaffected. **If you would prefer the refusal check in the shell/consumer layer** (per the `test_parse_response_headerless_summary` / `_raw_conversation_echo` "format validation is the shell's job" intent), I am happy to move it.

## Tests

Added to `tests/test_haiku.py`: `REMEMBER_MODEL` default / override / blank-fallback, cmd uses the resolved model, and reject-gate cases (keeps real summaries including the headerless + echo cases; drops refusals). Env-isolated the existing `test_call_haiku_success`. Full `tests/test_haiku.py` green; no regressions in `shell` / `types` / `consolidate`.

Happy to split into two PRs (env knob / reject-gate) if you prefer.
