### PR TITLE
fix(ndc): serialize now.md writers behind a lock (follow-up to #142)

### DIFF
--- a/scripts/lib-now-lock.sh
+++ b/scripts/lib-now-lock.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# ============================================================================
+# lib-now-lock.sh — serialized read/modify/write access to now.md
+# ============================================================================
+#
+# DESCRIPTION
+#   Follow-up to #142. That fix replaced the blind `: > "$MEMORY_FILE"` NDC
+#   truncate with a partial truncate (drop only the bytes that were actually
+#   compressed, keep anything a concurrent save appended after the snapshot)
+#   — the right idea, but every step around it is still unsynchronized:
+#
+#     1. The byte-count snapshot (`wc -c`) and the `build-ndc-prompt` read
+#        that follows it are two separate, unlocked reads of now.md. A save
+#        landing in between makes the snapshot disagree with what was
+#        actually fed to the summarizer — the eventual truncate then drops
+#        bytes that were never summarized.
+#     2. The closing `tail`/`mv` that commits the truncate is itself
+#        unserialized against a concurrent append landing at the same time.
+#     3. The `tail`-failure branch still falls back to `: > "$MEMORY_FILE"`
+#        — the original #142 bug, preserved as an error path.
+#
+#   This library gives every now.md writer (save's append, NDC's snapshot,
+#   NDC's commit) a single flock-guarded critical section, so none of the
+#   three windows above can open.
+#
+# USAGE
+#   source "$(dirname "$0")/lib-now-lock.sh"
+#   now_locked 30 now_append "$MEMORY_FILE" "$HAIKU_TEXT_FILE"
+#
+# EXIT CODES (now_locked)
+#   rc of the wrapped command, or 99 if the lock could not be acquired
+#   within the given timeout.
+#
+# ============================================================================
+
+[ -n "${_LIB_NOW_LOCK_LOADED:-}" ] && return 0
+_LIB_NOW_LOCK_LOADED=1
+
+# now_locked <timeout_s> <command> [args...]
+# Runs the command (function or external) inside a subshell holding an
+# flock on now.lock, so it cannot interleave with any other now_locked
+# caller. Returns the command's exit code, or 99 on lock-acquire timeout.
+now_locked() {
+    local _timeout="$1"; shift
+    (
+        flock -w "$_timeout" 9 || exit 99
+        "$@"
+    ) 9>>"${REMEMBER_DIR}/tmp/now.lock"
+}
+
+# now_append <memory_file> <content_file>
+# Blank-line separator + content, same shape as the unlocked append it
+# replaces. Call only via now_locked.
+now_append() {
+    local mem="$1" content="$2"
+    echo "" >> "$mem" && cat "$content" >> "$mem"
+}
+
+# now_truncate_first <memory_file> <n_bytes>
+# Drops ONLY the first n bytes (the span already compressed into
+# today-*.md), preserving anything appended after the snapshot. Call only
+# via now_locked, immediately after taking the same snapshot count under
+# the same lock (see save-session.sh's NDC step).
+#
+# Writes the tail to a sibling temp file and `mv`s it over $mem (same
+# directory, same filesystem — an atomic rename, not an O_TRUNC window).
+# If `n` exceeds the file's current size, or `tail` itself fails, $mem is
+# left completely untouched and a nonzero rc is returned — never the
+# blind `: > $mem` of #142. The temp file is removed on every path.
+now_truncate_first() {
+    local mem="$1" n="$2" tmp size rc
+    [ -z "$n" ] && return 0
+    [ "$n" -eq 0 ] && return 0
+
+    size=$(wc -c < "$mem") || return 1
+    if [ "$n" -gt "$size" ]; then
+        return 1
+    fi
+
+    tmp="${mem}.tail.$$"
+    if tail -c +"$((n + 1))" "$mem" > "$tmp"; then
+        mv -f "$tmp" "$mem"
+        rc=$?
+        [ "$rc" -ne 0 ] && rm -f "$tmp"
+    else
+        rc=$?
+        rm -f "$tmp"
+    fi
+    return $rc
+}

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -58,6 +58,7 @@ source "$(dirname "$0")/resolve-paths.sh"
 source "$(dirname "$0")/detect-tools.sh"
 source "$(dirname "$0")/bootstrap-dirs.sh"
 source "$(dirname "$0")/log.sh"
+source "$(dirname "$0")/lib-now-lock.sh"
 log "hook" "save-session: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR PYTHON=$PYTHON REMEMBER_DIR=$REMEMBER_DIR"
 
 LOCK_FILE="${REMEMBER_DIR}/tmp/save.lock"
@@ -350,8 +351,8 @@ fi
 if [ ! -s "$MEMORY_FILE" ]; then
     printf '%s\n' "$TODAY_DATE" > "$NOW_DAY_FILE" 2>/dev/null || true
 fi
-echo "" >> "$MEMORY_FILE" 2>/dev/null || { log "write" "ERROR: cannot write now.md"; exit 1; }
-cat "$HAIKU_TEXT_FILE" >> "$MEMORY_FILE"
+now_locked 30 now_append "$MEMORY_FILE" "$HAIKU_TEXT_FILE" \
+    || { log "write" "ERROR: cannot write now.md (lock timeout or write failed)"; exit 1; }
 log "write" "appended: $(head -1 "$HAIKU_TEXT_FILE" | cut -c1-80)"
 cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell save-position "$LAST_SAVE_FILE" "$SESSION_ID" "$POSITION"
 log "write" "position → $POSITION"
@@ -393,12 +394,22 @@ TODAY_FILE="${REMEMBER_DIR}/today-${NDC_DAY}.md"
 if [ "$RUN_NDC" = true ]; then
     log "ndc" "now.md → today-${NDC_DAY}.md"
     date +%s > "$NDC_MARKER"
-    NDC_SRC_BYTES=$(wc -c < "$MEMORY_FILE" | tr -d ' ')
     NDC_PROMPT=$(mktemp "${TMPDIR:-/tmp}"/remember-ndc-XXXXXX)
 
-    cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell build-ndc-prompt "$MEMORY_FILE" "$NDC_PROMPT"
+    # Snapshot the byte-count and the build-ndc-prompt read together, under
+    # now.lock — so the count can never disagree with what was actually fed
+    # to the summarizer (a save landing between an unlocked `wc -c` and the
+    # prompt build was defect (a) of #142's incomplete follow-up).
+    _ndc_snapshot() {
+        wc -c < "$MEMORY_FILE" | tr -d ' '
+        (cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell build-ndc-prompt "$MEMORY_FILE" "$NDC_PROMPT") >&2
+    }
+    NDC_SRC_BYTES=$(now_locked 30 _ndc_snapshot) || NDC_SRC_BYTES=""
+    if [ -z "$NDC_SRC_BYTES" ]; then
+        log "ndc" "ERROR: snapshot lock timeout — skipping NDC this round"
+    fi
 
-    if [ -s "$NDC_PROMPT" ]; then
+    if [ -n "$NDC_SRC_BYTES" ] && [ -s "$NDC_PROMPT" ]; then
         (set +e  # don't inherit set -e — a haiku non-zero exit must not kill the subshell
             NDC_ERR=$(mktemp "${TMPDIR:-/tmp}"/remember-ndc-err-XXXXXX)
             # 180s (not the 120s default): NDC compresses a whole now.md.
@@ -411,48 +422,49 @@ if [ "$RUN_NDC" = true ]; then
                 safe_eval <<< "$NDC_VARS"
                 NDC_TEXT=$(cat "$HAIKU_TEXT_FILE")
                 if [ -n "$NDC_TEXT" ]; then
-                    [ -s "$TODAY_FILE" ] && echo "" >> "$TODAY_FILE"
-                    cat "$HAIKU_TEXT_FILE" >> "$TODAY_FILE"
-                    # Drop exactly the bytes that were compressed, not the whole
-                    # file (#142). now.md was snapshotted before the Haiku call
-                    # above, which can take up to 180s — and by then the parent
-                    # has released the save lock and exited, so a *newer* save
-                    # may well have appended an entry. `: >` erased those
-                    # entries, and their position had already been advanced, so
-                    # they were unrecoverable and nothing was logged. Keep
-                    # everything past the snapshot offset instead.
-                    NDC_TAIL=$(mktemp "${TMPDIR:-/tmp}"/remember-ndc-tail-XXXXXX)
-                    if tail -c +$(( NDC_SRC_BYTES + 1 )) "$MEMORY_FILE" > "$NDC_TAIL" 2>/dev/null; then
-                        NDC_KEPT=$(wc -c < "$NDC_TAIL" | tr -d ' ')
-                        mv "$NDC_TAIL" "$MEMORY_FILE"
-                        # The stamped day is spent with the bytes it covered.
-                        # Anything kept was appended during this compression,
-                        # so stamp it with the day it is NOW — not $TODAY_DATE,
-                        # which was computed once in the parent before a Haiku
-                        # call that can run 180s. A compression that started
-                        # before midnight would otherwise stamp those newer
-                        # bytes with the previous day: not the day they were
-                        # appended, not their own day, but a third stale one
-                        # belonging to an earlier run. That is the #142-shaped
-                        # window, and misfiling is exactly what it costs here.
-                        #
-                        # Still one stamp for the whole kept range. If two saves
-                        # land inside this window on opposite sides of midnight,
-                        # the earlier one is filed with the later one's day.
-                        # Splitting the range would need each entry to carry its
-                        # own day, which is the thing now.md does not have and
-                        # the reason this stamp exists — see #141 for the flush
-                        # design that would close it.
+                    # Commit today-*.md + drop exactly the compressed bytes from
+                    # now.md, all under one now.lock acquisition, so the
+                    # tail/mv (defect (b)) cannot interleave with a concurrent
+                    # append, and a tail failure (defect (c)) leaves now.md
+                    # untouched instead of falling back to #142's blind `: >`.
+                    #
+                    # The stamped day is spent with the bytes it covered.
+                    # Anything kept was appended during this compression, so
+                    # it is stamped with the day it is NOW — not $TODAY_DATE,
+                    # which was computed once in the parent before a Haiku
+                    # call that can run 180s. A compression that started
+                    # before midnight would otherwise stamp those newer bytes
+                    # with the previous day: not the day they were appended,
+                    # not their own day, but a third stale one belonging to
+                    # an earlier run. That is the #142-shaped window, and
+                    # misfiling is exactly what it costs here.
+                    #
+                    # Still one stamp for the whole kept range. If two saves
+                    # land inside this window on opposite sides of midnight,
+                    # the earlier one is filed with the later one's day.
+                    # Splitting the range would need each entry to carry its
+                    # own day, which is the thing now.md does not have and
+                    # the reason this stamp exists — see #141 for the flush
+                    # design that would close it.
+                    _ndc_commit() {
+                        [ -s "$TODAY_FILE" ] && echo "" >> "$TODAY_FILE"
+                        cat "$HAIKU_TEXT_FILE" >> "$TODAY_FILE"
+                        now_truncate_first "$MEMORY_FILE" "$NDC_SRC_BYTES"
+                    }
+                    now_locked 60 _ndc_commit
+                    _NDC_RC=$?
+                    if [ "$_NDC_RC" -eq 99 ]; then
+                        log "ndc" "ERROR: now.lock timeout — skipped commit, now.md untouched"
+                    elif [ "$_NDC_RC" -ne 0 ]; then
+                        log "ndc" "ERROR: truncate refused (stale byte count?) rc=$_NDC_RC — now.md untouched"
+                    else
+                        NDC_KEPT=$(wc -c < "$MEMORY_FILE" | tr -d ' ')
                         if [ "$NDC_KEPT" -gt 0 ]; then
                             printf '%s\n' "$(_remember_date +%Y-%m-%d)" > "$NOW_DAY_FILE" 2>/dev/null || true
+                            log "ndc" "kept ${NDC_KEPT}b appended during compression"
                         else
                             rm -f "$NOW_DAY_FILE"
                         fi
-                        [ "$NDC_KEPT" -gt 0 ] && log "ndc" "kept ${NDC_KEPT}b appended during compression"
-                    else
-                        rm -f "$NDC_TAIL"
-                        : > "$MEMORY_FILE"
-                        rm -f "$NOW_DAY_FILE"
                     fi
                     log_tokens "ndc" "$TK_IN" "$TK_OUT" "$TK_CACHE" "$TK_COST"
                     NDC_OUT_BYTES=$(wc -c < "$HAIKU_TEXT_FILE" | tr -d ' ')

--- a/tests/test_now_lock_concurrency.py
+++ b/tests/test_now_lock_concurrency.py
@@ -1,0 +1,140 @@
+"""Follow-up to #142: NDC compression against now.md must be lock-serialized.
+
+#142 replaced the blind ``: > "$MEMORY_FILE"`` truncate with a partial one
+that keeps bytes appended after the snapshot — but held no lock, so three
+defects remained in ``save-session.sh``:
+
+  (a) the byte-count snapshot (``wc -c``) and the ``build-ndc-prompt`` read
+      are two unsynchronized reads of now.md;
+  (b) the closing ``tail``/``mv`` that commits the truncate is itself
+      unserialized against a concurrent append;
+  (c) the ``tail``-failure branch still falls back to a blind
+      ``: > "$MEMORY_FILE"`` — the original #142 bug, preserved as an error
+      path.
+
+``scripts/lib-now-lock.sh`` gives every now.md writer (append, NDC snapshot,
+NDC commit) one flock-guarded critical section (``now_locked``), plus a
+bounds-checked, atomic-rename truncate (``now_truncate_first``) that leaves
+now.md completely untouched — never emptied — whenever it cannot safely
+proceed.
+
+These tests exercise the library directly: (1) mutual exclusion between two
+concurrent ``now_locked`` holders, and (2)/(3) ``now_truncate_first``'s
+bounds guard and its behavior on a failing ``tail``. All three fail on
+pristine 0.8.6, where the library does not exist at all.
+"""
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="flock + bash subprocess — not portable to Windows runners (#79)",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LIB_SCRIPT = REPO_ROOT / "scripts" / "lib-now-lock.sh"
+
+
+def _require_lib():
+    if not LIB_SCRIPT.exists():
+        pytest.fail(
+            "scripts/lib-now-lock.sh does not exist — the #142 follow-up "
+            "fix (locked NDC snapshot/commit) is not present"
+        )
+
+
+class TestNowLockedMutualExclusion:
+
+    def test_two_concurrent_holders_never_overlap(self, tmp_path):
+        """Two now_locked critical sections racing on the same REMEMBER_DIR
+        must be strictly serialized — proof that a concurrent save's append
+        and a concurrent NDC snapshot/commit cannot interleave (defects a/b)."""
+        _require_lib()
+        remember = tmp_path / ".remember" / "tmp"
+        remember.mkdir(parents=True)
+        trace = tmp_path / "trace.log"
+
+        # Each holder: acquire the lock, record "start <id>", sleep (simulating
+        # the work a real snapshot/commit does), record "end <id>". If the
+        # lock does not serialize, both "start" lines can appear before either
+        # "end" line.
+        script = f"""
+        set -e
+        export REMEMBER_DIR={tmp_path}/.remember
+        source {LIB_SCRIPT}
+        _work() {{
+            echo "start $1" >> {trace}
+            sleep 0.5
+            echo "end $1" >> {trace}
+        }}
+        now_locked 10 _work "$1"
+        """
+        p1 = subprocess.Popen(["bash", "-c", script, "_", "A"])
+        time.sleep(0.1)  # give A a head start so it acquires first
+        p2 = subprocess.Popen(["bash", "-c", script, "_", "B"])
+        assert p1.wait(timeout=15) == 0
+        assert p2.wait(timeout=15) == 0
+
+        lines = trace.read_text().splitlines()
+        assert lines == ["start A", "end A", "start B", "end B"], (
+            f"critical sections overlapped: {lines!r} — now_locked did not "
+            "serialize two concurrent holders"
+        )
+
+
+class TestNowTruncateFirstSafety:
+
+    def test_refuses_when_n_exceeds_current_size(self, tmp_path):
+        """A stale/racing byte count larger than the file must be refused —
+        never truncated past EOF, never treated as 'truncate everything'."""
+        _require_lib()
+        mem = tmp_path / "now.md"
+        mem.write_text("short content")
+
+        script = f"""
+        set -e
+        export REMEMBER_DIR={tmp_path}
+        source {LIB_SCRIPT}
+        now_truncate_first "{mem}" 9999
+        """
+        result = subprocess.run(["bash", "-c", script],
+                                capture_output=True, text=True, timeout=10)
+        assert result.returncode != 0
+        assert mem.read_text() == "short content", (
+            "now.md was modified despite the bounds guard refusing the stale count"
+        )
+
+    def test_tail_failure_leaves_file_untouched_not_emptied(self, tmp_path):
+        """If `tail` itself fails, now.md must be left exactly as it was —
+        never fall back to `: > $mem` (the original #142 bug as an error path)."""
+        _require_lib()
+        mem = tmp_path / "now.md"
+        mem.write_text("precious content that must survive a tail failure")
+
+        # A fake `tail` that always fails, placed first on PATH.
+        fake_bin = tmp_path / "fake-bin"
+        fake_bin.mkdir()
+        (fake_bin / "tail").write_text("#!/bin/bash\nexit 1\n")
+        (fake_bin / "tail").chmod(0o755)
+
+        script = f"""
+        set -e
+        export REMEMBER_DIR={tmp_path}
+        source {LIB_SCRIPT}
+        now_truncate_first "{mem}" 5
+        """
+        env = {**os.environ, "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}"}
+        result = subprocess.run(["bash", "-c", script], env=env,
+                                capture_output=True, text=True, timeout=10)
+        assert result.returncode != 0
+        assert mem.read_text() == "precious content that must survive a tail failure", (
+            "a failing `tail` emptied now.md instead of leaving it untouched"
+        )
+        # The sibling temp file must never accumulate either.
+        assert not list(tmp_path.glob("now.md.tail.*"))

--- a/tests/test_save_session_gates.py
+++ b/tests/test_save_session_gates.py
@@ -110,7 +110,8 @@ def _make_env(tmp_path: Path, *, exchanges: int, humans: int, position: int = 50
     (plugin / "pipeline" / "haiku.py").write_text("# marker\n")
     (plugin / "pipeline" / "shell.py").write_text(STUB_SHELL)
     for script in ("save-session.sh", "resolve-paths.sh", "detect-tools.sh",
-                   "bootstrap-dirs.sh", "log.sh", "lib-memory-dir.sh"):
+                   "bootstrap-dirs.sh", "log.sh", "lib-memory-dir.sh",
+                   "lib-now-lock.sh"):
         (plugin / "scripts" / script).write_text((REPO_ROOT / "scripts" / script).read_text())
 
     cfg = {"cooldowns": {"save_seconds": 0, "ndc_seconds": 999999},


### PR DESCRIPTION
## Credit where due

#142 fixed the headline bug: NDC compression used to `: > "$MEMORY_FILE"` —
a blind truncate — after handing `now.md` to a Haiku call that can take up
to 180s. By the time that landed, the parent had released the save lock
and exited, so a newer save could legitimately have appended an entry,
and the blind truncate erased it. #142's fix (keep only the bytes
actually compressed, drop the rest) is the right idea and stays in
place. This PR does not change that shape — it closes the gaps left by
*not holding a lock* around it.

## What's still broken

`save-session.sh`'s NDC step has three residual defects, all stemming
from the same root cause: nothing about it holds a lock.

**(a) Unsynchronized snapshot.** The byte-count read and the subsequent
`build-ndc-prompt` read are two separate, unlocked reads of `now.md`. A
save landing between them can change what's actually in the file, so
the byte count no longer describes what was fed to the summarizer.

**(b) Unsynchronized commit.** The closing `tail`/`mv` that commits the
partial truncate is itself unserialized against a concurrent append —
two NDC rounds, or an NDC round and a save's append, can interleave
arbitrarily.

**(c) The tail-failure branch still falls back to `: > "$MEMORY_FILE"`**
— the *original* #142 bug, preserved as an error path. If `tail` ever
fails (disk hiccup, permissions, etc.), the code path #142 specifically
added to avoid data loss regresses to exactly that data loss.

This is the shape of concurrency several worktree lanes plus two
accounts (`CLAUDE_CONFIG_DIR`) sharing one `REMEMBER_DIR` hits routinely.

## The fix

New `scripts/lib-now-lock.sh`, sourced by `save-session.sh`, giving
every `now.md` writer (save's append, NDC's snapshot, NDC's commit) a
single `flock`-guarded critical section:

- `now_locked <timeout_s> <command> [args...]` — runs a command inside
  a subshell holding `flock` on `${REMEMBER_DIR}/tmp/now.lock`. Returns
  the command's rc, or `99` on lock-acquire timeout.
- `now_append <memory_file> <content_file>` — the append, called via
  `now_locked` (replaces the unlocked `echo "" >> ...; cat ... >> ...`).
- `now_truncate_first <memory_file> <n_bytes>` — drops exactly the
  first `n` bytes via a sibling-temp-file + atomic `mv` (never an
  O_TRUNC window). If `n` exceeds the file's current size, or `tail`
  itself fails, `now.md` is left **completely untouched** and a nonzero
  rc is returned — never the blind `: >` of #142. The temp file is
  removed on every path.

`save-session.sh` changes:
- The append (Step 7) goes through `now_locked 30 now_append ...`.
- The byte-count snapshot and the `build-ndc-prompt` read are combined
  into one function (`_ndc_snapshot`) and run under one `now_locked 30`
  call, so they can never observe different states of `now.md` (closes
  (a)).
- The commit (today-*.md append + truncate) is combined into
  `_ndc_commit` and run under one `now_locked 60` call (closes (b)),
  and a truncate refusal is logged with its specific cause (lock
  timeout vs. bounds guard) instead of silently doing nothing (closes
  (c) — there is no more blind fallback to fall back to).

#164's day-attribution stamping (`NOW_DAY_FILE`, filing compressed
memory under the day it came from rather than the day the run happens
to fall on) is preserved unchanged — it now runs inside the same
locked commit it always logically belonged to.

## Test evidence

Existing `tests/test_ndc_truncate_race.py` (the #142 regression test)
is unaffected and still passes:
```
tests/test_ndc_truncate_race.py::TestNdcTruncateRace::test_entry_appended_during_compression_survives PASSED
tests/test_ndc_truncate_race.py::TestNdcTruncateRace::test_compressed_content_is_still_removed PASSED
2 passed in 5.05s
```
(Its shared harness in `test_save_session_gates.py` needed one line
added — `lib-now-lock.sh` to the list of scripts copied into the stub
plugin dir — since `save-session.sh` now sources it.)

New file: `tests/test_now_lock_concurrency.py`, exercising the library
directly:
- `test_two_concurrent_holders_never_overlap` — two real processes race
  on `now_locked`; asserts their critical sections are strictly
  serialized (start/end trace never interleaves).
- `test_refuses_when_n_exceeds_current_size` — the bounds guard.
- `test_tail_failure_leaves_file_untouched_not_emptied` — a fake
  failing `tail` on `PATH`; asserts `now.md` is byte-for-byte unchanged
  (defect (c)).

Before (unpatched `main`, HEAD `d9480ec` — `lib-now-lock.sh` does not
exist):
```
FAILED tests/test_now_lock_concurrency.py::TestNowLockedMutualExclusion::test_two_concurrent_holders_never_overlap
FAILED tests/test_now_lock_concurrency.py::TestNowTruncateFirstSafety::test_refuses_when_n_exceeds_current_size
FAILED tests/test_now_lock_concurrency.py::TestNowTruncateFirstSafety::test_tail_failure_leaves_file_untouched_not_emptied
3 failed in 0.15s
```

After (patched):
```
3 passed in 5.05s
```

### Regression suite

This machine has no `jq`, so `main`'s own `pytest tests/ -q` baseline
already fails a batch of tests unrelated to this change:

- Baseline (`main`, HEAD `d9480ec`): `38 failed, 625 passed, 58 skipped`
- Patched: `38 failed, 628 passed, 58 skipped` (identical pre-existing
  failures, +3 for this patch's new tests)

## Backward compatibility

None needed. `now.lock` is a new file under `${REMEMBER_DIR}/tmp/`,
created on first use; no existing file's format or location changes.

---
This PR is independent of the other four bug-fix PRs I'm submitting
alongside it and can be reviewed/merged in any order.