### PR TITLE
fix: clean up merged config in scripts that replace the lib EXIT trap

### DIFF
--- a/scripts/run-consolidation.sh
+++ b/scripts/run-consolidation.sh
@@ -52,7 +52,9 @@ if ! ( set -o noclobber; echo $$ > "$LOCK_FILE" ) 2>/dev/null; then
     log "consolidation" "stale lock (PID $LOCK_PID dead), taking over"
     echo $$ > "$LOCK_FILE"
 fi
-trap 'rm -f "$LOCK_FILE"' EXIT
+# This trap REPLACES the cleanup trap lib-memory-dir.sh installed for
+# $REMEMBER_CONFIG (bash keeps a single EXIT trap), so remove it here too.
+trap 'rm -f "$LOCK_FILE" "$REMEMBER_CONFIG"' EXIT
 
 STAGING_DIR="${REMEMBER_DIR}"
 RECENT_FILE="${STAGING_DIR}/recent.md"

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -66,6 +66,9 @@ LAST_SAVE_FILE="${REMEMBER_DIR}/tmp/last-save.json"
 COOLDOWN_MARKER="${REMEMBER_DIR}/tmp/last-save-ts"
 TODAY_DATE=$(_remember_date +%Y-%m-%d)
 CLEANUP_FILES=()
+# The trap below REPLACES the cleanup trap lib-memory-dir.sh installed for
+# $REMEMBER_CONFIG (bash keeps a single EXIT trap), so remove it here too.
+CLEANUP_FILES+=("$REMEMBER_CONFIG")
 
 # Remove lock file and all accumulated temp files on exit.
 cleanup() { rm -f "$LOCK_FILE" "${CLEANUP_FILES[@]}"; }

