### PR TITLE
fix(config): wire the jq-free fallback into config() and the layered merge

### DIFF
--- a/scripts/detect-tools.sh
+++ b/scripts/detect-tools.sh
@@ -69,7 +69,13 @@ try:
             break
     if val is None:
         sys.exit(0)
-    print(val if isinstance(val, (str, int, float, bool)) else json.dumps(val))
+    # jq -r prints strings raw and everything else in jq's JSON textual
+    # form — crucially "true"/"false" for booleans, not Python's capitalized
+    # str(True)/str(False). Getting this wrong silently breaks every caller
+    # that does `[ "$x" = "true" ]` against a boolean config key (e.g.
+    # git_backup.gpg_sign, allow_remote_change) whenever jq is absent: the
+    # comparison never matches, so the key always reads as false.
+    print(val if isinstance(val, str) else json.dumps(val))
 except Exception:
     sys.exit(0)
 PYEOF

--- a/scripts/lib-memory-dir.sh
+++ b/scripts/lib-memory-dir.sh
@@ -188,8 +188,39 @@ if [ "${#_cfg_sources[@]}" -gt 0 ] && command -v jq >/dev/null 2>&1; then
     # convention: `_*` are user-facing docs (_comments/_purpose/_notes), never runtime data.
     jq -s 'reduce .[] as $x ({}; . * $x) | with_entries(select(.key | startswith("_") | not))' "${_cfg_sources[@]}" > "$_merged_cfg" 2>/dev/null \
         || cp "$_bundled_cfg" "$_merged_cfg" 2>/dev/null
+elif [ "${#_cfg_sources[@]}" -gt 0 ]; then
+    # No jq — do the same deep-merge in Python instead of silently dropping
+    # the user-global/per-project layers and copying only the bundled
+    # defaults. Every override in ~/.remember/config.json or
+    # ${REMEMBER_DIR}/config.json (time_format, model, cooldowns.*,
+    # thresholds.*, git_backup.*) was previously invisible on any machine
+    # without jq — this made config() (log.sh) irrelevant to those users.
+    "${PYTHON:-python3}" - "$_merged_cfg" "${_cfg_sources[@]}" > /dev/null 2>&1 <<'PYMERGE' || cp "$_bundled_cfg" "$_merged_cfg" 2>/dev/null
+import json
+import sys
+
+
+def deep_merge(a, b):
+    if isinstance(a, dict) and isinstance(b, dict):
+        out = dict(a)
+        for k, v in b.items():
+            out[k] = deep_merge(out[k], v) if k in out else v
+        return out
+    return b
+
+
+out_path = sys.argv[1]
+merged = {}
+for path in sys.argv[2:]:
+    with open(path) as f:
+        merged = deep_merge(merged, json.load(f))
+# Strip `_`-prefixed doc keys, top-level only — same convention as the jq path.
+merged = {k: v for k, v in merged.items() if not str(k).startswith("_")}
+with open(out_path, "w") as f:
+    json.dump(merged, f)
+PYMERGE
 else
-    # No jq, or no config files — fall back to the bundled defaults.
+    # No config files at all — fall back to the bundled defaults.
     cp "$_bundled_cfg" "$_merged_cfg" 2>/dev/null || echo '{}' > "$_merged_cfg"
 fi
 

