### PR TITLE
fix(hooks): honor CLAUDE_CONFIG_DIR instead of hardcoding $HOME/.claude

### DIFF
--- a/pipeline/extract.py
+++ b/pipeline/extract.py
@@ -45,7 +45,15 @@ def _session_dir(project_dir: str) -> str:
     # Honor HOME explicitly so test fixtures patching only HOME also work on Windows
     # (where os.path.expanduser defaults to USERPROFILE, ignoring HOME).
     home = os.environ.get("HOME") or os.path.expanduser("~")
-    return home + "/.claude/projects/" + slug
+    # Claude Code honors CLAUDE_CONFIG_DIR to relocate its whole config root
+    # (e.g. a second account on one machine: CLAUDE_CONFIG_DIR=~/.claude-max)
+    # — sessions then live under "$CLAUDE_CONFIG_DIR/projects/", not
+    # "~/.claude/projects/". An unset *or empty* value must fall back to the
+    # default; "or" (not a bare os.environ["..."] lookup) covers both, unlike
+    # a naive os.environ.get(...) + "/projects" which would yield a path
+    # starting "/projects" for CLAUDE_CONFIG_DIR="".
+    config_dir = os.environ.get("CLAUDE_CONFIG_DIR") or (home + "/.claude")
+    return config_dir + "/projects/" + slug
 
 
 def _is_line_number(value: object) -> bool:

--- a/scripts/post-tool-hook.sh
+++ b/scripts/post-tool-hook.sh
@@ -42,7 +42,7 @@ log "hook" "post-tool: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR PYTHO
 SAVE_SCRIPT="$PLUGIN_ROOT/scripts/save-session.sh"
 LAST_SAVE_FILE="$REMEMBER_DIR/tmp/last-save.json"
 PID_FILE="$REMEMBER_DIR/tmp/save-session.pid"
-SESSION_DIR="$HOME/.claude/projects/$(session_dir_slug "$PROJECT")"
+SESSION_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/$(session_dir_slug "$PROJECT")"
 
 [ -f "$SAVE_SCRIPT" ] || exit 0
 

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -99,7 +99,7 @@ for arg in "$@"; do
     esac
 done
 
