### PR TITLE
fix: don't crash the nested Haiku session on unresolvable project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A nested `claude -p` session crashed on every hook** ([#137](https://github.com/Digital-Process-Tools/claude-remember/pull/137)) — `scripts/resolve-paths.sh` is always *sourced*, but signalled failure with a bare `exit 1`, which terminates the **caller's** whole process. The three Claude Code hooks are documented "EXIT CODES: 0 Always", and the one caller most likely to fail resolution is the plugin's own nested Haiku session (it runs with `cwd` in a temp dir and no `CLAUDE_PROJECT_DIR`, so it is not a project at all) — so the plugin crashed the very session it spawned. Resolution failure now stays **loud by default** (`exit 1`, unchanged for every worker script and for any caller that forgets to check), while a caller that must never take its host process down opts in with `REMEMBER_PATHS_SOFT_FAIL=1` and gets `return 1` to handle itself. Only the three hooks opt in, and they still report FATAL on stderr, which `hooks.json` redirects into `hook-errors.log` — a failed hook is silent to the session, never silent to the logs. Diagnosed and fixed by [@lucasrodriggs-tech](https://github.com/lucasrodriggs-tech).
+
 ## [0.8.5] — Ship the 0.8.4-era fixes: manifest bump, worktree safety, fork storm
 
 ### Fixed

--- a/scripts/post-tool-hook.sh
+++ b/scripts/post-tool-hook.sh
@@ -28,11 +28,11 @@
 # ============================================================================
 
 # --- Resolve paths ---
-# resolve-paths.sh signals failure via `return`, not `exit` — see the comment
-# in session-start-hook.sh. This hook must never block the agent, so a
-# resolution failure (e.g. a nested/headless session with no
-# CLAUDE_PROJECT_DIR) is a silent no-op, not a crash.
-source "$(dirname "$0")/resolve-paths.sh" || exit 0
+# Opt into resolve-paths.sh's soft-failure mode — see the comment in
+# session-start-hook.sh. This hook must never block the agent, so a resolution
+# failure (e.g. a nested/headless session with no CLAUDE_PROJECT_DIR) is a
+# silent no-op, not a crash.
+REMEMBER_PATHS_SOFT_FAIL=1 source "$(dirname "$0")/resolve-paths.sh" || exit 0
 source "$(dirname "$0")/detect-tools.sh"
 source "$(dirname "$0")/bootstrap-dirs.sh"
 PLUGIN_ROOT="$PIPELINE_DIR"

--- a/scripts/post-tool-hook.sh
+++ b/scripts/post-tool-hook.sh
@@ -28,7 +28,11 @@
 # ============================================================================
 
 # --- Resolve paths ---
-source "$(dirname "$0")/resolve-paths.sh"
+# resolve-paths.sh signals failure via `return`, not `exit` — see the comment
+# in session-start-hook.sh. This hook must never block the agent, so a
+# resolution failure (e.g. a nested/headless session with no
+# CLAUDE_PROJECT_DIR) is a silent no-op, not a crash.
+source "$(dirname "$0")/resolve-paths.sh" || exit 0
 source "$(dirname "$0")/detect-tools.sh"
 source "$(dirname "$0")/bootstrap-dirs.sh"
 PLUGIN_ROOT="$PIPELINE_DIR"

--- a/scripts/resolve-paths.sh
+++ b/scripts/resolve-paths.sh
@@ -14,8 +14,17 @@
 #     3. Symlinked:   Any of the above with symlinks in the chain
 #
 # USAGE
-#   source "$(dirname "$0")/resolve-paths.sh"
+#   source "$(dirname "$0")/resolve-paths.sh" || exit <caller-appropriate-code>
 #   # Now PROJECT_DIR and PIPELINE_DIR are set and validated
