### PR TITLE
Bound consolidation prompt size to prevent context-window overflow (#122)

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -8,7 +8,8 @@
   "thresholds": {
     "min_human_messages": 3,
     "delta_lines_trigger": 50,
-    "extract_max_bytes": 300000
+    "extract_max_bytes": 300000,
+    "consolidate_max_bytes": 600000
   },
   "features": {
     "ndc_compression": true,
@@ -20,6 +21,15 @@
   "reject_pattern": "",
 
   "_comments": {
+    "consolidate_max_bytes": [
+      "Skip-guard cap (UTF-8 bytes) on the assembled consolidation prompt",
+      "(staging + recent.md + archive.md). Default 600000. If the prompt would",
+      "exceed this, consolidation SKIPS that run (staging + memory left intact)",
+      "rather than overflowing Haiku's window with 'Prompt is too long' and",
+      "stalling all saves. Unlike extract_max_bytes the input is NOT truncated,",
+      "because consolidation rewrites recent/archive and truncating would drop",
+      "archived memory. Set 0 to disable the guard."
+    ],
     "model": [
       "Model for the summarize/consolidate calls (claude -p). Default 'haiku'.",
       "Set 'sonnet' (or another tier) to improve salience + compression-cap",

--- a/pipeline/consolidate.py
+++ b/pipeline/consolidate.py
@@ -41,6 +41,17 @@ class ConsolidationSkipped(Exception):
     """
 
 
+class ConsolidationTooLarge(ConsolidationSkipped):
+    """Raised when the assembled prompt exceeds ``max_prompt_bytes``.
+
+    Subclass of ConsolidationSkipped so existing ``except ConsolidationSkipped``
+    handlers keep their "leave everything untouched" behavior unchanged. Callers
+    that CAN shrink the input (e.g. rotate archive.md to a dated sibling and
+    retry with a fresh archive) may catch this subclass specifically to recover
+    instead of skipping forever.
+    """
+
+
 def _is_valid_consolidation(text: str) -> bool:
     """Return True only if the model output is real consolidated memory.
 
@@ -69,6 +80,7 @@ def consolidate(
     staging_contents: dict[str, str],
     recent: str,
     archive: str,
+    max_prompt_bytes: int = 0,
 ) -> ConsolidationResult:
     """Run full consolidation: build prompt, call Haiku, parse response.
 
@@ -77,16 +89,37 @@ def consolidate(
             staging file to consolidate.
         recent: Current content of recent.md (may be empty).
         archive: Current content of archive.md (may be empty).
+        max_prompt_bytes: Upper bound on the assembled prompt's UTF-8 byte
+            size. ``0`` disables the guard. When the prompt would exceed the
+            bound, consolidation is SKIPPED (not truncated) -- see below.
 
     Returns:
         ConsolidationResult with new recent/archive content and token usage.
 
     Raises:
         RuntimeError: If the Haiku call fails or times out.
-        ConsolidationSkipped: If the model declined (SKIP) or returned
+        ConsolidationSkipped: If the assembled prompt exceeds
+            ``max_prompt_bytes``, or the model declined (SKIP) or returned
             non-conforming output. The caller must not write or retire files.
     """
     prompt = build_consolidation_prompt(staging_contents, recent, archive)
+
+    # Oversized-prompt guard. Mirrors the save path's extract_max_bytes cap
+    # (build-prompt), but SKIPS instead of truncating: consolidation rewrites
+    # recent.md/archive.md, so tail-truncating the input would feed the model a
+    # partial archive and permanently drop the dropped head on the next write.
+    # Skipping leaves staging + memory untouched (handled by the caller's
+    # ConsolidationSkipped path) -- strictly better than firing a doomed call
+    # that fails with "Prompt is too long" and stalls every subsequent save.
+    if max_prompt_bytes > 0:
+        prompt_bytes = len(prompt.encode("utf-8"))
+        if prompt_bytes > max_prompt_bytes:
+            raise ConsolidationTooLarge(
+                f"consolidation prompt too large ({prompt_bytes} bytes > "
+                f"{max_prompt_bytes} cap) -- skipping to avoid a context-window "
+                f"overflow; staging + memory left untouched"
+            )
+
     result = call_haiku(prompt, timeout=180)
 
     # Guard: never let a SKIP or a conversational reply overwrite memory.

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -252,7 +252,32 @@ def cmd_save_position(last_save_file: str, session_id: str, position: int) -> No
         json.dump({"session": session_id, "line": position}, f)
 
 
-def cmd_consolidate(staging_dir: str, recent_file: str, archive_file: str) -> None:
+def _rotate_archive(archive_file: str) -> str | None:
+    """Rename a non-empty archive.md to a dated sibling so consolidation can
+    proceed with a fresh archive instead of stalling forever on an archive that
+    has grown past the prompt cap.
+
+    Returns the rotated path (e.g. ``archive-2026-06-29.md``, with a ``-N``
+    suffix on same-day collisions), or ``None`` when there is nothing worth
+    rotating (missing/empty archive -> the oversized bulk is staging/recent, not
+    the archive, so rotating would not help).
+    """
+    if not archive_file or not os.path.exists(archive_file) or os.path.getsize(archive_file) == 0:
+        return None
+    from ._tz import today_str
+    parent = os.path.dirname(archive_file)
+    stem = f"archive-{today_str()}"
+    target = os.path.join(parent, f"{stem}.md")
+    n = 2
+    while os.path.exists(target):
+        target = os.path.join(parent, f"{stem}-{n}.md")
+        n += 1
+    os.rename(archive_file, target)
+    return target
+
+
+def cmd_consolidate(staging_dir: str, recent_file: str, archive_file: str,
+                    max_prompt_bytes: int = 0) -> None:
     """Run the full consolidation pipeline and print shell variables.
 
     Collects staging files (excluding today's and ``.done`` files), reads
@@ -263,6 +288,9 @@ def cmd_consolidate(staging_dir: str, recent_file: str, archive_file: str) -> No
         staging_dir: Directory containing ``today-*.md`` staging files.
         recent_file: Path to the current recent.md file.
         archive_file: Path to the current archive.md file.
+        max_prompt_bytes: Skip-guard cap on the assembled consolidation
+            prompt's UTF-8 byte size. ``0`` disables it. An oversized prompt
+            yields ``CONSOLIDATION_STATUS=skip`` instead of overflowing.
 
     Prints:
         STAGING_COUNT (0 if nothing to consolidate), RECENT_OUT and
@@ -274,7 +302,7 @@ def cmd_consolidate(staging_dir: str, recent_file: str, archive_file: str) -> No
     import tempfile
 
     from ._tz import today_str
-    from .consolidate import consolidate, ConsolidationSkipped
+    from .consolidate import consolidate, ConsolidationSkipped, ConsolidationTooLarge
 
     today = today_str()
 
@@ -301,16 +329,40 @@ def cmd_consolidate(staging_dir: str, recent_file: str, archive_file: str) -> No
         with open(archive_file, encoding="utf-8", errors="replace") as f:
             archive = f.read()
 
-    try:
-        result = consolidate(staging_contents, recent, archive)
-    except ConsolidationSkipped:
-        # Model declined (SKIP) or returned non-conforming output. Emit a
-        # skip status so the shell leaves recent.md/archive.md untouched and
-        # does NOT rename the source staging files to .done.md — they remain
-        # available for the next run. STAGING_COUNT is non-zero (we did find
-        # files) but the shell gates on CONSOLIDATION_STATUS.
+    def _emit_skip() -> None:
+        # Skip status so the shell leaves recent.md/archive.md untouched and does
+        # NOT rename the source staging files to .done.md — they remain available
+        # for the next run. STAGING_COUNT is non-zero (we found files) but the
+        # shell gates on CONSOLIDATION_STATUS.
         print(f"STAGING_COUNT={len(staging_contents)}")
         print("CONSOLIDATION_STATUS=skip")
+
+    try:
+        result = consolidate(staging_contents, recent, archive,
+                             max_prompt_bytes=max_prompt_bytes)
+    except ConsolidationTooLarge:
+        # archive.md is the bulk of the oversized prompt. Rotate it to a dated
+        # sibling (memory preserved in cold storage) and retry once with a fresh
+        # empty archive, so consolidation keeps progressing instead of skipping
+        # every run forever. If there is nothing to rotate, or the retry still
+        # overflows (staging + recent alone exceed the cap), restore and skip.
+        rotated = _rotate_archive(archive_file)
+        if rotated is None:
+            _emit_skip()
+            return
+        try:
+            result = consolidate(staging_contents, recent, "",
+                                 max_prompt_bytes=max_prompt_bytes)
+        except ConsolidationSkipped:
+            os.replace(rotated, archive_file)  # still too big -> undo, skip
+            _emit_skip()
+            return
+        except Exception:
+            os.replace(rotated, archive_file)  # retry errored -> undo, re-raise
+            raise
+    except ConsolidationSkipped:
+        # Model declined (SKIP) or returned non-conforming output.
+        _emit_skip()
         return
 
     # Write results to temp files
@@ -388,6 +440,7 @@ def main() -> None:
             staging_dir=sys.argv[2],
             recent_file=sys.argv[3],
             archive_file=sys.argv[4],
+            max_prompt_bytes=int(sys.argv[5]) if len(sys.argv) > 5 else 0,
         )
     else:
         print(f"Unknown command: {cmd}", file=sys.stderr)

--- a/scripts/run-consolidation.sh
+++ b/scripts/run-consolidation.sh
@@ -64,8 +64,11 @@ dispatch "before_consolidate"
 # --- Consolidate ---
 # Python does: find staging files, read all content, build prompt,
 # call Haiku (text-only), parse structured response into recent/archive.
+# Oversized-prompt skip-guard: cap the assembled prompt so a runaway staging/
+# archive never overflows Haiku's window (skips cleanly instead of crashing).
+CONSOLIDATE_MAX_BYTES=$(config ".thresholds.consolidate_max_bytes" 600000)
 log "consolidation" "start"
-RESULT=$(cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell consolidate "$STAGING_DIR" "$RECENT_FILE" "$ARCHIVE_FILE" 2>&1) || {
+RESULT=$(cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell consolidate "$STAGING_DIR" "$RECENT_FILE" "$ARCHIVE_FILE" "$CONSOLIDATE_MAX_BYTES" 2>&1) || {
     log "consolidation" "ERROR: pipeline failed — $RESULT"
     exit 1
 }

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -13,6 +13,7 @@ from pipeline.consolidate import (
     consolidate,
     _is_valid_consolidation,
     ConsolidationSkipped,
+    ConsolidationTooLarge,
 )
 from pipeline.types import HaikuResult, TokenUsage, ConsolidationResult
 
@@ -225,3 +226,46 @@ def test_consolidate_accepts_valid_envelope():
         )
     assert "2026-06-01" in result.recent
     assert "Old" in result.archive
+
+
+# --- Oversized-prompt guard (consolidation parity with the save-path cap) ---
+
+def test_consolidate_skips_when_prompt_exceeds_cap():
+    """An assembled prompt over max_prompt_bytes must skip BEFORE calling Haiku.
+
+    Mirrors the save path's extract_max_bytes cap, but skips (not truncates)
+    because consolidation rewrites recent/archive - truncating the input would
+    permanently drop archived memory. The skip leaves staging + memory untouched.
+    """
+    huge_staging = {"today-2026-01-01.md": "x" * 5000}
+    with patch("pipeline.consolidate.call_haiku") as mock_haiku:
+        with pytest.raises(ConsolidationTooLarge) as exc:
+            consolidate(huge_staging, recent="", archive="", max_prompt_bytes=1000)
+    # subclass of ConsolidationSkipped so existing handlers keep working
+    assert isinstance(exc.value, ConsolidationSkipped)
+    mock_haiku.assert_not_called()  # never fire a doomed context-overflow call
+
+
+def test_consolidate_proceeds_when_under_cap():
+    """Under the cap, consolidation proceeds normally and calls Haiku once."""
+    ok = HaikuResult(
+        text="===RECENT===\n# Recent\n\n## 2026-01-01\nwork\n\n===ARCHIVE===\n# Archive\n",
+        tokens=TokenUsage(input=10, output=5, cache=0, cost_usd=0.0),
+    )
+    with patch("pipeline.consolidate.call_haiku", return_value=ok) as mock_haiku:
+        res = consolidate({"today-2026-01-01.md": "small"}, recent="", archive="",
+                          max_prompt_bytes=10_000_000)
+    mock_haiku.assert_called_once()
+    assert res.recent.startswith("# Recent")
+
+
+def test_consolidate_no_cap_by_default():
+    """max_prompt_bytes defaults to 0 = disabled, preserving prior behavior."""
+    ok = HaikuResult(
+        text="===RECENT===\n# Recent\n\n## 2026-01-01\nx\n\n===ARCHIVE===\n# Archive\n",
+        tokens=TokenUsage(input=10, output=5, cache=0, cost_usd=0.0),
+    )
+    big_staging = {"today-2026-01-01.md": "x" * 50000}
+    with patch("pipeline.consolidate.call_haiku", return_value=ok) as mock_haiku:
+        consolidate(big_staging, recent="", archive="")  # no cap arg -> uncapped
+    mock_haiku.assert_called_once()

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -373,6 +373,100 @@ def test_cmd_consolidate_skip_emits_status_and_no_output_paths(capsys):
         assert "STAGING_PATHS_FILE=" not in output
 
 
+# --- cmd_consolidate: oversized-archive rotation (deeper fix) ---
+
+def _valid_envelope():
+    return HaikuResult(
+        text="===RECENT===\n# Recent\n\n## 2020-01-01\nx\n\n===ARCHIVE===\n# Archive\n",
+        tokens=TokenUsage(input=10, output=5, cache=0, cost_usd=0.0),
+    )
+
+
+def test_cmd_consolidate_rotates_oversized_archive_then_succeeds(capsys):
+    """When archive.md is the oversized bulk, rotate it aside and retry once with
+    a fresh archive so consolidation proceeds (memory preserved in the sibling)."""
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, "today-2020-01-01.md"), "w") as f:
+            f.write("small entry")
+        recent_file = os.path.join(d, "recent.md")
+        open(recent_file, "w").close()
+        archive_file = os.path.join(d, "archive.md")
+        with open(archive_file, "w") as f:
+            f.write("OLD ARCHIVE " + "x" * 500_000)  # > 300 KB cap
+
+        with patch("pipeline.consolidate.call_haiku", return_value=_valid_envelope()) as mock_haiku:
+            cmd_consolidate(d, recent_file, archive_file, max_prompt_bytes=300_000)
+
+        output = capsys.readouterr().out
+        assert "CONSOLIDATION_STATUS=ok" in output
+        assert "ARCHIVE_OUT=" in output
+        mock_haiku.assert_called_once()  # only the post-rotation retry calls Haiku
+        # original archive.md was rotated to a dated sibling, content preserved
+        rotated = [n for n in os.listdir(d) if n.startswith("archive-") and n.endswith(".md")]
+        assert rotated, "archive.md should have been rotated to archive-<date>.md"
+        assert "OLD ARCHIVE" in open(os.path.join(d, rotated[0])).read()
+        for key, path in _consolidate_output_paths(output).items():
+            if os.path.exists(path):
+                os.unlink(path)
+
+
+def test_cmd_consolidate_oversized_no_archive_skips(capsys):
+    """Oversized with no archive to rotate (staging itself is the bulk) -> skip."""
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, "today-2020-01-01.md"), "w") as f:
+            f.write("x" * 500_000)  # staging alone exceeds the cap
+        archive_file = os.path.join(d, "archive.md")  # does not exist
+
+        with patch("pipeline.consolidate.call_haiku") as mock_haiku:
+            cmd_consolidate(d, "/nonexistent", archive_file, max_prompt_bytes=300_000)
+
+        output = capsys.readouterr().out
+        assert "CONSOLIDATION_STATUS=skip" in output
+        assert "ARCHIVE_OUT=" not in output
+        mock_haiku.assert_not_called()
+        assert not any(n.startswith("archive-") for n in os.listdir(d))
+
+
+def test_cmd_consolidate_restores_archive_when_retry_still_too_large(capsys):
+    """If even an empty archive doesn't fit (staging + recent too big), undo the
+    rotation so the original archive.md is left intact, then skip."""
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, "today-2020-01-01.md"), "w") as f:
+            f.write("x" * 500_000)  # staging alone already exceeds the cap
+        archive_file = os.path.join(d, "archive.md")
+        with open(archive_file, "w") as f:
+            f.write("OLD ARCHIVE CONTENT")
+
+        with patch("pipeline.consolidate.call_haiku") as mock_haiku:
+            cmd_consolidate(d, "/nonexistent", archive_file, max_prompt_bytes=300_000)
+
+        output = capsys.readouterr().out
+        assert "CONSOLIDATION_STATUS=skip" in output
+        mock_haiku.assert_not_called()
+        # rotation undone: archive.md intact, no orphan sibling left behind
+        assert open(archive_file).read() == "OLD ARCHIVE CONTENT"
+        assert not any(n.startswith("archive-") for n in os.listdir(d))
+
+
+def test_cmd_consolidate_restores_archive_when_retry_errors():
+    """If the post-rotation retry's Haiku call errors, restore archive.md and
+    re-raise so no state is lost on a transient failure."""
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, "today-2020-01-01.md"), "w") as f:
+            f.write("small entry")
+        archive_file = os.path.join(d, "archive.md")
+        with open(archive_file, "w") as f:
+            f.write("OLD ARCHIVE " + "x" * 500_000)  # > cap, will trigger rotation
+
+        with patch("pipeline.consolidate.call_haiku", side_effect=RuntimeError("api down")):
+            with pytest.raises(RuntimeError):
+                cmd_consolidate(d, "/nonexistent", archive_file, max_prompt_bytes=300_000)
+
+        # archive restored, no orphan sibling left behind
+        assert open(archive_file).read().startswith("OLD ARCHIVE")
+        assert not any(n.startswith("archive-") for n in os.listdir(d))
+
+
 def test_cmd_consolidate_staging_paths_file_handles_special_chars(capsys):
     """STAGING_PATHS_FILE correctly encodes filenames with single quotes and spaces."""
     fake_tokens = TokenUsage(input=10, output=5, cache=0, cost_usd=0.0)
@@ -685,6 +779,20 @@ def test_main_dispatches_consolidate():
         staging_dir="/staging",
         recent_file="recent.md",
         archive_file="archive.md",
+        max_prompt_bytes=0,  # absent 6th arg -> guard disabled
+    )
+
+
+def test_main_dispatches_consolidate_with_max_bytes():
+    """The optional 6th arg sets the oversized-prompt skip-guard cap."""
+    with patch("pipeline.shell.cmd_consolidate") as mock_fn:
+        with patch("sys.argv", ["shell.py", "consolidate", "/staging", "recent.md", "archive.md", "600000"]):
+            main()
+    mock_fn.assert_called_once_with(
+        staging_dir="/staging",
+        recent_file="recent.md",
+        archive_file="archive.md",
+        max_prompt_bytes=600000,
     )
 
 


### PR DESCRIPTION
Fixes #122.

## Problem

#96 (v0.8.2) capped the **save** path (`extract_max_bytes` → `cmd_build_prompt`), but the **consolidation** path still inlines the full staging set + `recent.md` + `archive.md` into one prompt and calls Haiku with no size check. A large input overflows the model window (`Prompt is too long`); `run-consolidation.sh` logs `ERROR` and exits 1, so daily rotation halts — and it is self-reinforcing, since staging is not retired and re-feeds identically next run (the #96 failure mode, one path over). Observed as 57 crashed `sdk-cli` sessions carrying the consolidation system prompt on one machine.

## Change

**1. Skip-guard (the direct #122 fix).** New `thresholds.consolidate_max_bytes` (default `600000`, `0` disables), threaded `run-consolidation.sh` → `cmd_consolidate` → `consolidate()`, mirroring how `extract_max_bytes` reaches `cmd_build_prompt`. When the assembled prompt would exceed the cap, consolidation **skips** rather than truncates — because consolidation *rewrites* `recent.md`/`archive.md`, so truncating the input would feed a partial archive and permanently drop the dropped head on the next write. `ConsolidationTooLarge` subclasses `ConsolidationSkipped`, so every existing `except ConsolidationSkipped` handler behaves identically.

**2. Archive rotation (the deeper follow-up noted in #122).** A plain skip prevents the crash but means a project whose `archive.md` has grown past the cap stops consolidating. So when `archive.md` is the oversized bulk, `cmd_consolidate` rotates it to a dated sibling (`archive-YYYY-MM-DD.md`, cold storage — no memory lost) and retries once with a fresh archive, so consolidation keeps progressing. If there is nothing to rotate, or the retry still overflows, or the retry's Haiku call errors, the rotation is undone and the original state is left intact.

I'm happy to **split these into two PRs** (cap first, rotation second) if you'd prefer to land the minimal #122 fix on its own — just say the word.

## Tests

- `tests/test_consolidate.py`: oversized prompt raises `ConsolidationTooLarge` (and is-a `ConsolidationSkipped`) with `call_haiku` never called; under-cap proceeds; `max_prompt_bytes=0` preserves prior behavior.
- `tests/test_shell.py`: dispatch passes the new arg; rotation-then-success; nothing-to-rotate → skip; retry-still-too-large → restore + skip; retry-errors → restore + re-raise.

Full suite green locally (py3.12): **494 passed, 41 skipped**. (One pre-existing failure, `test_bsd_mktemp_no_randomization_with_extension`, is a macOS host-`mktemp` assertion unrelated to this change and untouched by it; it passes on Linux CI.) End-to-end: `pipeline.shell consolidate` on a 1.6 MB staging file with a 600 KB cap prints `CONSOLIDATION_STATUS=skip`, exit 0, never spawning `claude`; and an oversized-archive run rotates then restores `archive.md` byte-for-byte when the retry can't reach the model.

Opened as a **draft** for your review.
