### PR TITLE
fix: emit === HANDOFF === hint only in external mode

### DIFF
--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -99,10 +99,14 @@ REMEMBER_NOW="$REMEMBER_DIR/now.md"
 REMEMBER_TODAY_FILE="$REMEMBER_DIR/today-${TODAY}.md"
 
 # ── Handoff path hint (consumed by the /remember skill) ───────────────────
-# Emitted unconditionally so the skill always knows the correct write target.
-echo "=== HANDOFF ==="
-echo "Write next handoff to: $REMEMBER_HANDOFF"
-echo ""
+# Emitted only in external mode. In legacy mode REMEMBER_HANDOFF resolves to
+# {project}/.remember/remember.md — the exact path the skill defaults to when
+# no === HANDOFF === block is present, so the hint would be pure noise.
+if [ "$REMEMBER_ROOT" != "$PROJECT_DIR" ]; then
+    echo "=== HANDOFF ==="
+    echo "Write next handoff to: $REMEMBER_HANDOFF"
+    echo ""
+fi
 
 # ── Last handoff (injected FIRST so it survives context-preview truncation) ─
 # The session-start output can be large; the harness may deliver only a leading

--- a/tests/test_external_data_dir.py
+++ b/tests/test_external_data_dir.py
@@ -181,6 +181,42 @@ class TestHandoffEmission:
             f"handoff path does not reference external base.\noutput: {output}\nstderr: {result.stderr[:300]}"
         )
 
+    def test_session_start_suppresses_handoff_block_in_legacy_mode(self, tmp_path):
+        """In legacy mode the === HANDOFF === hint is noise — the /remember skill
+        falls back to {project}/.remember/remember.md, the exact path the hint
+        would carry. Suppress it. The === LAST HANDOFF === block (file-gated) is
+        unaffected and not asserted here.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        home = tmp_path / "home"
+        (home / ".remember").mkdir(parents=True)
+
+        # Legacy mode: relative data_dir resolves to {project}/.remember,
+        # so REMEMBER_ROOT == PROJECT_DIR.
+        (home / ".remember" / "config.json").write_text(
+            json.dumps({"data_dir": ".remember", "features": {"recovery": False}})
+        )
+
+        slug = _slug(str(project))
+        sessions_dir = home / ".claude" / "projects" / slug
+        sessions_dir.mkdir(parents=True)
+
+        env = {
+            **os.environ,
+            "CLAUDE_PROJECT_DIR": str(project),
+            "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
+            "HOME": str(home),
+        }
+        result = subprocess.run(
+            ["bash", str(SESSION_START_SCRIPT)], env=env, capture_output=True, text=True
+        )
+        output = result.stdout
+
+        assert "=== HANDOFF ===" not in output, (
+            f"=== HANDOFF === hint should be suppressed in legacy mode.\noutput: {output}\nstderr: {result.stderr[:300]}"
+        )
+
 
 class TestIdentityFallback:
 


### PR DESCRIPTION
## Context

Implements #61. `session-start-hook.sh` emitted the `=== HANDOFF ===` write-target hint unconditionally. In legacy mode `REMEMBER_HANDOFF` resolves to `{project}/.remember/remember.md` — the exact path the `/remember` skill already falls back to when no block is present (`SKILL.md:9`). So in legacy mode the hint was pure noise.

## Change

- Gate the hint on the existing external-mode predicate `[ "$REMEMBER_ROOT" != "$PROJECT_DIR" ]` (same test already used for identity tiering at line 88 — one definition of "external", no drift).
- External mode: unchanged. Legacy mode: hint suppressed, skill fallback handles it.
- `README.md:269` already described this as external-only behavior, so docs now match code. No README change needed; the issue's "document the noise" alternative is moot.

## Tests

- Added `test_session_start_suppresses_handoff_block_in_legacy_mode` (negative case). Proven red before the fix, green after.
- Full suite: 481 passed, 41 skipped, 98.48% coverage.

Closes #61