### PR TITLE
release: 0.8.6 — memory actually saves

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remember",
   "description": "Continuous memory for Claude Code. Extracts, summarizes, and compresses conversations into tiered daily logs. Claude remembers what you did yesterday.",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.6] — Memory actually saves: agentic sessions, auth, channels, and an NDC data race
+
 ### Fixed
 
 - **Channel-delivered messages were dropped, so those sessions never saved** ([#128](https://github.com/Digital-Process-Tools/claude-remember/issues/128)) — input arriving through a channel integration (e.g. the Telegram plugin) is wrapped by the transport and carries `isMeta`, the same flag Claude Code puts on genuine meta records. `extract_messages()` filtered on it before counting, so every real human turn in such a session vanished: the human count stayed at 0, the min-human gate never cleared, and memory was never written for the entire class of channel-driven users. The wrapped text is now recovered and counted as the human turn it is. Reported by [@ondomru](https://github.com/ondomru).


### PR DESCRIPTION
Cuts 0.8.6 from what has landed on main since 0.8.5. Manifest bumped per #133 — without it, none of these reach marketplace installs.

Six fixes, all the same shape: **memory silently not written, with nothing in the logs to say so.**

| Issue | Who it broke for |
|---|---|
| #147 / #125 | every agentic session — many tool calls, few human turns never cleared the gate, and no early exit advanced the cursor, so the same span re-extracted forever |
| #131 + #129 | every `setup-token` / hosted Agent SDK install — nested calls unauthenticated, and the reason invisible behind an empty error string |
| #128 | every channel-driven user (Telegram plugin) — real human turns filtered out as `isMeta` |
| #142 | anyone whose save landed during an NDC compression window — entry erased, position already advanced, unrecoverable |
| #137 | nested `claude -p` sessions — a sourced `exit 1` killed the hook process |
| #126 | `recent.md` readers — doubled `# Recent` header from a wrapping fence |

After merge I'll tag `v0.8.6` and publish the release.