+#
+#   This file is ALWAYS sourced, never executed directly, so it signals
+#   failure with `return 1` (not `exit 1`). A bare `exit` inside a sourced
+#   script terminates the CALLER's whole process immediately — fatal for
+#   session-start-hook.sh / post-tool-hook.sh, which are documented to never
+#   block the host session (see their own EXIT CODES: 0 Always). Callers
+#   must check the source's exit status and decide their own failure policy;
+#   see save-session.sh (hard-fails via `set -e`) vs. the two hook scripts
+#   (`|| exit 0`).
 #
 # ENVIRONMENT (inputs)
 #   CLAUDE_PROJECT_DIR    Project root (set by Claude Code hooks)
@@ -25,8 +34,9 @@
 #   PROJECT_DIR           Resolved project root (validated to exist)
 #   PIPELINE_DIR          Resolved plugin root (validated to exist)
 #
-# EXIT CODES
-#   1   Path resolution failed (PROJECT_DIR or PIPELINE_DIR not found)
+# RETURN CODES
+#   1   Path resolution failed (PROJECT_DIR or PIPELINE_DIR not found) —
+#       caller must check `|| ...`, this script never exits the caller itself.
 #
 # ============================================================================
 
@@ -60,7 +70,7 @@ else
     if [ -d "$_log_dir" ]; then
         echo "$(date '+%H:%M:%S') [resolve] $_msg" >> "$_log_dir/memory-$(date '+%Y-%m-%d').log" 2>/dev/null
     fi
-    exit 1
+    return 1
 fi
 
 # --- Resolve PROJECT_DIR (the user's project root) ---
@@ -81,7 +91,7 @@ else
     if [ -d "$_log_dir" ]; then
         echo "$(date '+%H:%M:%S') [resolve] $_msg" >> "$_log_dir/memory-$(date '+%Y-%m-%d').log" 2>/dev/null
     fi
-    exit 1
+    return 1
 fi
 
 # --- Windows shell normalization (Git Bash / MSYS / Cygwin) ----------------
@@ -110,13 +120,13 @@ esac
 if [ ! -d "$PROJECT_DIR" ]; then
     _msg="FATAL: PROJECT_DIR does not exist: $PROJECT_DIR"
     echo "$_msg" >&2
-    exit 1
+    return 1
 fi
 
 if [ ! -d "$PIPELINE_DIR" ]; then
     _msg="FATAL: PIPELINE_DIR does not exist: $PIPELINE_DIR"
     echo "$_msg" >&2
-    exit 1
+    return 1
 fi
 
 # --- Export for subprocesses (critical for nohup) ---

--- a/scripts/resolve-paths.sh
+++ b/scripts/resolve-paths.sh
@@ -17,14 +17,20 @@
 #   source "$(dirname "$0")/resolve-paths.sh" || exit <caller-appropriate-code>
 #   # Now PROJECT_DIR and PIPELINE_DIR are set and validated
 #
-#   This file is ALWAYS sourced, never executed directly, so it signals
-#   failure with `return 1` (not `exit 1`). A bare `exit` inside a sourced
-#   script terminates the CALLER's whole process immediately — fatal for
-#   session-start-hook.sh / post-tool-hook.sh, which are documented to never
-#   block the host session (see their own EXIT CODES: 0 Always). Callers
-#   must check the source's exit status and decide their own failure policy;
-#   see save-session.sh (hard-fails via `set -e`) vs. the two hook scripts
-#   (`|| exit 0`).
+#   This file is ALWAYS sourced, never executed directly. On failure it is
+#   LOUD BY DEFAULT: it prints FATAL and `exit 1`s the caller, because a caller
+#   that continues with unresolved paths writes memory to the wrong place —
+#   worse than a crash.
+#
+#   A caller that must never terminate its host process opts out by setting
+#   REMEMBER_PATHS_SOFT_FAIL=1 before sourcing; failure then `return 1`s and the
+#   caller decides. Only the three Claude Code hooks do this — they are
+#   documented "EXIT CODES: 0 Always" (a bare `exit` inside a sourced file kills
+#   the whole hook process, which crashes the nested Haiku session that runs
+#   with no resolvable project root). They pair it with `|| exit 0`.
+#
+#   The default is loud on purpose: a future caller that forgets to check the
+#   status still fails safely instead of silently continuing with empty paths.
 #
 # ENVIRONMENT (inputs)
 #   CLAUDE_PROJECT_DIR    Project root (set by Claude Code hooks)
