### PR TITLE
release: 0.8.7 — everything that failed in silence

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remember",
   "description": "Continuous memory for Claude Code. Extracts, summarizes, and compresses conversations into tiered daily logs. Claude remembers what you did yesterday.",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.7] — Everything that failed in silence
+
+Nine issues, one shape: memory not written, and nothing anywhere saying so. Six were reported by users who had already done the diagnosis — several arrived with a verified patch, the exact call sites, and in one case a correct prediction of which tests would break. Manifest bumped per [#133](https://github.com/Digital-Process-Tools/claude-remember/issues/133).
+
 ### Fixed
 
 - **Nothing ever saved when `CLAUDE_CONFIG_DIR` was set** ([#166](https://github.com/Digital-Process-Tools/claude-remember/issues/166)) — Claude Code relocates its whole config tree, `projects/` included, when `CLAUDE_CONFIG_DIR` is set, which people use to run a separate account per project. The plugin hardcoded `~/.claude`, so it listed a directory holding no current transcripts and the save pipeline no-oped in silence: the reporter had five days and ~2000 `PostToolUse` invocations with zero saves, an empty `logs/autonomous/`, and nothing anywhere suggesting a problem. The silent version is not the worst case — a stale transcript left in the default tree with more lines than `delta_lines_trigger` would have been summarized into memory as though it were the live session. All four sites now resolve through one helper rather than four copies of the path. The test suite leaked the same variable: sandboxes point `HOME` at a temp directory but never cleared `CLAUDE_CONFIG_DIR`, so a developer who exports it had the real value follow the code out of the fixture — invisible while the plugin ignored the variable, and exposed the moment it stopped. It is cleared for every test now. Reported, diagnosed, patched and test-triaged by [@samoilovartem](https://github.com/samoilovartem), who also predicted exactly which five tests would break.


### PR DESCRIPTION
Nine issues since 0.8.6, one shape: **memory not written, and nothing anywhere saying so.**

| | |
|---|---|
| #126 | a fence parser that corrupted the entries it was meant to clean |
| #144, #145 | non-ASCII paths silently disabled the whole pipeline on Windows |
| #140 | two live sessions overwrote each other's saved position, duplicating memory |
| #139 | the summarizer stamped entries with times read out of the transcript |
| #136, #119 | a validator that detected malformed output and appended it anyway |
| #135 | git-backup read its config after forking, racing the file's deletion |
| #132 | a session opened in `$HOME` migrated away the config that directs migration |
| #124 | rotated archive slices preserved on disk and reachable by nothing |
| #141 | work done late at night filed under the next day |
| #159 | `config()` could not read `false` — two documented options unswitchable |
| #166 | a relocated session tree the plugin never looked in |

## Reported by people who had already done the work

Six of these came in diagnosed. @shenkang11 traced the non-ASCII failures down to the cp932 byte level across two boundaries. @bonyohana re-verified three separate mechanisms against `main` before filing. @jqit-ricky included recovery steps for data already lost. @samoilovartem arrived with a verified patch, the four exact call sites, and a correct prediction of which five tests would break and why. @oliver-mee asked which trade-off we wanted rather than guessing. @whatrwewaitingf0r built an isolated harness to reproduce a race they could not trigger directly.

That is most of the diagnostic work on this release.

## Manifest

Bumped to 0.8.7 per #133 — the release that shipped nothing at all, because the updater compares manifest versions and ours still said 0.8.3. `tests/test_version_manifest.py` now fails the build on that drift, so it is enforced rather than remembered.

## Verification

684 tests passing. Every fix was reviewed adversarially and re-reviewed until a round came back clean — six rounds on the fence parser, six on the save-session gates, four each on the slug and the rotated archives. CI was green at every stage and caught none of what those rounds found.

## Known, not in this release

- **#157** — the slug does not truncate at 200 characters with a hash, so deep project paths still never save. Confirmed against a real session; the algorithm is verified and in the issue. This is a live silent failure for anyone with a deep enough path.
- **#158** — a duplicate naive slug in `lib-memory-dir.sh`, live for `user-prompt-hook.sh`, plus a third copy in `extract.py`.
- **#169** — `CLAUDE_CONFIG_DIR` is not path-normalised on Windows the way `PROJECT_DIR` is; no coverage on the platform where it matters.
