### PR TITLE
docs: clarify first-backup tracks only config, memory lands on next /remember

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ git commit -m "init: remember config"
 git push -u origin main
 ```
 
+> **Note:** This first commit only tracks `.gitignore` and `config.json` — there's no memory in the backup yet. Per-project slug directories aren't tracked until the `after_save` hook runs after your next `/remember`. To confirm backup is working, run `/remember` once, then check `cd ~/.remember && git log` for an automatic commit. (If you already have memory to commit now, `git add <slug>/` it explicitly before the first push.)
+
 #### Automatic commits
 
 Once `~/.remember/` is a git repo, the `after_save` hook commits each project's memory subdir on its own schedule — one commit per project save, throttled by `cooldowns.git_backup_seconds` (default 15 min) — and pushes to your configured remote. No further setup is needed beyond credential availability (SSH agent or git credential helper) in the environment Claude Code launches hooks in.


### PR DESCRIPTION
Closes #65.

The "Back up your memory" snippet ends with `git add .gitignore config.json` + push. A first-time user runs it, pushes, and finds no memory in the backup — slug dirs aren't tracked until the `after_save` hook fires after the next `/remember`.

Added a note after the snippet covering all three asks from #65:
- initial commit only tracks `.gitignore` / `config.json`
- per-project slug dirs land automatically via the `after_save` hook on next `/remember`
- verify via `cd ~/.remember && git log`
- plus the optional `git add <slug>/` for existing memory

Docs-only, 2 lines.