@@ -34,9 +40,13 @@
 #   PROJECT_DIR           Resolved project root (validated to exist)
 #   PIPELINE_DIR          Resolved plugin root (validated to exist)
 #
+# ENVIRONMENT (opt-in)
+#   REMEMBER_PATHS_SOFT_FAIL=1   Signal failure with `return 1` instead of
+#                                exiting the caller. Set by the hook scripts.
+#
 # RETURN CODES
-#   1   Path resolution failed (PROJECT_DIR or PIPELINE_DIR not found) —
-#       caller must check `|| ...`, this script never exits the caller itself.
+#   1   Path resolution failed, and the caller opted into soft failure.
+#       Without the opt-in, resolution failure exits the caller with 1.
 #
 # ============================================================================
 
@@ -57,6 +67,18 @@ umask 077
 _SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _PLUGIN_ROOT_CANDIDATE="$(cd "$_SCRIPT_DIR/.." && pwd)"
 
+# _resolve_paths_fail <message> [log_dir]
+# Report a resolution failure, then apply the caller's failure policy: `return 1`
+# when REMEMBER_PATHS_SOFT_FAIL=1, otherwise exit the caller (the default).
+_resolve_paths_fail() {
+    echo "$1" >&2
+    if [ -n "${2:-}" ] && [ -d "$2" ]; then
+        echo "$(date '+%H:%M:%S') [resolve] $1" >> "$2/memory-$(date '+%Y-%m-%d').log" 2>/dev/null
+    fi
+    [ "${REMEMBER_PATHS_SOFT_FAIL:-0}" = "1" ] && return 1
+    exit 1
+}
+
 if [ -n "$CLAUDE_PLUGIN_ROOT" ]; then
     PIPELINE_DIR="$CLAUDE_PLUGIN_ROOT"
 elif [ -f "$_PLUGIN_ROOT_CANDIDATE/pipeline/haiku.py" ]; then
@@ -64,13 +86,7 @@ elif [ -f "$_PLUGIN_ROOT_CANDIDATE/pipeline/haiku.py" ]; then
     PIPELINE_DIR="$_PLUGIN_ROOT_CANDIDATE"
 else
     _msg="FATAL: Cannot resolve plugin root. CLAUDE_PLUGIN_ROOT is not set and $_PLUGIN_ROOT_CANDIDATE/pipeline/haiku.py does not exist."
-    echo "$_msg" >&2
-    # Try to log if we can find a log directory
-    _log_dir="${CLAUDE_PROJECT_DIR:-.}/.remember/logs"
-    if [ -d "$_log_dir" ]; then
-        echo "$(date '+%H:%M:%S') [resolve] $_msg" >> "$_log_dir/memory-$(date '+%Y-%m-%d').log" 2>/dev/null
-    fi
-    return 1
+    _resolve_paths_fail "$_msg" "${CLAUDE_PROJECT_DIR:-.}/.remember/logs" || return 1
 fi
 
 # --- Resolve PROJECT_DIR (the user's project root) ---
@@ -86,12 +102,7 @@ elif [[ "$PIPELINE_DIR" == *"/.claude/remember" ]]; then
     PROJECT_DIR="$(cd "$PIPELINE_DIR/../.." && pwd)"
 else
     _msg="FATAL: Cannot resolve project root. CLAUDE_PROJECT_DIR is not set and plugin is not in a local .claude/remember/ layout (PIPELINE_DIR=$PIPELINE_DIR)."