--- a/tests/test_tmpdir_cleanup.py
+++ b/tests/test_tmpdir_cleanup.py
@@ -1,0 +1,113 @@
+"""Regression tests: no remember-config-<pid>.json may survive in TMPDIR.
+
+lib-memory-dir.sh creates ``${TMPDIR}/remember-config-$$.json`` at source time
+and registers a chaining EXIT trap to remove it.  Scripts that later install
+their own plain ``trap ... EXIT`` (save-session.sh, run-consolidation.sh)
+REPLACE that trap — bash keeps a single EXIT trap — so the merged-config file
+used to be orphaned on every exit taken after the script's own trap was
+installed.  These tests run the real scripts in an isolated TMPDIR and assert
+nothing is left behind.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SAVE_SH = REPO_ROOT / "scripts" / "save-session.sh"
+CONSOLIDATION_SH = REPO_ROOT / "scripts" / "run-consolidation.sh"
+RESOLVE_PATHS_SH = REPO_ROOT / "scripts" / "resolve-paths.sh"
+BOOTSTRAP_DIRS_SH = REPO_ROOT / "scripts" / "bootstrap-dirs.sh"
+
+
+def _bash_path(p) -> str:
+    """`C:\\Users\\x` -> `C:/Users/x`; unchanged on POSIX (see test_security_fixes)."""
+    return str(p).replace("\\", "/")
+
+
+def _find_bash():
+    if sys.platform != "win32":
+        return "bash"
+    import shutil
+    candidates = []
+    for env_var in ("ProgramFiles", "ProgramFiles(x86)", "ProgramW6432"):
+        base = os.environ.get(env_var)
+        if base:
+            candidates.append(Path(base) / "Git" / "bin" / "bash.exe")
+            candidates.append(Path(base) / "Git" / "usr" / "bin" / "bash.exe")
+    for cand in candidates:
+        if cand.is_file():
+            return str(cand)
+    resolved = shutil.which("bash")
+    if resolved and "git" in resolved.replace("\\", "/").lower():
+        return resolved
+    return None
+
+
+_BASH = _find_bash()
+pytestmark = pytest.mark.skipif(_BASH is None, reason="bash not available")
+
+
+def _run_and_collect_strays(tmp_path, inner_commands: str):
+    """Source resolve-paths + bootstrap-dirs in an isolated TMPDIR, run
+    ``inner_commands``, and return the remember-config-* files that survive
+    after the outer shell (and everything it started) has exited."""
+    isolated_tmp = tmp_path / "tmp"
+    isolated_tmp.mkdir()
+    project = tmp_path / "proj"
+    (project / ".claude" / "remember").mkdir(parents=True)
+    (project / ".remember").mkdir(parents=True)
+
+    script = f"""
+set -e
+export CLAUDE_PROJECT_DIR="{_bash_path(project)}"
+export PIPELINE_DIR="{_bash_path(REPO_ROOT)}"
+source "{_bash_path(RESOLVE_PATHS_SH)}"
+export TMPDIR="{_bash_path(isolated_tmp)}"
+source "{_bash_path(BOOTSTRAP_DIRS_SH)}"
+{inner_commands}
+"""
+    result = subprocess.run(
+        [_BASH, "-c", script],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "HOME": _bash_path(tmp_path)},
+    )
+    assert result.returncode == 0, (
+        f"script failed: rc={result.returncode}\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    return sorted(isolated_tmp.glob("remember-config-*.json"))
+
+
+def test_save_session_exit_cleans_merged_config(tmp_path):
+    """save-session.sh must not orphan its remember-config file on the
+    lock-skip path (any path after its ``trap cleanup EXIT`` leaks alike)."""
+    strays = _run_and_collect_strays(
+        tmp_path,
+        f"""
+mkdir -p "$REMEMBER_DIR/tmp"
+echo $$ > "$REMEMBER_DIR/tmp/save.lock"
+bash "{_bash_path(SAVE_SH)}"
+""",
+    )
+    assert strays == [], (
+        f"save-session.sh orphaned merged-config file(s) in TMPDIR: {strays} "
+        "— its plain EXIT trap replaced lib-memory-dir.sh's cleanup trap"
+    )
+
+
+def test_run_consolidation_exit_cleans_merged_config(tmp_path):
+    """run-consolidation.sh must not orphan its remember-config file on the
+    no-staging path (taken after its lock-cleanup ``trap ... EXIT``)."""
+    strays = _run_and_collect_strays(
+        tmp_path,
+        f'bash "{_bash_path(CONSOLIDATION_SH)}"',
+    )
+    assert strays == [], (
+        f"run-consolidation.sh orphaned merged-config file(s) in TMPDIR: {strays} "
+        "— its lock-cleanup EXIT trap replaced lib-memory-dir.sh's cleanup trap"
+    )


### PR DESCRIPTION
## Summary

`lib-memory-dir.sh` creates `${TMPDIR}/remember-config-$$.json` at source time and registers a chaining EXIT trap to remove it (it even parses `trap -p EXIT` specifically to avoid clobbering an existing trap). But two callers source the lib first and install their own plain `trap ... EXIT` **afterwards** — and bash keeps a single EXIT trap, so the lib's cleanup is silently discarded:

- `save-session.sh:72` — `trap cleanup EXIT`, and `cleanup()` removes only `$LOCK_FILE` + `${CLEANUP_FILES[@]}`; the merged config is never registered there
- `run-consolidation.sh:55` — `trap 'rm -f "$LOCK_FILE"' EXIT`

Result: one orphaned `remember-config-<pid>.json` (a 3-byte `{}` in a default install with no `config.json`) per run, on every exit taken after the script's trap is installed — for `save-session.sh` that includes the cooldown-skip and lock-skip paths. We found ~13k stray files in `$TMPDIR` on one long-running machine. (Orthogonal to #125 — that affects how often these scripts are forked; this fixes the per-run cleanup.)

## Changes

- `save-session.sh`: register `$REMEMBER_CONFIG` in `CLEANUP_FILES` so the existing `cleanup()` removes it
- `run-consolidation.sh`: append `$REMEMBER_CONFIG` to the lock-cleanup trap
- `tests/test_tmpdir_cleanup.py`: regression tests running both real scripts in an isolated `TMPDIR`, asserting no `remember-config-*` survives (both fail before this fix, pass after)

## Test plan

- [x] `pytest` passes locally (504 passed, 41 skipped; macOS, bash 5.3.12)
- [x] New behavior covered by a test (`tests/test_tmpdir_cleanup.py`, red before / green after)
- [x] Targeted manual checks: ran `save-session.sh` on the lock-skip and cooldown-skip paths and `run-consolidation.sh` on the no-staging path; no `remember-config-*` file remained, exit codes and logs unchanged
- [ ] Not tested on Linux / Windows-Git-Bash

## Checklist

- [x] Docs updated if a new config key, hook, or skill was added (`README.md`, `config.example.json`) — N/A, none added
- [x] Version bumped in `.claude-plugin/plugin.json` if shipping a release — N/A, not a release
- [ ] Changelog entry added in `README.md` — not included; happy to add if you'd like it in this PR