--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -60,8 +60,12 @@ fi
 config() {
     local key="$1"
     local default="$2"
-    if [ -f "$REMEMBER_CONFIG" ] && command -v jq >/dev/null 2>&1; then
-        local val
+    if [ ! -f "$REMEMBER_CONFIG" ]; then
+        echo "$default"
+        return
+    fi
+    local val=""
+    if command -v jq >/dev/null 2>&1; then
         # NOT `$key // empty`: jq's // treats false the same as null, so every
         # boolean option set to false read back as its default and could never
         # be switched off (#159). features.ndc_compression and features.recovery
@@ -76,10 +80,45 @@ config() {
         #   the string "null" — `jq -r` prints both as the same bare word.
         val=$(jq -r "if $key == null then \"\" else ($key | tostring) end" \
             "$REMEMBER_CONFIG" 2>/dev/null)
-        [ -n "$val" ] && echo "$val" || echo "$default"
+    elif type _jq_fallback >/dev/null 2>&1; then
+        # No jq — detect-tools.sh already defined a Python-based fallback for
+        # exactly this (bare-key `jq -r '.key' file` reads). config() branched
+        # on `command -v jq` and fell straight to `echo "$default"` without
+        # ever trying it, so every user config override was silently ignored
+        # on any jq-less machine. Wire it in here, matching #159's null-vs-
+        # false semantics: an absent/null key falls through to `default`
+        # below; a present `false` prints as the string "false" (see
+        # detect-tools.sh's isinstance(val, str) fix for why that's not
+        # Python's "False").
+        val=$(_jq_fallback -r "$key" "$REMEMBER_CONFIG" 2>/dev/null)
     else
-        echo "$default"
+        # log.sh can be sourced directly without detect-tools.sh (some
+        # callers/tests do), so _jq_fallback may not exist. Same read,
+        # inlined, so config() never regresses to bundled-default-only just
+        # because of sourcing order. Same null-vs-false semantics as above:
+        # a genuinely absent/null key leaves $val empty (falls to $default
+        # below); a present `false` renders as jq's "false", not Python's
+        # str(False).
+        val=$("${PYTHON:-python3}" -c '
+import json, sys
+try:
+    data = json.load(open(sys.argv[2]))
+    keys = sys.argv[1].strip(".").split(".")
+    v = data
+    for k in keys:
+        if k and isinstance(v, dict):
+            v = v.get(k)
+        if v is None:
+            break
+    if v is not None:
+        # jq -r semantics: raw strings, JSON textual form otherwise
+        # (crucially "true"/"false", not Python str(True)/str(False)).
+        print(v if isinstance(v, str) else json.dumps(v))
+except Exception:
+    pass
+' "$key" "$REMEMBER_CONFIG" 2>/dev/null)
     fi
+    [ -n "$val" ] && echo "$val" || echo "$default"
 }
 
 REMEMBER_TZ=$(config ".timezone" "")

--- a/tests/test_jq_free_config.py
+++ b/tests/test_jq_free_config.py
@@ -1,0 +1,198 @@
+"""``config()`` (scripts/log.sh) and the 3-layer merge (scripts/lib-memory-dir.sh)
+must actually use the jq-free fallback that scripts/detect-tools.sh already
+ships, on any machine without ``jq`` on PATH.
+
+Before this fix, both branched on ``command -v jq`` and fell straight through
+to ``echo "$default"`` / a bundled-only copy whenever it was absent — even
+though detect-tools.sh defines ``_jq_fallback``, a Python-based reader, for
+exactly this case. It was simply never wired into either caller. Consequence:
+on any jq-less install, *every* user config override (time_format, model,
+cooldowns.*, thresholds.*, git_backup.*) was silently ignored — config()
+always returned its hardcoded default, and the merge always returned the
+plugin-bundled config.json untouched.
+
+A second, narrower bug rides along: the fallback's Python reader printed
+``str(True)`` / ``str(False)`` ("True"/"False") for boolean config values
+instead of jq's JSON textual form ("true"/"false"). Every ``[ "$x" = "true" ]``
+caller against a boolean key (git_backup.gpg_sign, allow_remote_change) read
+it as false no matter what the config said.
+
+These tests force jq off PATH by construction (a filtered PATH with every
+real binary symlinked in *except* jq), so they fail deterministically on
+pristine 0.8.6 whether or not the machine running them happens to have jq
+installed, and pass once the fallback is actually wired in.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash subprocess + POSIX layout — not portable to Windows runners (#79)",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DETECT_SCRIPT = REPO_ROOT / "scripts" / "detect-tools.sh"
+LIB_SCRIPT = REPO_ROOT / "scripts" / "lib-memory-dir.sh"
+LOG_SH = REPO_ROOT / "scripts" / "log.sh"
+
+
+def _path_without_jq(tmp_path: Path) -> str:
+    """Build a PATH that resolves every real binary except ``jq``.
+
+    Symlinking the entire real PATH minus jq (rather than e.g. an empty PATH)
+    keeps bash, python3, coreutils etc. all working exactly as on the real
+    machine — only jq disappears, deterministically, regardless of whether
+    this test happens to run on a box that has it installed.
+    """
+    fake_bin = tmp_path / "no-jq-bin"
+    fake_bin.mkdir()
+    for d in os.environ.get("PATH", "").split(os.pathsep):
+        try:
+            names = os.listdir(d)
+        except OSError:
+            continue
+        for name in names:
+            if name == "jq":
+                continue
+            target = fake_bin / name
+            if target.exists() or target.is_symlink():
+                continue
+            try:
+                os.symlink(os.path.join(d, name), target)
+            except OSError:
+                pass
+    return str(fake_bin)
+
+
+def _dirs(tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+    pipeline = tmp_path / "plugin"
+    pipeline.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    return project, pipeline, home
+
+
+def _run_config(tmp_path: Path, key: str, default: str, config_json: dict) -> str:
+    """Source detect-tools + lib-memory-dir + log.sh (no jq on PATH) against a
+    per-project config override, and return what config() prints for `key`."""
+    project, pipeline, home = _dirs(tmp_path)
+    (pipeline / "config.json").write_text(json.dumps({}))
+    remember = project / ".remember"
+    remember.mkdir()
+    (remember / "config.json").write_text(json.dumps(config_json))
+
+    script = f"""
+    set -e
+    export PROJECT_DIR={project}
+    export PIPELINE_DIR={pipeline}
+    export HOME={home}
+    source {DETECT_SCRIPT}
+    source {LIB_SCRIPT}
+    source {LOG_SH}
+    config '{key}' '{default}'
+    """
+    env = {**os.environ, "PATH": _path_without_jq(tmp_path)}
+    result = subprocess.run(["bash", "-c", script], env=env,
+                            capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, f"config() sourcing failed:\n{result.stderr}"
+    return result.stdout.strip()
+
+
+class TestConfigUsesJqFreeFallback:
+
+    def test_string_override_honoured_without_jq(self, tmp_path):
+        """A per-project config override must not be silently dropped just
+        because jq is absent — config() must fall through to the Python
+        fallback detect-tools.sh already provides."""
+        out = _run_config(tmp_path, ".model", "haiku", {"model": "sonnet"})
+        assert out == "sonnet", (
+            "config() ignored the project override and returned the "
+            "hardcoded default — the jq-free fallback was never wired in"
+        )
+
+    def test_nested_cooldown_override_honoured_without_jq(self, tmp_path):
+        out = _run_config(tmp_path, ".cooldowns.save_seconds", "120",
+                          {"cooldowns": {"save_seconds": 45}})
+        assert out == "45"
+
+    def test_boolean_true_reads_as_lowercase_true_without_jq(self, tmp_path):
+        """git_backup.gpg_sign / allow_remote_change are booleans compared with
+        `[ "$x" = "true" ]` — Python's str(True) ("True") must never leak
+        through; jq's own textual form ("true") must."""
+        out = _run_config(tmp_path, ".git_backup.gpg_sign", "false",
+                          {"git_backup": {"gpg_sign": True}})
+        assert out == "true", (
+            f"expected jq-style lowercase 'true', got {out!r} — a bash "
+            '`[ "$x" = "true" ]` comparison against this would always be false'
+        )
+
+    def test_boolean_false_reads_as_lowercase_false_without_jq(self, tmp_path):
+        out = _run_config(tmp_path, ".git_backup.gpg_sign", "true",
+                          {"git_backup": {"gpg_sign": False}})
+        assert out == "false"
+
+
+class TestLayeredMergeUsesJqFreeFallback:
+
+    def test_per_project_override_survives_merge_without_jq(self, tmp_path):
+        """lib-memory-dir.sh's 3-layer merge must not collapse to the bundled
+        config alone just because jq is absent."""
+        project, pipeline, home = _dirs(tmp_path)
+        (pipeline / "config.json").write_text(
+            json.dumps({"cooldowns": {"save_seconds": 99}})
+        )
+        remember = project / ".remember"
+        remember.mkdir()
+        (remember / "config.json").write_text(
+            json.dumps({"cooldowns": {"save_seconds": 999}})
+        )
+
+        script = f"""
+        set -e
+        export PROJECT_DIR={project}
+        export PIPELINE_DIR={pipeline}
+        export HOME={home}
+        source {DETECT_SCRIPT}
+        source {LIB_SCRIPT}
+        source {LOG_SH}
+        config '.cooldowns.save_seconds' '120'
+        """
+        env = {**os.environ, "PATH": _path_without_jq(tmp_path)}
+        result = subprocess.run(["bash", "-c", script], env=env,
+                                capture_output=True, text=True, timeout=30)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "999", (
+            "per-project override was dropped by the no-jq merge fallback — "
+            "it copied only the bundled config"
+        )
+
+    def test_underscore_keys_stripped_without_jq(self, tmp_path):
+        """The `_`-prefixed doc-key convention must hold in the Python merge
+        path too, not just the jq path."""
+        project, pipeline, home = _dirs(tmp_path)
+        (pipeline / "config.json").write_text(
+            json.dumps({"_comments": {"a": "doc"}, "cooldowns": {"save_seconds": 99}})
+        )
+
+        script = f"""
+        set -e
+        export PROJECT_DIR={project}
+        export PIPELINE_DIR={pipeline}
+        export HOME={home}
+        source {DETECT_SCRIPT}
+        source {LIB_SCRIPT}
+        python3 -c "import json,sys; d=json.load(open('$REMEMBER_CONFIG')); print('_comments' in d)"
+        """
+        env = {**os.environ, "PATH": _path_without_jq(tmp_path)}
+        result = subprocess.run(["bash", "-c", script], env=env,
+                                capture_output=True, text=True, timeout=30)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "False"


### PR DESCRIPTION
## The bug

`scripts/log.sh`'s `config()` and the 3-layer merge in
`scripts/lib-memory-dir.sh` both branch on `command -v jq` and fall straight
through to a hardcoded default / the bundled-only config whenever `jq` is
absent — even though `scripts/detect-tools.sh` already defines `_jq_fallback`,
a Python-based reader, for exactly this case. It is simply never wired into
either caller.

A second, narrower bug rides along in `_jq_fallback` itself: its Python
reader printed `str(True)` / `str(False)` ("True"/"False") for boolean
config values instead of jq's own JSON textual form ("true"/"false"). Every
`[ "$x" = "true" ]` comparison against a boolean key — `git_backup.gpg_sign`,
`allow_remote_change` — read as false regardless of the config, once jq was
absent, because the fallback was actually reached.

## Why it matters

On any machine without `jq` on PATH, **every** user config override —
`time_format`, `model`, `cooldowns.*`, `thresholds.*`, `git_backup.*` — is
silently ignored. `config()` always returns its built-in default and
`lib-memory-dir.sh`'s merge always returns the plugin-bundled `config.json`
untouched, with no warning to the user.

## Relationship to #165

This is adjacent to, but distinct from, #165 ("a false boolean is a value,
not a missing key"). #165 fixed the jq expression itself, inside the jq
branch, so that a present `false` isn't conflated with a missing key (jq's
`//` treats both as null) — but that fix only matters when jq actually runs.
This PR is about the **no-jq path never running any lookup at all**: the
fallback existed, and (once fixed here) is shaped correctly, but `config()`
never called it. #165's jq expression is preserved verbatim in the jq
branch; the no-jq branches (the fallback function, and an inlined
equivalent for the rare case `log.sh` is sourced without
`detect-tools.sh`) are written to match its same null-vs-false semantics:
an absent/null key falls through to the caller's `default`, and a present
`false` renders as the string `"false"`.

## The fix

- `detect-tools.sh`: `_jq_fallback`'s Python reader now prints
  `json.dumps(v)` for non-string values (so booleans render as jq does:
  `true`/`false`), keeping raw output only for actual strings.
- `log.sh`'s `config()`: tries `jq` first (#165's expression, unchanged),
  then `_jq_fallback` if it was defined by `detect-tools.sh`, then an
  inlined equivalent Python reader for the (rare) case `log.sh` is sourced
  directly without `detect-tools.sh` — so `config()` can never silently
  regress to bundled-default-only purely because of sourcing order.