-SESSION_DIR_PATH="$HOME/.claude/projects/$(session_dir_slug "$PROJECT_DIR")"
+SESSION_DIR_PATH="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/$(session_dir_slug "$PROJECT_DIR")"
 if [ -z "$SESSION_ID" ]; then
     LATEST_JSONL=$(ls -t "$SESSION_DIR_PATH"/*.jsonl 2>/dev/null | head -1)
     SESSION_ID=$(basename "$LATEST_JSONL" .jsonl)

--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -70,7 +70,7 @@ rm -f "$REMEMBER_DIR/tmp/save-session.pid"
 # ── Recovery: save the most recent missed session ──────────────────────────
 if [ "$(config '.features.recovery' true)" = "true" ]; then
 PROJECT_PATH_SLUG="$(session_dir_slug "$PROJECT")"
-SESSIONS_DIR="$HOME/.claude/projects/${PROJECT_PATH_SLUG}"
+SESSIONS_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/${PROJECT_PATH_SLUG}"
 LAST_SAVE_FILE="$REMEMBER_DIR/tmp/last-save.json"
 
 if [ -d "$SESSIONS_DIR" ] && [ -f "$LAST_SAVE_FILE" ]; then

--- a/tests/test_claude_config_dir.py
+++ b/tests/test_claude_config_dir.py
@@ -1,0 +1,167 @@
+"""Hooks must honour ``CLAUDE_CONFIG_DIR``, not hardcode ``$HOME/.claude``.
+
+Claude Code supports relocating its whole config root via ``CLAUDE_CONFIG_DIR``
+(e.g. a second account on one machine: ``CLAUDE_CONFIG_DIR=~/.claude-max``).
+When set, session transcripts live under
+``$CLAUDE_CONFIG_DIR/projects/<slug>/``, not ``$HOME/.claude/projects/<slug>/``.
+
+Four sites hardcoded the default path outright: ``scripts/save-session.sh``,
+``scripts/session-start-hook.sh``, ``scripts/post-tool-hook.sh``, and
+``pipeline/extract.py:_session_dir``. Under a non-default
+``CLAUDE_CONFIG_DIR`` every one of them looked in the *wrong account's*
+``~/.claude/projects/`` — either finding nothing (silently no-op'ing memory
+for the whole account), or, if both accounts happen to run in the same
+project directory, reading and summarizing the *other* account's transcripts
+into this one's memory.
+
+An empty-string ``CLAUDE_CONFIG_DIR`` (unset-but-exported, or exported empty
+by some shell init) must fall back to the default rather than producing a
+path that starts with "/projects".
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash subprocess + POSIX layout — not portable to Windows runners (#79)",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestExtractSessionDirHonoursConfigDir:
+
+    def test_uses_claude_config_dir_when_set(self, monkeypatch, tmp_path):
+        # No importlib.reload: _session_dir reads os.environ at call time,
+        # not at import time, so a plain import is enough — and reloading
+        # pipeline.extract here would rebind its functions to new objects,
+        # breaking the `is`-identity check in
+        # test_position_store.py::test_the_two_modules_share_one_reader for
+        # any test that runs afterward in the same session.
+        sys.path.insert(0, str(REPO_ROOT))
+        import pipeline.extract as extract_mod
+
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "custom-config"))
+        result = extract_mod._session_dir("/Users/foo/myproject")
+        assert result == str(tmp_path / "custom-config") + "/projects/-Users-foo-myproject"
+        assert ".claude/projects" not in result
+
+    def test_falls_back_to_home_claude_when_unset(self, monkeypatch, tmp_path):
+        sys.path.insert(0, str(REPO_ROOT))
+        import pipeline.extract as extract_mod
+
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+        result = extract_mod._session_dir("/Users/foo/myproject")
+        assert result == str(tmp_path / "home" / ".claude") + "/projects/-Users-foo-myproject"
+
+    def test_empty_string_falls_back_not_projects_root(self, monkeypatch, tmp_path):
+        """An empty (but exported) CLAUDE_CONFIG_DIR must not produce a path
+        that starts with '/projects' — it must fall back like unset."""
+        sys.path.insert(0, str(REPO_ROOT))
+        import pipeline.extract as extract_mod
+
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", "")
+        result = extract_mod._session_dir("/Users/foo/myproject")
+        assert not result.startswith("/projects")
+        assert result == str(tmp_path / "home" / ".claude") + "/projects/-Users-foo-myproject"
+
+
+def _slug(path: str) -> str:
+    import re
+    return re.sub(r"[^a-zA-Z0-9]", "-", path)
+
+
+class TestShellHooksHonourConfigDir:
+    """save-session.sh / post-tool-hook.sh / session-start-hook.sh must find
+    the *right* account's transcript directory under CLAUDE_CONFIG_DIR."""
+
+    def _project_and_home(self, tmp_path, config_dir_name="custom-config"):
+        home = tmp_path / "home"
+        project = tmp_path / "project"
+        remember = project / ".remember"
+        (remember / "tmp").mkdir(parents=True)
+        (remember / "logs").mkdir(parents=True)
+        config_dir = tmp_path / config_dir_name
+        slug = _slug(str(project))
+        session_dir = config_dir / "projects" / slug
+        session_dir.mkdir(parents=True)
+        # A decoy under the DEFAULT ~/.claude/projects/ — if a hook falls back
+        # to the hardcoded default despite CLAUDE_CONFIG_DIR being set, it
+        # will find this session instead of the real one below.
+        decoy_dir = home / ".claude" / "projects" / slug
+        decoy_dir.mkdir(parents=True)
+        (decoy_dir / "decoy-session-0000.jsonl").write_text('{"type":"user"}\n')
+        return home, project, remember, config_dir, session_dir
+
+    def test_save_session_finds_transcript_under_config_dir(self, tmp_path):
+        home, project, remember, config_dir, session_dir = self._project_and_home(tmp_path)
+        real_session_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        (session_dir / f"{real_session_id}.jsonl").write_text('{"type":"user"}\n' * 5)
+
+        plugin = tmp_path / "plugin"
+        (plugin / "scripts").mkdir(parents=True)
+        (plugin / "pipeline").mkdir(parents=True)
+        (plugin / "pipeline" / "__init__.py").write_text("")
+        (plugin / "pipeline" / "haiku.py").write_text("# marker\n")
+        # Auto-detect session-id path: script must pick the real session
+        # (from CLAUDE_CONFIG_DIR/projects/), not the decoy under $HOME/.claude.
+        stub_shell = '''\
+import sys, os, tempfile
+CALLS = os.environ["STUB_CALLS_LOG"]
+with open(CALLS, "a") as f:
+    f.write(" ".join(sys.argv[1:]) + "\\n")
+cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+if cmd == "extract":
+    fd, path = tempfile.mkstemp(suffix="-extract")
+    with os.fdopen(fd, "w") as f:
+        f.write("Human: something\\nAssistant: something else\\n")
+    print("POSITION=5")
+    print("HUMAN_COUNT=5")
+    print("ASSISTANT_COUNT=1")
+    print("EXCHANGE_COUNT=6")
+    print(f"EXTRACT_FILE={path}")
+'''
+        (plugin / "pipeline" / "shell.py").write_text(stub_shell)
+        for script in ("save-session.sh", "resolve-paths.sh", "detect-tools.sh",
+                       "bootstrap-dirs.sh", "log.sh", "lib-memory-dir.sh"):
+            (plugin / "scripts" / script).write_text(
+                (REPO_ROOT / "scripts" / script).read_text())
+
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text('{"cooldowns": {"save_seconds": 0}}')
+        (plugin / "config.json").write_text('{}')
+        calls_log = tmp_path / "calls.log"
+
+        env = {
+            **os.environ,
+            "HOME": str(home),
+            "CLAUDE_CONFIG_DIR": str(config_dir),
+            "CLAUDE_PROJECT_DIR": str(project),
+            "CLAUDE_PLUGIN_ROOT": str(plugin),
+            "REMEMBER_CONFIG": str(cfg_path),
+            "STUB_CALLS_LOG": str(calls_log),
+        }
+        # No explicit session-id arg — the script must auto-detect the latest
+        # jsonl under CLAUDE_CONFIG_DIR/projects/<slug>/, not $HOME/.claude's.
+        result = subprocess.run(
+            ["bash", str(plugin / "scripts" / "save-session.sh"), "--dry"],
+            env=env, capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        calls_text = calls_log.read_text() if calls_log.exists() else ""
+        assert real_session_id in calls_text, (
+            f"save-session.sh did not extract the session under "
+            f"CLAUDE_CONFIG_DIR — calls were: {calls_text!r}"
+        )
+        assert "decoy-session-0000" not in calls_text, (
+            "save-session.sh fell back to $HOME/.claude/projects (the decoy) "
+            "instead of honouring CLAUDE_CONFIG_DIR"
+        )


### PR DESCRIPTION
## The bug

Claude Code supports relocating its entire config root via the
`CLAUDE_CONFIG_DIR` environment variable — used, for example, to run a
second account on one machine (`CLAUDE_CONFIG_DIR=~/.claude-max`). When
set, session transcripts live under `$CLAUDE_CONFIG_DIR/projects/<slug>/`,
not `$HOME/.claude/projects/<slug>/`.

Four sites in the plugin hardcode the default path outright, ignoring
`CLAUDE_CONFIG_DIR` entirely:

- `scripts/save-session.sh` (`SESSION_DIR_PATH`, used for session-id
  auto-detection)
- `scripts/session-start-hook.sh` (`SESSIONS_DIR`, used for missed-session
  recovery)
- `scripts/post-tool-hook.sh` (`SESSION_DIR`, used for the delta-based
  save trigger)
- `pipeline/extract.py:_session_dir` (used by every Python-side session
  lookup, including the actual extraction itself)

## Why it matters

Under a non-default `CLAUDE_CONFIG_DIR`, every one of these looks in the
*wrong account's* `~/.claude/projects/`. Depending on what's there, this
fails one of two ways:

- Nothing under the default path for this project → every hook silently
  no-ops (finds no transcript, does nothing) — memory simply never gets
  written for that account, with no error anywhere.
- The *other* account happens to have session data for a directory of the
  same slug (the same project, opened from both accounts) → this account's
  hooks read and summarize **the other account's transcripts** into this
  account's memory.

## The fix

`${CLAUDE_CONFIG_DIR:-$HOME/.claude}` in shell (all three scripts), and
the equivalent in Python:

```python
config_dir = os.environ.get("CLAUDE_CONFIG_DIR") or (home + "/.claude")
return config_dir + "/projects/" + slug
```

Bash's `:-` (colon-dash) already treats *unset or null* as "use the
default", so `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` handles an
empty-but-exported `CLAUDE_CONFIG_DIR=""` correctly with no extra logic.
The Python side needed `or`, not a bare dict lookup, for the same reason
— a naive `os.environ.get("CLAUDE_CONFIG_DIR") + "/projects"` would
produce a path starting `/projects` for an empty value.

## Test evidence

New file: `tests/test_claude_config_dir.py`:
- Three unit tests against `pipeline.extract._session_dir` (set, unset,
  empty-string `CLAUDE_CONFIG_DIR`).
- One end-to-end test running the real `save-session.sh --dry` with a
  session transcript planted under `$CLAUDE_CONFIG_DIR/projects/<slug>/`
  and a decoy transcript planted under the default
  `$HOME/.claude/projects/<slug>/` — asserts the script's session-id
  auto-detection finds the real one, not the decoy.

Before (unpatched `main`, HEAD `d9480ec`):
```
FAILED tests/test_claude_config_dir.py::TestExtractSessionDirHonoursConfigDir::test_uses_claude_config_dir_when_set
FAILED tests/test_claude_config_dir.py::TestShellHooksHonourConfigDir::test_save_session_finds_transcript_under_config_dir
2 failed, 2 passed in 0.36s
```
(The 2 passes are the unset and empty-string fallback cases, which already
matched the default; included to pin the invariant down explicitly, not
to demonstrate the bug.)

After (patched):
```
4 passed in 0.66s
```

### Regression suite

This machine has no `jq`, so `main`'s own `pytest tests/ -q` baseline
already fails a batch of tests unrelated to this change:

- Baseline (`main`, HEAD `d9480ec`): `38 failed, 625 passed, 58 skipped`
- Patched: `38 failed, 629 passed, 58 skipped` (identical pre-existing
  failures, +4 for this patch's new tests)

## Backward compatibility

None needed. Every existing installation runs with `CLAUDE_CONFIG_DIR`
unset, which is exactly the fallback branch — byte-for-byte identical
behavior to `main`.

---
This PR is independent of the other four bug-fix PRs I'm submitting
alongside it and can be reviewed/merged in any order.