-    echo "$_msg" >&2
-    _log_dir="${PROJECT_DIR:-.}/.remember/logs"
-    if [ -d "$_log_dir" ]; then
-        echo "$(date '+%H:%M:%S') [resolve] $_msg" >> "$_log_dir/memory-$(date '+%Y-%m-%d').log" 2>/dev/null
-    fi
-    return 1
+    _resolve_paths_fail "$_msg" "${PROJECT_DIR:-.}/.remember/logs" || return 1
 fi
 
 # --- Windows shell normalization (Git Bash / MSYS / Cygwin) ----------------
@@ -119,14 +130,12 @@ esac
 # --- Validate both paths exist ---
 if [ ! -d "$PROJECT_DIR" ]; then
     _msg="FATAL: PROJECT_DIR does not exist: $PROJECT_DIR"
-    echo "$_msg" >&2
-    return 1
+    _resolve_paths_fail "$_msg" || return 1
 fi
 
 if [ ! -d "$PIPELINE_DIR" ]; then
     _msg="FATAL: PIPELINE_DIR does not exist: $PIPELINE_DIR"
-    echo "$_msg" >&2
-    return 1
+    _resolve_paths_fail "$_msg" || return 1
 fi
 
 # --- Export for subprocesses (critical for nohup) ---

--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -37,12 +37,13 @@
 #
 # ============================================================================
 
-# resolve-paths.sh signals failure via `return`, not `exit` — it's a sourced
-# library, and a bare `exit` there would kill this whole hook process, which
-# is documented to never block session startup. Most likely to fail here for
-# a NESTED `claude -p` session (e.g. the remember pipeline's own Haiku call):
-# it has no CLAUDE_PROJECT_DIR and isn't a real project, so just no-op.
-source "$(dirname "$0")/resolve-paths.sh" || exit 0
+# resolve-paths.sh exits its caller on failure by default (a caller that keeps
+# going with unresolved paths writes memory to the wrong place). This hook is
+# documented to never block session startup, so it opts into soft failure and
+# handles the status itself. Most likely to fail here for a NESTED `claude -p`
+# session (e.g. the remember pipeline's own Haiku call): it has no
+# CLAUDE_PROJECT_DIR and isn't a real project, so just no-op.
+REMEMBER_PATHS_SOFT_FAIL=1 source "$(dirname "$0")/resolve-paths.sh" || exit 0
 source "$(dirname "$0")/detect-tools.sh"
 source "$(dirname "$0")/bootstrap-dirs.sh"
 PLUGIN_ROOT="$PIPELINE_DIR"

--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -37,7 +37,12 @@
 #
 # ============================================================================
 
-source "$(dirname "$0")/resolve-paths.sh"
+# resolve-paths.sh signals failure via `return`, not `exit` — it's a sourced
+# library, and a bare `exit` there would kill this whole hook process, which
+# is documented to never block session startup. Most likely to fail here for
+# a NESTED `claude -p` session (e.g. the remember pipeline's own Haiku call):
+# it has no CLAUDE_PROJECT_DIR and isn't a real project, so just no-op.
+source "$(dirname "$0")/resolve-paths.sh" || exit 0
 source "$(dirname "$0")/detect-tools.sh"
 source "$(dirname "$0")/bootstrap-dirs.sh"
 PLUGIN_ROOT="$PIPELINE_DIR"

--- a/scripts/user-prompt-hook.sh
+++ b/scripts/user-prompt-hook.sh
@@ -28,7 +28,10 @@
 # ============================================================================
 
 # --- Resolve paths ---
-source "$(dirname "$0")/resolve-paths.sh"
+# resolve-paths.sh signals failure via `return`, not `exit` — see the comment
+# in session-start-hook.sh. This hook must never block the agent, so a
+# resolution failure is a silent no-op, not a crash.
+source "$(dirname "$0")/resolve-paths.sh" || exit 0
 source "$(dirname "$0")/bootstrap-dirs.sh"
 source "$(dirname "$0")/log.sh" 2>/dev/null
 