- `lib-memory-dir.sh`: the 3-layer merge gets a Python deep-merge fallback
  (mirroring the jq `reduce` expression, later files override earlier ones,
  `_`-prefixed doc keys stripped) instead of copying only the bundled
  config when jq is absent and config files exist.

No behavior changes when `jq` is present.

## Test evidence

New file: `tests/test_jq_free_config.py`. Forces jq off `PATH` by
construction (symlinks every real binary except `jq` into a private bin
dir), so it is deterministic regardless of whether the CI machine happens
to have `jq` installed.

Before (unpatched `main`, HEAD `d9480ec`):
```
FAILED tests/test_jq_free_config.py::TestConfigUsesJqFreeFallback::test_string_override_honoured_without_jq
FAILED tests/test_jq_free_config.py::TestConfigUsesJqFreeFallback::test_nested_cooldown_override_honoured_without_jq
FAILED tests/test_jq_free_config.py::TestConfigUsesJqFreeFallback::test_boolean_true_reads_as_lowercase_true_without_jq
FAILED tests/test_jq_free_config.py::TestConfigUsesJqFreeFallback::test_boolean_false_reads_as_lowercase_false_without_jq
FAILED tests/test_jq_free_config.py::TestLayeredMergeUsesJqFreeFallback::test_per_project_override_survives_merge_without_jq
FAILED tests/test_jq_free_config.py::TestLayeredMergeUsesJqFreeFallback::test_underscore_keys_stripped_without_jq
6 failed in 87.45s
```

After (patched):
```
6 passed in 87.75s
```

### Regression suite

This machine has no `jq` installed, so `main`'s own `pytest tests/ -q`
baseline already fails a batch of tests unrelated to this patch's own new
file (`test_layered_config.py`, `test_log_sh.py`, `test_path_resolution.py`'s
config/timezone cases, `test_git_backup_hook.py`'s gpg-sign case) — several
of those are directly explained by this same bug and disappear once this
patch is applied:

- Baseline (`main`, HEAD `d9480ec`): `38 failed, 625 passed, 58 skipped`
- Patched: `12 failed, 657 passed, 58 skipped` (+6 for this patch's own new
  tests, +20 pre-existing failures fixed as a side effect of the real fix)

The remaining 12 failures on this machine are a limitation of those
particular tests' own verification code (several call real `jq` directly to
inspect the merged config, independent of what `lib-memory-dir.sh` itself
does) — not a regression introduced by this patch, and not present on any
CI runner that has `jq` installed.

## Backward compatibility

None needed — this only changes what happens when `jq` is absent; a
`jq`-equipped install is byte-for-byte unaffected.

---
This PR is independent of the other four bug-fix PRs I'm submitting
alongside it and can be reviewed/merged in any order.