### PR TITLE
fix: key memory to the main checkout for git worktree sessions (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Worktree sessions built a throwaway memory that vanished on cleanup** ([#56](https://github.com/Digital-Process-Tools/claude-remember/issues/56)) — the plugin derives `REMEMBER_DIR` from `CLAUDE_PROJECT_DIR`, which Claude Code sets to the *worktree* path for worktree sessions. In the default (legacy) layout that put memory at `<worktree>/.remember` — physically inside the worktree, and gitignored with `*`, so a plain `git worktree remove` (no `--force`, no warning) deleted every `now.md` / `today-*.md` / `remember.md` built up during the session, and none of it was ever migrated to the main checkout. In external mode the `{slug}` was computed from the worktree path, producing an orphaned `~/.remember/<slug-of-worktree>` subtree the main checkout's sessions never loaded. `REMEMBER_DIR` resolution now routes through git's *common dir*: when `PROJECT_DIR` is a linked worktree, memory is keyed to the main checkout, so it survives `worktree remove` and is shared across all worktrees of the repo. `PROJECT_DIR` itself is left untouched (session recovery still resolves transcripts under the worktree slug), and non-worktree / non-git projects behave exactly as before. Reported and diagnosed by [@KrzysztofKasprowicz](https://github.com/Digital-Process-Tools/claude-remember/issues/56) and [@dewet22](https://github.com/Digital-Process-Tools/claude-remember/issues/56).
+
 ## [0.8.4] — Bound consolidation prompt size so a huge archive can't stall saves
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -315,6 +315,15 @@ Once `~/.remember/` is a git repo, the `after_save` hook commits each project's 
 
 If you don't want automatic commits, leave `~/.remember/` as a plain directory and commit manually as before.
 
+## Git worktrees
+
+Claude Code sets `CLAUDE_PROJECT_DIR` to the *worktree* path for sessions started inside a [git worktree](https://git-scm.com/docs/git-worktree). Memory is deliberately **not** kept in the worktree — it is keyed to the repository's **main checkout** instead, so that:
+
+- it survives `git worktree remove` (a worktree-local `.remember/` would be deleted with the worktree — silently, since it is gitignored with `*`), and
+- every worktree of the same repo shares one continuous memory rather than a separate throwaway one.
+
+Concretely, `REMEMBER_DIR` resolves through git's *common dir*: in legacy mode it lands in `<main-checkout>/.remember/`, and in external mode the `{slug}` is computed from the main checkout, so all worktrees map to the same `~/.remember/<slug>/`. Only the memory location is redirected — `CLAUDE_PROJECT_DIR` is left as the worktree path, so session recovery still finds transcripts where Claude Code stored them. Non-worktree checkouts and non-git projects are unaffected.
+
 ## Running tests
 
 ```bash

--- a/scripts/bootstrap-dirs.sh
+++ b/scripts/bootstrap-dirs.sh
@@ -36,8 +36,11 @@ unset _BOOTSTRAP_SCRIPT_DIR
 # --- System temp directory (portable: macOS, Linux, Windows/Git Bash) ---
 SYS_TMPDIR="${TMPDIR:-/tmp}"
 
-# --- One-shot migration: legacy ${PROJECT_DIR}/.remember → external REMEMBER_DIR ---
-_legacy_dir="${PROJECT_DIR}/.remember"
+# --- One-shot migration: legacy .remember → external REMEMBER_DIR ---
+# Keyed to MEMORY_PROJECT_DIR (the main checkout when in a worktree) so the
+# legacy dir we migrate/gitignore matches where REMEMBER_DIR now resolves.
+_mem_proj="${MEMORY_PROJECT_DIR:-$PROJECT_DIR}"
+_legacy_dir="${_mem_proj}/.remember"
 if [ "$REMEMBER_DIR" != "$_legacy_dir" ] && [ -d "$_legacy_dir" ] && [ ! -e "$REMEMBER_DIR" ]; then
     mkdir -p "$(dirname "$REMEMBER_DIR")" 2>/dev/null
     if mv "$_legacy_dir" "$REMEMBER_DIR" 2>/dev/null; then
@@ -60,10 +63,11 @@ mkdir -p \
 # to write — the user manages that tree themselves (typically as a private git
 # repo at ~/.remember/).
 case "$REMEMBER_DIR" in
-    "$PROJECT_DIR"/*)
+    "$_mem_proj"/*)
         [ -f "$REMEMBER_DIR/.gitignore" ] || echo '*' > "$REMEMBER_DIR/.gitignore" 2>/dev/null
         ;;
 esac
+unset _mem_proj
 
 # --- Redirect stderr to hook-errors.log ---
 # This replaces the 2>> that was in hooks.json. Now the directory is

--- a/scripts/lib-memory-dir.sh
+++ b/scripts/lib-memory-dir.sh
@@ -55,6 +55,55 @@ _read_data_dir() {
     fi
 }
 
+# _resolve_memory_project_dir <project_dir>
+# Returns the directory memory should be keyed to. Normally this is PROJECT_DIR
+# itself. When PROJECT_DIR is a *linked git worktree*, Claude Code has set
+# CLAUDE_PROJECT_DIR to the worktree path — but memory should live with the main
+# checkout so it survives `git worktree remove` and is shared across worktrees
+# of the same repo (issue #56). A linked worktree is detected via git's common
+# dir differing from its git dir; the main checkout is the parent of the shared
+# common dir.
+#
+# Fail-safe by design: it only redirects when it positively identifies a linked
+# worktree whose main checkout is a real work tree. Ordinary checkouts, non-git
+# directories, bare-repo worktrees, and old git without --path-format all fall
+# through to PROJECT_DIR unchanged — identical to pre-fix behaviour. Only
+# REMEMBER_DIR is affected; PROJECT_DIR stays the worktree path so session
+# recovery still finds transcripts under the worktree slug.
+_resolve_memory_project_dir() {
+    local proj="$1"
+    command -v git >/dev/null 2>&1 || { echo "$proj"; return 0; }
+
+    # One rev-parse yields both paths (common-dir first, git-dir second).
+    # --path-format=absolute requires git >= 2.31; on older git this fails and
+    # we fall through to the unchanged PROJECT_DIR.
+    local _out _gcd _gd
+    _out=$(git -C "$proj" rev-parse --path-format=absolute \
+                --git-common-dir --git-dir 2>/dev/null) || _out=""
+    { IFS= read -r _gcd; IFS= read -r _gd; } <<EOF
+$_out
+EOF
+
+    # Not a git repo, unsupported flag, or an ordinary checkout (common == git):
+    # leave PROJECT_DIR untouched.
+    if [ -z "$_gcd" ] || [ -z "$_gd" ] || [ "$_gcd" = "$_gd" ]; then
+        echo "$proj"
+        return 0
+    fi
+
+    # Linked worktree: the main checkout is the parent of the shared git dir.
+    # Guard against bare-repo worktrees (parent is not a work tree) by only
+    # redirecting to a directory git confirms is inside a work tree.
+    local _main
+    _main=$(dirname "$_gcd")
+    if [ -d "$_main" ] && \
+       git -C "$_main" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "$_main"
+    else
+        echo "$proj"
+    fi
+}
+
 # _resolve_remember_dir <data_dir_value> <project_dir>
 # Resolves the final absolute REMEMBER_DIR.
 # If data_dir starts with / or ~ treat as absolute; expand ~ and {slug}.
@@ -112,7 +161,13 @@ done
 # Default to legacy layout if nothing found.
 _data_dir_raw="${_data_dir_raw:-.remember}"
 
-REMEMBER_DIR=$(_resolve_remember_dir "$_data_dir_raw" "$PROJECT_DIR")
+# Key memory to the main checkout when PROJECT_DIR is a linked worktree, so it
+# survives `git worktree remove` and is shared across worktrees (issue #56).
+# For non-worktree / non-git projects this is exactly PROJECT_DIR.
+MEMORY_PROJECT_DIR=$(_resolve_memory_project_dir "$PROJECT_DIR")
+export MEMORY_PROJECT_DIR
+
+REMEMBER_DIR=$(_resolve_remember_dir "$_data_dir_raw" "$MEMORY_PROJECT_DIR")
 export REMEMBER_DIR
 
 # ── Pass 2: layered config merge ─────────────────────────────────────────────

--- a/tests/test_worktree_memory.py
+++ b/tests/test_worktree_memory.py
@@ -1,0 +1,274 @@
+"""Tests for worktree-aware REMEMBER_DIR resolution (issue #56).
+
+When a Claude Code session runs inside a git worktree, Claude Code sets
+CLAUDE_PROJECT_DIR to the *worktree* path. Without special handling the plugin
+resolves REMEMBER_DIR relative to that worktree path, so:
+
+  - Legacy mode: memory lands in ``<worktree>/.remember`` — physically inside
+    the worktree. ``git worktree remove`` deletes it (silently, since the plugin
+    gitignores it with ``*``), and it is never migrated to the main checkout.
+  - External mode: the ``{slug}`` is computed from the worktree path, producing
+    ``~/.remember/<slug-of-worktree>`` — a separate subtree the main checkout's
+    session never loads.
+
+The fix routes REMEMBER_DIR resolution through git's *common dir* so worktree
+sessions share the main checkout's memory root, while PROJECT_DIR itself is left
+untouched (session recovery relies on the worktree slug).
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash subprocess + POSIX git worktree layout — not portable to Windows runners",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DETECT_SCRIPT = REPO_ROOT / "scripts" / "detect-tools.sh"
+BOOTSTRAP_SCRIPT = REPO_ROOT / "scripts" / "bootstrap-dirs.sh"
+SESSION_START_SCRIPT = REPO_ROOT / "scripts" / "session-start-hook.sh"
+
+
+def _slug(path: str) -> str:
+    """Reproduce session_dir_slug for assertions."""
+    return re.sub(r"[^a-zA-Z0-9]", "-", path)
+
+
+def _make_plugin_dir(tmp_path: Path, data_dir_value: str) -> Path:
+    """Create a minimal plugin directory with a config.json carrying data_dir."""
+    plugin = tmp_path / "plugin"
+    plugin.mkdir(parents=True)
+    (plugin / "scripts").mkdir()
+    (plugin / "pipeline").mkdir()
+    (plugin / "pipeline" / "haiku.py").write_text("# marker\n")
+    (plugin / "config.json").write_text(json.dumps({
+        "data_dir": data_dir_value,
+        "cooldowns": {"save_seconds": 120, "ndc_seconds": 3600},
+        "thresholds": {"min_human_messages": 3, "delta_lines_trigger": 50},
+        "features": {"ndc_compression": True, "recovery": False},
+    }))
+    return plugin
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=str(cwd), check=True,
+                   capture_output=True, text=True)
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "t@t.com")
+    _git(path, "config", "user.name", "t")
+    (path / "file.txt").write_text("hello\n")
+    _git(path, "add", "file.txt")
+    _git(path, "commit", "-qm", "init")
+
+
+def _add_worktree(main: Path, wt: Path, branch: str) -> None:
+    _git(main, "worktree", "add", "-q", "-b", branch, str(wt))
+
+
+def _run_bootstrap(project_dir: str, pipeline_dir: str, home_dir: str) -> dict:
+    """Source detect-tools.sh + bootstrap-dirs.sh and capture REMEMBER_DIR."""
+    script = f"""
+    set -e
+    export PROJECT_DIR="{project_dir}"
+    export PIPELINE_DIR="{pipeline_dir}"
+    export HOME="{home_dir}"
+    source "{DETECT_SCRIPT}"
+    source "{BOOTSTRAP_SCRIPT}"
+    echo "REMEMBER_DIR=$REMEMBER_DIR"
+    """
+    result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, f"bootstrap failed:\n{result.stderr}"
+    parsed: dict = {}
+    for line in result.stdout.strip().splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            parsed[k] = v
+    return parsed
+
+
+# ─── Legacy mode ─────────────────────────────────────────────────────────────
+
+class TestLegacyModeWorktree:
+
+    def test_worktree_resolves_to_main_checkout_remember(self, tmp_path):
+        """A worktree session's REMEMBER_DIR points at the MAIN checkout's .remember."""
+        main = tmp_path / "main"
+        _init_repo(main)
+        wt = tmp_path / "wt-feature"
+        _add_worktree(main, wt, "feature")
+
+        home = tmp_path / "home"
+        home.mkdir()
+        plugin = _make_plugin_dir(tmp_path, ".remember")  # legacy default
+
+        result = _run_bootstrap(str(wt), str(plugin), str(home))
+        remember_dir = Path(result["REMEMBER_DIR"]).resolve()
+
+        assert remember_dir == (main / ".remember").resolve(), (
+            f"worktree memory should live in main checkout, got {remember_dir}"
+        )
+        # And crucially NOT inside the worktree (which gets deleted on cleanup).
+        assert not str(remember_dir).startswith(str(wt.resolve())), (
+            "REMEMBER_DIR must not live inside the worktree"
+        )
+
+    def test_worktree_remember_is_gitignored(self, tmp_path):
+        """The main-checkout .remember reached via a worktree still gets .gitignore."""
+        main = tmp_path / "main"
+        _init_repo(main)
+        wt = tmp_path / "wt-feature"
+        _add_worktree(main, wt, "feature")
+
+        home = tmp_path / "home"
+        home.mkdir()
+        plugin = _make_plugin_dir(tmp_path, ".remember")
+
+        result = _run_bootstrap(str(wt), str(plugin), str(home))
+        remember_dir = Path(result["REMEMBER_DIR"])
+
+        assert (remember_dir / ".gitignore").exists(), (
+            ".gitignore should still be written for the main-checkout .remember"
+        )
+
+    def test_non_worktree_repo_unchanged(self, tmp_path):
+        """Regression: an ordinary (non-worktree) checkout resolves to its own .remember."""
+        main = tmp_path / "main"
+        _init_repo(main)
+
+        home = tmp_path / "home"
+        home.mkdir()
+        plugin = _make_plugin_dir(tmp_path, ".remember")
+
+        result = _run_bootstrap(str(main), str(plugin), str(home))
+        remember_dir = Path(result["REMEMBER_DIR"]).resolve()
+
+        assert remember_dir == (main / ".remember").resolve()
+
+    def test_non_git_dir_unchanged(self, tmp_path):
+        """Regression: a plain (non-git) project resolves to PROJECT_DIR/.remember."""
+        project = tmp_path / "plain-proj"
+        project.mkdir()
+
+        home = tmp_path / "home"
+        home.mkdir()
+        plugin = _make_plugin_dir(tmp_path, ".remember")
+
+        result = _run_bootstrap(str(project), str(plugin), str(home))
+        remember_dir = Path(result["REMEMBER_DIR"]).resolve()
+
+        assert remember_dir == (project / ".remember").resolve()
+
+
+# ─── External mode ───────────────────────────────────────────────────────────
+
+class TestExternalModeWorktree:
+
+    def test_worktree_slug_matches_main_checkout(self, tmp_path):
+        """External mode: {slug} is derived from the MAIN checkout, not the worktree."""
+        main = tmp_path / "main"
+        _init_repo(main)
+        wt = tmp_path / "wt-feature"
+        _add_worktree(main, wt, "feature")
+
+        home = tmp_path / "home"
+        home.mkdir()
+        ext_base = tmp_path / "ext-mem"
+        plugin = _make_plugin_dir(tmp_path, str(ext_base) + "/{slug}")
+
+        result = _run_bootstrap(str(wt), str(plugin), str(home))
+        remember_dir = result["REMEMBER_DIR"]
+
+        expected_slug = _slug(str(main.resolve()))
+        assert remember_dir.endswith(expected_slug), (
+            f"expected slug of main checkout '{expected_slug}', got {remember_dir}"
+        )
+        wt_slug = _slug(str(wt.resolve()))
+        assert not remember_dir.endswith(wt_slug), (
+            "external REMEMBER_DIR must not be keyed by the worktree slug"
+        )
+
+    def test_worktree_and_main_share_external_dir(self, tmp_path):
+        """A worktree session and a main-checkout session resolve to the SAME external dir."""
+        main = tmp_path / "main"
+        _init_repo(main)
+        wt = tmp_path / "wt-feature"
+        _add_worktree(main, wt, "feature")
+
+        home = tmp_path / "home"
+        home.mkdir()
+        ext_base = tmp_path / "ext-mem"
+        plugin = _make_plugin_dir(tmp_path, str(ext_base) + "/{slug}")
+
+        from_wt = _run_bootstrap(str(wt), str(plugin), str(home))["REMEMBER_DIR"]
+        from_main = _run_bootstrap(str(main), str(plugin), str(home))["REMEMBER_DIR"]
+
+        assert from_wt == from_main, (
+            f"worktree and main should share memory dir; got {from_wt} vs {from_main}"
+        )
+
+
+# ─── Handoff path in worktree sessions ───────────────────────────────────────
+
+class TestWorktreeHandoff:
+
+    def test_legacy_worktree_emits_handoff_to_main_checkout(self, tmp_path):
+        """In a worktree, session-start must emit === HANDOFF === pointing at the
+        MAIN checkout's remember.md — even in legacy mode.
+
+        Legacy mode normally suppresses the hint (#118) because the /remember
+        skill's fallback ``{project}/.remember/remember.md`` already matches. But
+        inside a worktree that fallback would resolve to the *worktree* path,
+        which is wrong (and deleted on cleanup). The hint must fire so the skill
+        writes to the main checkout instead. This is covered by session-start's
+        existing ``REMEMBER_ROOT != PROJECT_DIR`` guard once REMEMBER_DIR is
+        redirected — this test locks that interaction in.
+        """
+        main = tmp_path / "main"
+        _init_repo(main)
+        wt = tmp_path / "wt-feature"
+        _add_worktree(main, wt, "feature")
+
+        home = tmp_path / "home"
+        (home / ".remember").mkdir(parents=True)
+        # Legacy mode via user-global config.
+        (home / ".remember" / "config.json").write_text(
+            json.dumps({"data_dir": ".remember", "features": {"recovery": False}})
+        )
+        # session-start reads ~/.claude/projects/<worktree-slug>/ — create it.
+        sessions_dir = home / ".claude" / "projects" / _slug(str(wt.resolve()))
+        sessions_dir.mkdir(parents=True)
+
+        env = {
+            **os.environ,
+            "CLAUDE_PROJECT_DIR": str(wt),
+            "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
+            "HOME": str(home),
+        }
+        result = subprocess.run(
+            ["bash", str(SESSION_START_SCRIPT)], env=env,
+            capture_output=True, text=True,
+        )
+        output = result.stdout
+
+        assert "=== HANDOFF ===" in output, (
+            f"HANDOFF block must be emitted for worktree sessions.\n"
+            f"stdout: {output[:400]}\nstderr: {result.stderr[:400]}"
+        )
+        expected = str((main / ".remember" / "remember.md").resolve())
+        assert expected in output, (
+            f"handoff should point at main checkout {expected}.\noutput: {output[:500]}"
+        )
+        assert str(wt.resolve()) + "/.remember" not in output, (
+            "handoff must not point inside the worktree"
+        )


### PR DESCRIPTION
## Summary

Fixes #56 — memory built up during a **git worktree** session was thrown away instead of being kept with the repository.

Claude Code sets `CLAUDE_PROJECT_DIR` to the *worktree* path for worktree sessions, and the plugin derives `REMEMBER_DIR` from it. So:

- **Legacy (default) mode** — memory landed in `<worktree>/.remember`, physically inside the worktree. Because the plugin gitignores it with `*`, a plain `git worktree remove` (no `--force`, no warning) deletes every `now.md` / `today-*.md` / `remember.md` from that session, and none of it is migrated to the main checkout.
- **External mode** — the `{slug}` was computed from the worktree path, producing an orphaned `~/.remember/<slug-of-worktree>` subtree the main checkout's sessions never load.

This matches the observation and fix direction in #56 (thanks @KrzysztofKasprowicz for the report and @dewet22 for the diagnosis).

## Fix

`REMEMBER_DIR` resolution now routes through git's **common dir**. When `PROJECT_DIR` is a linked worktree, memory is keyed to the repo's **main checkout**, so it:

- survives `git worktree remove`, and
- is shared across all worktrees of the same repo (one continuous memory, not a throwaway per worktree).

`CLAUDE_PROJECT_DIR` / `PROJECT_DIR` is left **untouched** — session recovery still resolves transcripts under the worktree slug Claude Code computed, exactly as @dewet22 flagged.

### Fail-safe by design

The redirect only fires when a linked worktree is *positively* identified (git's common-dir ≠ git-dir) **and** the computed main checkout is a real work tree. These all fall through to the unchanged `PROJECT_DIR`:

- ordinary (non-worktree) checkouts
- non-git directories
- bare-repo worktrees (parent of the common dir is not a work tree)
- git without `--path-format` (< 2.31)

So non-worktree and non-git users see byte-for-byte identical behavior.

## Changes

- `scripts/lib-memory-dir.sh` — new `_resolve_memory_project_dir()`; `REMEMBER_DIR` is resolved against it and it is exported as `MEMORY_PROJECT_DIR`.
- `scripts/bootstrap-dirs.sh` — the one-shot legacy→external migration and the `.gitignore` write are keyed to `MEMORY_PROJECT_DIR` so they stay consistent with where `REMEMBER_DIR` now resolves.
- `tests/test_worktree_memory.py` — new: legacy + external resolution in a real worktree, regression guards for non-worktree / non-git, the shared-dir invariant, and that session-start emits `=== HANDOFF ===` pointing at the main checkout (the existing `REMEMBER_ROOT != PROJECT_DIR` guard already covers this once `REMEMBER_DIR` is redirected).
- `CHANGELOG.md`, `README.md` — document the behavior (new "Git worktrees" section).

## Handoff interaction (no extra code needed)

In legacy mode the `=== HANDOFF ===` hint is normally suppressed (#118) because the `/remember` skill's fallback `{project}/.remember/remember.md` already matches. Inside a worktree that fallback would be wrong — but session-start's existing `REMEMBER_ROOT != PROJECT_DIR` guard now fires (since `REMEMBER_ROOT` is the main checkout ≠ the worktree `PROJECT_DIR`), so the hint is emitted and the skill writes the handoff to the main checkout. A test locks this in.

## Testing

- Full suite (CI-equivalent, `pytest` with coverage): **500 passed, 43 skipped, 98.24% coverage**.
- New `tests/test_worktree_memory.py` uses real `git worktree` layouts.
- Manual end-to-end: accumulated memory during a worktree session now survives `git worktree remove` and lands in the main checkout's `.remember/`.

> Windows is skipped for the new tests (POSIX worktree layout + slug assertions), consistent with the existing worktree/path tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