--- a/scripts/user-prompt-hook.sh
+++ b/scripts/user-prompt-hook.sh
@@ -28,10 +28,10 @@
 # ============================================================================
 
 # --- Resolve paths ---
-# resolve-paths.sh signals failure via `return`, not `exit` — see the comment
-# in session-start-hook.sh. This hook must never block the agent, so a
-# resolution failure is a silent no-op, not a crash.
-source "$(dirname "$0")/resolve-paths.sh" || exit 0
+# Opt into resolve-paths.sh's soft-failure mode — see the comment in
+# session-start-hook.sh. This hook must never block the agent, so a resolution
+# failure is a silent no-op, not a crash.
+REMEMBER_PATHS_SOFT_FAIL=1 source "$(dirname "$0")/resolve-paths.sh" || exit 0
 source "$(dirname "$0")/bootstrap-dirs.sh"
 source "$(dirname "$0")/log.sh" 2>/dev/null
 

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -1000,24 +1000,38 @@ class TestRealisticPluginSimulation:
         assert "FATAL" not in result.stderr, f"Path resolution failed: {result.stderr[:300]}"
 
     def test_marketplace_without_env_fails_loud(self, tmp_path):
-        """Marketplace layout WITHOUT env vars — every script should fail with FATAL in stderr."""
+        """Marketplace layout WITHOUT env vars — every script reports FATAL.
+
+        Exit status differs by caller policy: the worker scripts abort, while the
+        Claude Code hooks are documented "EXIT CODES: 0 Always" and opt into
+        resolve-paths.sh's soft failure — they must still *report* the problem on
+        stderr (hooks.json redirects it to hook-errors.log), just not take the
+        host session down with them.
+        """
         plugin = os.path.join(str(tmp_path), "cache", "org", "remember", "0.1.0")
         os.makedirs(os.path.join(plugin, "scripts"))
         _create_full_plugin_copy(plugin)
 
         env = {k: v for k, v in os.environ.items()
                if k not in ("CLAUDE_PROJECT_DIR", "CLAUDE_PLUGIN_ROOT")}
-        for script in ("session-start-hook.sh", "post-tool-hook.sh",
-                        "save-session.sh", "run-consolidation.sh"):
+        WORKERS = ("save-session.sh", "run-consolidation.sh")
+        HOOKS = ("session-start-hook.sh", "post-tool-hook.sh", "user-prompt-hook.sh")
+        for script in WORKERS + HOOKS:
             result = _run_hook_like_claude_code(plugin, script, env)
             combined = result.stderr + result.stdout
             assert "FATAL" in combined, (
                 f"{script} should emit FATAL without env vars, got: "
                 f"rc={result.returncode} stderr={result.stderr[:200]}"
             )
