### PR TITLE
fix(consolidate): strip the orphaned closing fence from the archive half (#126)

### DIFF
--- a/pipeline/consolidate.py
+++ b/pipeline/consolidate.py
@@ -49,6 +49,17 @@ def _strip_wrapping_fence(text: str) -> str:
     Strip the opening fence whenever present, and the closing fence only if
     present (truncated model output can drop it), before the header check runs.
 
+    The closing fence is NOT gated on this section having had an opener. When
+    the model fences the whole ===RECENT===/===ARCHIVE=== envelope rather than
+    one section, the opener lands in the FIRST section and the closer in the
+    LAST — so the archive half inherits an unmatched ``` with no opener of its
+    own, and an opener-gated strip would leave it to land in archive.md.
+
+    Balance decides it: an odd number of fence delimiters means one is
+    unmatched, so the trailing fence is the orphan and is removed. An even
+    number means they pair up, so a section legitimately ending in a fenced
+    code block keeps it.
+
     Args:
         text: A section body, before header normalization.
 
@@ -59,6 +70,7 @@ def _strip_wrapping_fence(text: str) -> str:
     m = _OPEN_FENCE.match(t)
     if m:
         t = t[m.end():]
+    if sum(1 for ln in t.split("\n") if ln.lstrip().startswith("```")) % 2:
         t = _CLOSE_FENCE.sub("", t)
     return t.strip()
 

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -300,3 +300,32 @@ def test_parse_strips_wrapping_markdown_fence():
     assert "```" not in recent
     assert archive.startswith("# Archive")
     assert "```" not in archive
+
+
+def test_parse_strips_orphaned_closing_fence_from_archive():
+    """A fence wrapping the WHOLE envelope leaves its closer in the ARCHIVE half.
+
+    The opener lands before ===RECENT=== and the closer after the archive body,
+    so the archive section inherits an unmatched ``` with no opener of its own —
+    _strip_wrapping_fence's opener-gated close-strip never fires and the fence
+    survives into archive.md (the other half of issue #126).
+    """
+    recent, archive = parse_consolidation_response(
+        "```\n"
+        "===RECENT===\n# Recent\n\n## 2026-07-20\nDid a thing.\n\n"
+        "===ARCHIVE===\n# Archive\n\n## Week of 2026-07-14\nOld stuff.\n"
+        "```"
+    )
+    assert "```" not in recent
+    assert "```" not in archive
+    assert archive.startswith("# Archive")
+    assert "Old stuff." in archive
+
+
+def test_parse_keeps_balanced_code_block_at_end_of_section():
+    """A section legitimately ENDING in a fenced block must keep it."""
+    _, archive = parse_consolidation_response(
+        "===RECENT===\n# Recent\n\nx\n\n"
+        "===ARCHIVE===\n# Archive\n\nRan:\n```bash\nnpm test\n```"
+    )
+    assert "```bash\nnpm test\n```" in archive


### PR DESCRIPTION
## The other half of #126

`_strip_wrapping_fence` removes a closing fence only when the **same** section also started with an opening one:

```python
m = _OPEN_FENCE.match(t)
if m:
    t = t[m.end():]
    t = _CLOSE_FENCE.sub("", t)   # ← only reachable when this section had an opener
```

That holds when the model fences a single section body. It does not hold when the model fences the **whole** `===RECENT===`/`===ARCHIVE===` envelope — which is what the output-format block in `prompts/consolidate-staging.prompt.txt` asks for, since it shows the envelope inside a fence under "Return EXACTLY this structure".

Then the opener lands in the recent half and the closer in the archive half. The archive half has no opener of its own, so the gated strip never fires and the ``` survives into `archive.md`.

So #126's doubled `# Recent` header is fixed, but the *orphaned-fence artifact* the docstring names still lands — just on the archive side.

### Reproduction

```python
>>> parse_consolidation_response(
...     "```\n===RECENT===\n# Recent\n\nx\n\n===ARCHIVE===\n# Archive\n\ny\n```")
('# Recent\n\nx', '# Archive\n\ny\n```')
                                 ^^^ orphan
```

Observed in the wild on 0.8.3 and reproduced against 0.8.6: `recent.md` opened with an unclosed fence and `archive.md` ended with the matching closer. It matters mildly but persistently — `archive.md` is re-fed as the next consolidation's input and is injected into every session's context.

## The fix

Decide on **balance** rather than on the opener: an odd number of fence delimiters means one is unmatched, so the trailing fence is the orphan and is removed; an even number means they pair up, so a section legitimately ending in a fenced code block keeps it.

An unconditional `_CLOSE_FENCE.sub` would have been the smaller diff, but it silently corrupts a section whose body genuinely ends in a code block — `test_parse_keeps_balanced_code_block_at_end_of_section` covers that case.

## Tests

Two added to `tests/test_consolidate.py`:

- `test_parse_strips_orphaned_closing_fence_from_archive` — fails on `main`, passes with the fix
- `test_parse_keeps_balanced_code_block_at_end_of_section` — guards the fix against over-stripping

Full suite: **538 passed, 42 skipped**, coverage 98.21%. Existing fence tests (`test_parse_strips_stray_leading_fence_no_double_header`, `test_parse_strips_wrapping_markdown_fence`) unchanged and green.

---

Found while diagnosing an unrelated 8-day outage on 0.8.3 where every memory write failed silently — thank you for the `_failure_detail()` change in 0.8.6, which is exactly what would have surfaced it.