-            assert result.returncode != 0, (
-                f"{script} should exit non-zero without env vars"
-            )
+            if script in WORKERS:
+                assert result.returncode != 0, (
+                    f"{script} should exit non-zero without env vars"
+                )
+            else:
+                assert result.returncode == 0, (
+                    f"{script} must never block the session (EXIT CODES: 0 Always), "
+                    f"got rc={result.returncode}"
+                )
 
     def test_hooks_json_stderr_redirect_captures_errors(self, tmp_path):
         """hooks.json stderr redirect captures FATAL errors to hook-errors.log.
@@ -1047,7 +1061,10 @@ class TestRealisticPluginSimulation:
             ["bash", "-c", cmd], capture_output=True, text=True,
             env=env, timeout=10,
         )
-        assert result.returncode != 0
+        # The hook exits 0 even when resolution fails — it must never block the
+        # session — so the redirect, not the exit status, is what preserves the
+        # diagnosis. That is exactly what this test pins.
+        assert result.returncode == 0
 
         # The FATAL error should be in hook-errors.log, not lost
         assert os.path.isfile(hook_errors_log), "hook-errors.log not created"
@@ -3582,7 +3599,12 @@ echo "DISPATCH_COMPLETED=true"
         assert "DISPATCH_COMPLETED=true" in result.stdout
 
     def test_resolve_paths_failure_does_not_silently_continue(self, tmp_path):
-        """If resolve-paths.sh fails (bad PROJECT_DIR), hook must not run with wrong paths."""
+        """If resolve-paths.sh fails (bad PROJECT_DIR), the hook must not run with wrong paths.
+
+        The hook exits 0 (it may never block the agent) but must produce nothing:
+        no timestamp injection, no dispatch. Silence plus a FATAL on stderr — not
+        continuation with empty paths, and not a crash.
+        """
         plugin = os.path.join(str(tmp_path), "cache", "org", "remember", "0.5.0")
         _create_full_plugin_copy(plugin)
 
@@ -3595,10 +3617,18 @@ echo "DISPATCH_COMPLETED=true"
             ["bash", os.path.join(plugin, "scripts", "user-prompt-hook.sh")],
             capture_output=True, text=True, env=env, timeout=10,
         )
-        # resolve-paths.sh should exit 1, killing the hook
-        assert result.returncode != 0, (
-            "Hook must fail if resolve-paths.sh can't find PROJECT_DIR. "
-            "Silent continuation with wrong paths is worse than a crash."
+        assert result.returncode == 0, (
+            "user-prompt-hook.sh is documented EXIT CODES: 0 Always — a sourced "
+            "`exit 1` here kills the hook process and crashes nested sessions."
+        )
+        assert result.stdout.strip() == "", (
+            "Hook must not inject anything when paths are unresolved. Silent "
+            "continuation with wrong paths is worse than a crash: "
+            f"stdout={result.stdout[:200]}"
+        )
+        assert "FATAL" in result.stderr, (
+            "The failure must still be reported on stderr (hooks.json redirects "
+            f"it to hook-errors.log): stderr={result.stderr[:200]}"
         )
 
     def test_handoff_consumed_after_session_start(self, tmp_path):


### PR DESCRIPTION
## Summary
- `haiku.py`'s `call_haiku()` spawns a nested `claude -p` process to summarize each save. Since plugins are installed globally, that nested session also loads this plugin and fires its own `SessionStart` hook — an unintended recursive activation.
- That nested session runs with `cwd=tempdir` and no real project, so `CLAUDE_PROJECT_DIR` is unset for it. `resolve-paths.sh` correctly detects it can't guess a project root from a marketplace-cache layout, but signals that with a bare `exit 1` inside a script that is always `source`d — which kills the *caller's* whole process, even though `session-start-hook.sh` documents "EXIT CODES: 0 Always (hook must not block session startup)".
- Claude Code then reports the whole nested `claude -p` invocation as failed, which `call_haiku()` surfaces as `claude exited 1`, so the outer save silently never reaches `now.md`.

## Fix
- `resolve-paths.sh` now signals failure via `return 1` (correct for a sourced library) instead of `exit 1`.
- `session-start-hook.sh`, `post-tool-hook.sh`, `user-prompt-hook.sh` — the three entrypoints documented to never block the host session — now guard the source call with `|| exit 0`, matching their own contract.
- `save-session.sh` / `run-consolidation.sh` needed no change: they already run under `set -e`, so a failed `return 1` still correctly aborts them.

## Test plan
- [x] Reproduced the crash: forced a save with `CLAUDE_PROJECT_DIR` unset in the nested hook context, confirmed `[resolve] FATAL` + `claude exited 1` in logs.
- [x] Verified `source resolve-paths.sh` now returns 1 without killing the sourcing shell.
- [x] Verified `session-start-hook.sh` exits 0 cleanly instead of crashing when project root can't be resolved.
- [x] Ran a real `save-session.sh --force` end-to-end after the fix: no more `[resolve] FATAL`, Haiku call succeeds, `now.md` gets a real appended entry.