### PR TITLE
fix: two ways memory was discarded without a trace

### DIFF
--- a/pipeline/haiku.py
+++ b/pipeline/haiku.py
@@ -325,9 +325,11 @@ def _parse_response(raw: str) -> HaikuResult:
 
     # Drop SKIP (model found nothing worth saving) AND refusals/clarifications
     # (the reject-gate) so neither is ever written to the memory layer.
-    is_skip = text.strip().upper().startswith("SKIP") or _is_non_summary(text)
+    model_skipped = text.strip().upper().startswith("SKIP")
+    rejected = not model_skipped and _is_non_summary(text)
 
-    return HaikuResult(text=text, tokens=tokens, is_skip=is_skip)
+    return HaikuResult(text=text, tokens=tokens,
+                       is_skip=model_skipped or rejected, is_rejected=rejected)
 
 
 def _extract_tokens(data: dict) -> TokenUsage:

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -356,12 +356,24 @@ def cmd_consolidate(staging_dir: str, recent_file: str, archive_file: str,
 
     # Find staging files (exclude today + .done files)
     staging_contents: dict[str, str] = {}
+    # Raw file size, captured at read time. The consumed-byte count below drives
+    # the retire-vs-keep-tail split, so it has to describe the FILE, not the
+    # decoded string: errors="replace" turns each undecodable byte into one
+    # U+FFFD that re-encodes to three, and len(decoded.encode()) then overstates
+    # the file. Overstated, `staging_now -gt staging_consumed` reads false in
+    # run-consolidation.sh and it falls through to the blind rename — sealing
+    # concurrently appended entries inside .done.md, which is the exact loss
+    # this count exists to prevent. #142 measures now.md with `wc -c` for the
+    # same reason.
+    staging_raw_bytes: dict[str, int] = {}
     for path in sorted(globmod.glob(os.path.join(staging_dir, "today-*.md"))):
         basename = os.path.basename(path)
         if today in basename or basename.endswith(".done.md"):
             continue
-        with open(path, encoding="utf-8", errors="replace") as f:
-            staging_contents[basename] = f.read()
+        with open(path, "rb") as f:
+            raw = f.read()
+        staging_raw_bytes[basename] = len(raw)
+        staging_contents[basename] = raw.decode("utf-8", errors="replace")
 
     if not staging_contents:
         print("STAGING_COUNT=0")
@@ -435,11 +447,11 @@ def cmd_consolidate(staging_dir: str, recent_file: str, archive_file: str,
     # Same shape as #142, which fixed it for now.md and not for staging.
     fd_s, staging_paths_file = tempfile.mkstemp(prefix="remember-staging-paths-", suffix=".bin")
     with os.fdopen(fd_s, "wb") as f:
-        for name, content in staging_contents.items():
+        for name in staging_contents:
             # surrogatepass: os.listdir() surrogate-escapes undecodable filename
             # bytes on Windows; round-trip them so the shell gets the real path.
             f.write(os.path.join(staging_dir, name).encode("utf-8", "surrogatepass") + b"\x00")
-            f.write(str(len(content.encode("utf-8"))).encode("ascii") + b"\x00")
+            f.write(str(staging_raw_bytes[name]).encode("ascii") + b"\x00")
 
     print(f"STAGING_COUNT={len(staging_contents)}")
     print("CONSOLIDATION_STATUS=ok")

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -201,6 +201,7 @@ def _emit_haiku_result(r, output_file: str = "") -> None:
 
     print(f"HAIKU_TEXT_FILE={_shell_escape(text_file)}")
     print(f"IS_SKIP={'true' if r.is_skip else 'false'}")
+    print(f"IS_REJECTED={'true' if r.is_rejected else 'false'}")
     print(f"TK_IN={r.tokens.input}")
     print(f"TK_OUT={r.tokens.output}")
     print(f"TK_CACHE={r.tokens.cache}")
@@ -425,12 +426,20 @@ def cmd_consolidate(staging_dir: str, recent_file: str, archive_file: str,
     # can read them safely regardless of single quotes, spaces, or other
     # metacharacters in the filename.  Shell reads with:
     #   while IFS= read -r -d '' path; do ...; done < "$STAGING_PATHS_FILE"
+    # Each record is path\0consumed_bytes\0. The byte count is what was actually
+    # read into this prompt: run-consolidation.sh renames the file afterwards,
+    # and a save can land in between — the Haiku call above has a 180s budget
+    # and consolidation runs disowned alongside any live session. Renaming
+    # blindly sealed those newer bytes inside the .done.md, which nothing globs
+    # again and session start never injects: written to disk, then unreachable.
+    # Same shape as #142, which fixed it for now.md and not for staging.
     fd_s, staging_paths_file = tempfile.mkstemp(prefix="remember-staging-paths-", suffix=".bin")
     with os.fdopen(fd_s, "wb") as f:
-        for name in staging_contents:
+        for name, content in staging_contents.items():
             # surrogatepass: os.listdir() surrogate-escapes undecodable filename
             # bytes on Windows; round-trip them so the shell gets the real path.
             f.write(os.path.join(staging_dir, name).encode("utf-8", "surrogatepass") + b"\x00")
+            f.write(str(len(content.encode("utf-8"))).encode("ascii") + b"\x00")
 
     print(f"STAGING_COUNT={len(staging_contents)}")
     print("CONSOLIDATION_STATUS=ok")

--- a/pipeline/types.py
+++ b/pipeline/types.py
@@ -54,12 +54,19 @@ class HaikuResult:
         text: The model's text response (may be empty on error).
         tokens: Token usage and cost for this call.
         is_skip: True if the response starts with "SKIP", indicating
-            the model determined there was nothing worth summarizing.
+            the model determined there was nothing worth summarizing, or if
+            the reject gate matched a refusal-shaped reply.
+        is_rejected: True only for the second case. Both are kept out of
+            memory, but a rejection discards a span of real work, and the
+            caller has to be able to say so — reported as a plain SKIP it is
+            indistinguishable from a genuinely empty session, and it slips
+            past max_summary_failures too, which only counts hard errors.
     """
 
     text: str = ""
     tokens: TokenUsage = field(default_factory=TokenUsage)
     is_skip: bool = False
+    is_rejected: bool = False
 
 
 @dataclass

--- a/scripts/run-consolidation.sh
+++ b/scripts/run-consolidation.sh
@@ -101,11 +101,32 @@ log_tokens "consolidation" "$TK_IN" "$TK_OUT" "$TK_CACHE" "$TK_COST"
 
 # --- Rename processed staging files → .done.md ---
 # Paths are NUL-separated in STAGING_PATHS_FILE, safe for any filename.
-while IFS= read -r -d '' staging_path; do
-    if [ -f "$staging_path" ]; then
-        mv "$staging_path" "${staging_path%.md}.done.md"
-    else
+# Records are path\0consumed_bytes\0. Retire exactly the span that was
+# consolidated and keep anything appended past it — a save can land while the
+# Haiku call runs (180s budget, and this script is disowned so it runs
+# alongside live sessions). A blind rename sealed those bytes inside the
+# .done.md, which the next run's glob skips and session start never injects.
+while IFS= read -r -d '' staging_path && IFS= read -r -d '' staging_consumed; do
+    if [ ! -f "$staging_path" ]; then
         log "consolidation" "WARN: $(basename "$staging_path") disappeared"
+        continue
+    fi
+    case "$staging_consumed" in (''|*[!0-9]*) staging_consumed=0 ;; esac
+    staging_now=$(wc -c < "$staging_path" | tr -d ' ')
+    staging_done="${staging_path%.md}.done.md"
+
+    if [ "$staging_consumed" -gt 0 ] && [ "$staging_now" -gt "$staging_consumed" ]; then
+        staging_tail=$(mktemp "${TMPDIR:-/tmp}"/remember-staging-tail-XXXXXX)
+        if head -c "$staging_consumed" "$staging_path" > "$staging_done" 2>/dev/null &&
+           tail -c +$(( staging_consumed + 1 )) "$staging_path" > "$staging_tail" 2>/dev/null; then
+            mv "$staging_tail" "$staging_path"
+            log "consolidation" "kept $(( staging_now - staging_consumed ))b appended to $(basename "$staging_path") during consolidation"
+        else
+            rm -f "$staging_tail"
+            mv "$staging_path" "$staging_done"
+        fi
+    else
+        mv "$staging_path" "$staging_done"
     fi
 done < "$STAGING_PATHS_FILE"
 rm -f "$STAGING_PATHS_FILE"

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -266,6 +266,32 @@ log_tokens "tokens" "$TK_IN" "$TK_OUT" "$TK_CACHE" "$TK_COST"
 HAIKU_TEXT=$(cat "$HAIKU_TEXT_FILE")
 [ -z "$HAIKU_TEXT" ] && { log "haiku" "ERROR: empty response"; record_summary_failure; exit 1; }
 
+# Park a discarded reply where it can be read later. Three callers now (format
+# validator, reject gate, NDC compression) — one copy each drifts, so it lives
+# here once.
+#
+# The timestamp carries $$ because seconds-resolution alone collides: two
+# rejections in the same second overwrote each other, and the second one was
+# the evidence you actually wanted.
+keep_rejected_text() {
+    local _src="$1" _tag="$2"
+    local _dir="${REMEMBER_DIR}/tmp"
+    local _file="${_dir}/rejected-$(_remember_date +%Y%m%d-%H%M%S)-$$.md"
+    mkdir -p "$_dir" 2>/dev/null
+    # Report what actually happened. The copy used to be silenced with 2>/dev/null
+    # and the success line logged unconditionally, so a full disk or a bad
+    # permission produced a log entry pointing at a file that was never written.
+    if cp "$_src" "$_file" 2>/dev/null; then
+        log "$_tag" "rejected text kept at $_file"
+    else
+        log "$_tag" "WARNING: could not keep rejected text at $_file"
+    fi
+    # Keep the last 20; these are diagnostic, not memory.
+    ls -t "${_dir}"/rejected-*.md 2>/dev/null | tail -n +21 | while read -r _old; do
+        rm -f "$_old"
+    done
+}
+
 # --- Step 5b: Validate format (warn, never discard) ---
 if [ "$IS_SKIP" != "true" ]; then
     FIRST_LINE=$(head -1 "$HAIKU_TEXT_FILE")
@@ -280,15 +306,8 @@ if [ "$IS_SKIP" != "true" ]; then
         # tmp/rejected-*.md, so nothing is lost, it simply does not enter the
         # compression chain. The position still advances, exactly as a SKIP
         # does, or this span would be re-summarized on every run forever.
-        REJECT_FILE="${REMEMBER_DIR}/tmp/rejected-$(_remember_date +%Y%m%d-%H%M%S).md"
-        mkdir -p "${REMEMBER_DIR}/tmp" 2>/dev/null
-        cp "$HAIKU_TEXT_FILE" "$REJECT_FILE" 2>/dev/null
         log "validate" "REJECTED (not an entry header): $(echo "$FIRST_LINE" | head -c 80)"
-        log "validate" "rejected text kept at $REJECT_FILE"
-        # Keep the last 20; these are diagnostic, not memory.
-        ls -t "${REMEMBER_DIR}"/tmp/rejected-*.md 2>/dev/null | tail -n +21 | while read -r _old; do
-            rm -f "$_old"
-        done
+        keep_rejected_text "$HAIKU_TEXT_FILE" "validate"
         cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell save-position "$LAST_SAVE_FILE" "$SESSION_ID" "$POSITION"
         log "validate" "position → $POSITION"
         rm -f "$FAILURE_MARKER"
@@ -335,16 +354,8 @@ if [ "$IS_SKIP" = "true" ]; then
     # stops growing, and max_summary_failures never notices because that counts
     # hard errors and this call succeeded.
     if [ "${IS_REJECTED:-false}" = "true" ]; then
-        REJECT_FILE="${REMEMBER_DIR}/tmp/rejected-$(_remember_date +%Y%m%d-%H%M%S).md"
-        mkdir -p "${REMEMBER_DIR}/tmp" 2>/dev/null
-        cp "$HAIKU_TEXT_FILE" "$REJECT_FILE" 2>/dev/null
         log "haiku" "REJECTED (not a summary — refusal or clarification): $(head -c 80 "$HAIKU_TEXT_FILE" 2>/dev/null)"
-        log "haiku" "rejected text kept at $REJECT_FILE"
-        # Keep the last 20; diagnostic, not memory. Same bound as the format
-        # validator's rejects.
-        ls -t "${REMEMBER_DIR}"/tmp/rejected-*.md 2>/dev/null | tail -n +21 | while read -r _old; do
-            rm -f "$_old"
-        done
+        keep_rejected_text "$HAIKU_TEXT_FILE" "haiku"
     fi
     log "haiku" "SKIP — position → $POSITION"
     cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell save-position "$LAST_SAVE_FILE" "$SESSION_ID" "$POSITION"
@@ -427,9 +438,27 @@ if [ "$RUN_NDC" = true ]; then
             if [ "$NDC_EXIT" -ne 0 ]; then
                 log "ndc" "ERROR: $(head -1 "$NDC_ERR" 2>/dev/null)"
             else
+                # Defensive, and not load-bearing today: Step 6 exits before
+                # this block whenever either flag is true, and safe_eval rewrites
+                # both from NDC_VARS on every successful call, so no reachable
+                # path currently carries a stale value in here. Kept so the gate
+                # below cannot quietly start reading an inherited value if either
+                # invariant changes — a reset that costs nothing, guarding a
+                # failure mode that writes into permanent memory.
+                IS_SKIP=false
+                IS_REJECTED=false
                 safe_eval <<< "$NDC_VARS"
                 NDC_TEXT=$(cat "$HAIKU_TEXT_FILE")
-                if [ -n "$NDC_TEXT" ]; then
+                # Compression runs through the same reject gate as the summarize
+                # call, but nothing here consumed the verdict: a refusal came
+                # back non-empty, passed `[ -n ... ]`, and was appended to
+                # today-*.md as if it were a day summary. Not lost memory —
+                # corrupted memory, written into the permanent record with no
+                # log line. now.md is left intact so the next round retries.
+                if [ "$IS_SKIP" = "true" ] || [ "${IS_REJECTED:-false}" = "true" ]; then
+                    log "ndc" "REJECTED (not a summary — refusal or clarification): $(head -c 80 "$HAIKU_TEXT_FILE" 2>/dev/null)"
+                    keep_rejected_text "$HAIKU_TEXT_FILE" "ndc"
+                elif [ -n "$NDC_TEXT" ]; then
                     [ -s "$TODAY_FILE" ] && echo "" >> "$TODAY_FILE"
                     cat "$HAIKU_TEXT_FILE" >> "$TODAY_FILE"
                     # Drop exactly the bytes that were compressed, not the whole

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -327,6 +327,25 @@ fi
 
 # --- Step 6: Handle SKIP ---
 if [ "$IS_SKIP" = "true" ]; then
+    # A model SKIP and a reject-gate match both stay out of memory, but they are
+    # not the same event. SKIP means the span held nothing worth recording; a
+    # rejection means a span of real work was discarded because the reply came
+    # back as a refusal or a clarifying question. Reported identically, the
+    # second is invisible: the log reads like a quiet session, memory simply
+    # stops growing, and max_summary_failures never notices because that counts
+    # hard errors and this call succeeded.
+    if [ "${IS_REJECTED:-false}" = "true" ]; then
+        REJECT_FILE="${REMEMBER_DIR}/tmp/rejected-$(_remember_date +%Y%m%d-%H%M%S).md"
+        mkdir -p "${REMEMBER_DIR}/tmp" 2>/dev/null
+        cp "$HAIKU_TEXT_FILE" "$REJECT_FILE" 2>/dev/null
+        log "haiku" "REJECTED (not a summary — refusal or clarification): $(head -c 80 "$HAIKU_TEXT_FILE" 2>/dev/null)"
+        log "haiku" "rejected text kept at $REJECT_FILE"
+        # Keep the last 20; diagnostic, not memory. Same bound as the format
+        # validator's rejects.
+        ls -t "${REMEMBER_DIR}"/tmp/rejected-*.md 2>/dev/null | tail -n +21 | while read -r _old; do
+            rm -f "$_old"
+        done
+    fi
     log "haiku" "SKIP — position → $POSITION"
     cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell save-position "$LAST_SAVE_FILE" "$SESSION_ID" "$POSITION"
     # A SKIP is a successful summarization (the model judged the span not worth

--- a/tests/test_consolidation_append_race.py
+++ b/tests/test_consolidation_append_race.py
@@ -1,0 +1,167 @@
+"""Consolidation must not seal away entries appended while it runs.
+
+`cmd_consolidate` reads every `today-*.md`, then calls Haiku with a 180s
+budget, and `run-consolidation.sh` afterwards renames each file it read to
+`.done.md`. The rename is blind: it moves whatever the file contains NOW, not
+the bytes that were actually consolidated.
+
+A save landing in that window is therefore sealed inside the `.done.md`. The
+next consolidation's glob explicitly skips `.done.md`, and session start never
+injects those files either — so the entry was written to disk successfully and
+is then unreachable forever.
+
+This is #142's shape (parent reads → long call → blind write loses newer data),
+one layer over: #142's fix kept the bytes appended past the snapshot offset in
+`now.md`, but consolidation's staging rename never got the same treatment.
+`run-consolidation.sh` is spawned `nohup ... & disown` from session start, so it
+runs concurrently with any live `save-session.sh` by design — and NDC appends to
+`today-<day>.md`, which can be a past day for a session that crossed midnight.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash subprocess + POSIX layout — not portable to Windows runners (#79)",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: Stands in for the real pipeline. `consolidate` reads the staging files,
+#: records how many bytes it consumed, and then appends to one of them —
+#: standing in for a save that lands during the Haiku call.
+STUB_SHELL = '''\
+import os, sys, tempfile, glob
+
+cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+if cmd == "consolidate":
+    staging_dir = sys.argv[2]
+    paths = sorted(p for p in glob.glob(os.path.join(staging_dir, "today-*.md"))
+                   if not p.endswith(".done.md"))
+    consumed = {}
+    for p in paths:
+        with open(p, encoding="utf-8") as f:
+            consumed[p] = len(f.read().encode("utf-8"))
+
+    extra = os.environ.get("STUB_APPEND_DURING_CONSOLIDATION")
+    if extra and paths:
+        with open(paths[0], "a", encoding="utf-8") as f:
+            f.write(extra)
+
+    fd_r, recent_out = tempfile.mkstemp(suffix="-recent.md")
+    with os.fdopen(fd_r, "w") as f:
+        f.write("# Recent\\n\\nconsolidated\\n")
+    fd_a, archive_out = tempfile.mkstemp(suffix="-archive.md")
+    with os.fdopen(fd_a, "w") as f:
+        f.write("# Archive\\n\\nolder\\n")
+
+    fd_s, staging_paths_file = tempfile.mkstemp(suffix="-paths.bin")
+    with os.fdopen(fd_s, "wb") as f:
+        for p in paths:
+            f.write(p.encode("utf-8") + b"\\x00")
+            f.write(str(consumed[p]).encode("ascii") + b"\\x00")
+
+    print(f"STAGING_COUNT={len(paths)}")
+    print("CONSOLIDATION_STATUS=ok")
+    print(f"RECENT_OUT={recent_out}")
+    print(f"ARCHIVE_OUT={archive_out}")
+    print(f"STAGING_PATHS_FILE={staging_paths_file}")
+    print("TK_IN=0"); print("TK_OUT=0"); print("TK_CACHE=0"); print("TK_COST=0")
+'''
+
+
+def _make_env(tmp_path: Path):
+    """A project whose store holds one past-day staging file."""
+    project = tmp_path / "project"
+    remember = project / ".remember"
+    (remember / "tmp").mkdir(parents=True)
+    (remember / "logs").mkdir(parents=True)
+
+    plugin = tmp_path / "plugin"
+    (plugin / "scripts").mkdir(parents=True)
+    (plugin / "pipeline").mkdir(parents=True)
+    (plugin / "pipeline" / "__init__.py").write_text("")
+    (plugin / "pipeline" / "haiku.py").write_text("# marker\n")
+    (plugin / "pipeline" / "shell.py").write_text(STUB_SHELL)
+    for script in ("run-consolidation.sh", "resolve-paths.sh", "detect-tools.sh",
+                   "bootstrap-dirs.sh", "log.sh", "lib-memory-dir.sh"):
+        (plugin / "scripts" / script).write_text((REPO_ROOT / "scripts" / script).read_text())
+    (plugin / "config.json").write_text('{"cooldowns": {}, "thresholds": {}}')
+
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path / "home"),
+        "CLAUDE_PROJECT_DIR": str(project),
+        "CLAUDE_PLUGIN_ROOT": str(plugin),
+        "REMEMBER_DIR": str(remember),
+        "_LIB_MEMORY_DIR_LOADED": "1",
+    }
+    return env, project, plugin, remember
+
+
+def _run(plugin: Path, env: dict):
+    return subprocess.run(["bash", str(plugin / "scripts" / "run-consolidation.sh")],
+                          capture_output=True, text=True, env=env, timeout=90)
+
+
+APPENDED = "\n## 23:59 | main\n\n- landed during consolidation\n"
+
+
+def test_an_entry_appended_during_consolidation_is_not_sealed_away(tmp_path):
+    """The reported loss: written to disk, then unreachable forever."""
+    env, project, plugin, remember = _make_env(tmp_path)
+    staging = remember / "today-2026-07-24.md"
+    staging.write_text("# Day\n\n## 10:00 | main\n\n- earlier work\n", encoding="utf-8")
+    env["STUB_APPEND_DURING_CONSOLIDATION"] = APPENDED
+
+    result = _run(plugin, env)
+    assert result.returncode == 0, result.stderr
+
+    live = "".join(p.read_text(encoding="utf-8")
+                   for p in remember.glob("today-*.md")
+                   if not p.name.endswith(".done.md"))
+    assert "landed during consolidation" in live, (
+        "the entry was sealed into .done.md — nothing globs those again and "
+        "session start never injects them, so it is unreachable memory"
+    )
+
+
+def test_the_consolidated_span_is_still_retired(tmp_path):
+    """Keeping the tail must not stop the consumed part being retired.
+
+    Otherwise the next run re-consolidates work already in recent.md.
+    """
+    env, project, plugin, remember = _make_env(tmp_path)
+    staging = remember / "today-2026-07-24.md"
+    staging.write_text("# Day\n\n## 10:00 | main\n\n- earlier work\n", encoding="utf-8")
+    env["STUB_APPEND_DURING_CONSOLIDATION"] = APPENDED
+
+    _run(plugin, env)
+
+    done = list(remember.glob("today-*.done.md"))
+    assert done, "nothing was retired"
+    assert "earlier work" in done[0].read_text(encoding="utf-8")
+    live = "".join(p.read_text(encoding="utf-8")
+                   for p in remember.glob("today-*.md")
+                   if not p.name.endswith(".done.md"))
+    assert "earlier work" not in live, "the consolidated span was left to be redone"
+
+
+def test_a_quiet_consolidation_still_retires_the_whole_file(tmp_path):
+    """Nothing appended: the ordinary path must be untouched."""
+    env, project, plugin, remember = _make_env(tmp_path)
+    staging = remember / "today-2026-07-24.md"
+    staging.write_text("# Day\n\n## 10:00 | main\n\n- earlier work\n", encoding="utf-8")
+
+    _run(plugin, env)
+
+    assert not staging.exists(), "the file should have been renamed away entirely"
+    done = remember / "today-2026-07-24.done.md"
+    assert done.is_file() and "earlier work" in done.read_text(encoding="utf-8")

--- a/tests/test_consolidation_append_race.py
+++ b/tests/test_consolidation_append_race.py
@@ -165,3 +165,117 @@ def test_a_quiet_consolidation_still_retires_the_whole_file(tmp_path):
     assert not staging.exists(), "the file should have been renamed away entirely"
     done = remember / "today-2026-07-24.done.md"
     assert done.is_file() and "earlier work" in done.read_text(encoding="utf-8")
+
+
+# ── End-to-end through the REAL pipeline.shell (no STUB_SHELL) ─────────────
+#
+# The suite above stands in for `pipeline.shell consolidate` entirely, so it
+# cannot prove anything about how the consumed-byte count is actually
+# computed — that logic lives in the real cmd_consolidate (review of
+# 8d2cdab). This runs the genuine scripts/run-consolidation.sh against the
+# genuine pipeline package (CLAUDE_PLUGIN_ROOT = the repo itself), with only
+# the `claude` binary swapped for a script that returns a fixed response —
+# the one boundary every other test in this file also stubs.
+
+FAKE_CLAUDE = '''\
+#!/usr/bin/env python3
+import json, os, sys
+sys.stdin.read()  # the prompt arrives on stdin; content doesn't matter here
+
+# Stand-in for a save landing WHILE this (fake, but still out-of-process)
+# Haiku call is in flight — the real #142-shaped race: the file is read
+# before this call and renamed after it returns.
+append_file = os.environ.get("APPEND_DURING_CONSOLIDATION_FILE")
+append_text = os.environ.get("APPEND_DURING_CONSOLIDATION_TEXT")
+if append_file and append_text:
+    with open(append_file, "a", encoding="utf-8") as f:
+        f.write(append_text)
+
+print(json.dumps({
+    "result": "===RECENT===\\n# Recent\\n\\n## 2020-01-02\\n- compressed\\n\\n"
+              "===ARCHIVE===\\n# Archive\\n\\nolder\\n",
+    "input_tokens": 10,
+    "output_tokens": 5,
+    "cache_read_input_tokens": 0,
+}))
+'''
+
+
+def _real_pipeline_env(tmp_path: Path):
+    """Real pipeline.shell + real run-consolidation.sh; only `claude` is faked."""
+    project = tmp_path / "project"
+    remember = project / ".remember"
+    (remember / "tmp").mkdir(parents=True)
+    (remember / "logs").mkdir(parents=True)
+
+    fake_claude = tmp_path / "fake_claude"
+    fake_claude.write_text(FAKE_CLAUDE)
+    fake_claude.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "HOME": str(tmp_path / "home"),
+        "CLAUDE_PROJECT_DIR": str(project),
+        "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
+        "REMEMBER_CLAUDE_BIN": str(fake_claude),
+        "REMEMBER_DIR": str(remember),
+        "_LIB_MEMORY_DIR_LOADED": "1",
+    }
+    return env, project, remember
+
+
+def _run_real(env: dict):
+    return subprocess.run(["bash", str(REPO_ROOT / "scripts" / "run-consolidation.sh")],
+                          capture_output=True, text=True, env=env, timeout=90)
+
+
+class TestRealConsolidateNonUtf8AppendRace:
+    """Defect 1 (8d2cdab): an overstated consumed-byte count makes
+    run-consolidation.sh take the blind-rename branch, sealing anything
+    appended during consolidation inside .done.md.
+
+    A non-UTF-8 staging file used to trigger exactly that: the byte count
+    was measured from the decoded-and-re-encoded string (errors="replace"
+    turns each stray byte into a 3-byte U+FFFD), so it overstated the file,
+    `staging_now -gt staging_consumed` read false, and the append below
+    would have been sealed away rather than kept.
+    """
+
+    def test_entry_appended_during_real_consolidation_survives_non_utf8_staging(
+        self, tmp_path
+    ):
+        env, project, remember = _real_pipeline_env(tmp_path)
+        staging = remember / "today-2020-01-01.md"
+        # 30 stray non-UTF-8 bytes. Each becomes one U+FFFD on decode, which
+        # re-encodes to 3 bytes — a 60-byte overstatement, comfortably bigger
+        # than APPENDED (48 bytes) below. That margin is deliberate: it's what
+        # makes the bug's effect (an overstated count) outweigh the race's
+        # effect (more bytes on disk than were consumed) and actually flip the
+        # shell's `staging_now -gt staging_consumed` comparison to false, so
+        # this test would still fail with only a couple of stray bytes.
+        original = b"# Day\n\n## 10:00 | main\n\n- entry with " + b"\xff" * 30 + b" bytes\n"
+        staging.write_bytes(original)
+
+        # The fake `claude` process appends this to the staging file the
+        # moment it's invoked — after cmd_consolidate has read + snapshotted
+        # the file, before run-consolidation.sh renames it. Same window #142
+        # closed for now.md; this proves it for staging.
+        env["APPEND_DURING_CONSOLIDATION_FILE"] = str(staging)
+        env["APPEND_DURING_CONSOLIDATION_TEXT"] = APPENDED
+
+        result = _run_real(env)
+        assert result.returncode == 0, result.stderr
+
+        remaining = staging.read_text(encoding="utf-8", errors="replace") if staging.exists() else ""
+        assert "landed during consolidation" in remaining, (
+            "the entry appended while the (real) consumed-byte count was "
+            "measured wrong got sealed into .done.md instead of surviving in "
+            "the live staging file — an overstated count (from decoding a "
+            "non-UTF-8 staging file with errors='replace' before measuring) "
+            f"makes staging_now > staging_consumed read false. stderr={result.stderr}"
+        )
+        done = remember / "today-2020-01-01.done.md"
+        assert done.is_file(), f"the consumed span was not retired: {result.stderr}"
+        assert "entry with" in done.read_text(encoding="utf-8", errors="replace"), (
+            "the original (consumed) span must still be retired into .done.md"
+        )

--- a/tests/test_encoding_boundaries.py
+++ b/tests/test_encoding_boundaries.py
@@ -287,6 +287,62 @@ def test_consolidate_tolerates_non_utf8_staging(tmp_path, capsys):
     assert "RECENT_OUT=" in capsys.readouterr().out
 
 
+def test_consolidate_staging_consumed_bytes_match_real_file_size(tmp_path, capsys):
+    """The consumed-byte count recorded for run-consolidation.sh must describe
+    the FILE on disk, not the decoded-and-re-encoded string (review of 8d2cdab).
+
+    The staging file used to be read with ``open(..., errors="replace")`` and
+    the consumed count taken from ``len(content.encode("utf-8"))``. Each
+    undecodable byte becomes one U+FFFD, which re-encodes to three bytes, so a
+    file with two stray non-UTF-8 bytes measured four bytes bigger than it
+    actually is (a 61-byte file measured 65). Overstated, run-consolidation.sh's
+    ``staging_now -gt staging_consumed`` reads false and it falls through to the
+    blind ``mv`` rename — sealing anything appended during consolidation inside
+    ``.done.md``, unreachable, which is exactly the loss this count exists to
+    prevent (#142's shape, one layer over).
+    """
+    sys.path.insert(0, str(REPO_ROOT))
+    from unittest.mock import patch
+    from pipeline.shell import cmd_consolidate
+    from pipeline.types import ConsolidationResult, TokenUsage
+
+    staging = tmp_path / "staging"
+    staging.mkdir()
+    staging_file = staging / "today-2020-01-01.md"
+    # \xff\xfe: two bytes, neither valid UTF-8 on its own. errors="replace"
+    # turns them into two U+FFFD (6 bytes when re-encoded) instead of 2.
+    raw_bytes = b"entry with two stray bytes \xff\xfe right here, then more text\n"
+    staging_file.write_bytes(raw_bytes)
+    real_size = os.path.getsize(staging_file)
+
+    res = ConsolidationResult(
+        recent="r", archive="a", tokens=TokenUsage(input=1, output=1, cache=0, cost_usd=0.0))
+    with patch("pipeline.consolidate.consolidate", return_value=res):
+        cmd_consolidate(
+            staging_dir=str(staging),
+            recent_file=str(tmp_path / "r.md"),
+            archive_file=str(tmp_path / "a.md"),
+        )
+    output = capsys.readouterr().out
+    staging_paths_file = next(
+        line.split("=", 1)[1]
+        for line in output.splitlines()
+        if line.startswith("STAGING_PATHS_FILE=")
+    )
+    raw = Path(staging_paths_file).read_bytes()
+    fields = [p for p in raw.split(b"\x00") if p]
+    paths_from_file, counts = fields[0::2], fields[1::2]
+    idx = next(i for i, p in enumerate(paths_from_file)
+               if p.decode().endswith("today-2020-01-01.md"))
+    consumed = int(counts[idx].decode())
+    assert consumed == real_size, (
+        f"consumed count {consumed} != real file size {real_size} bytes — "
+        "measured from the decoded-and-re-encoded string instead of the file, "
+        "so run-consolidation.sh's staging_now > staging_consumed check goes "
+        "false and seals appended entries inside .done.md"
+    )
+
+
 # ── Boundary 3: shell.py's own stdout, read back as a path by bash (#145)
 #
 # Every cmd_* prints KEY=value lines that bash captures by command substitution

--- a/tests/test_encoding_boundaries.py
+++ b/tests/test_encoding_boundaries.py
@@ -25,10 +25,23 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
+def _ambient_env() -> dict[str, str]:
+    """os.environ minus every GIT_* var.
+
+    conftest's _sanitize_ambient_git_env strips those per test, but the dicts
+    below are built at import time — before any fixture runs — so a GIT_DIR
+    leaked into the launching shell would be baked in and handed to every
+    subprocess these constants feed. Harmless while pipeline.shell never shells
+    out to git; a silent reopening of the bug the moment it does. Filter on the
+    prefix rather than restating conftest's list, so the two cannot drift.
+    """
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
 # A non-UTF-8 locale that survives PEP 538 C-locale coercion — makes Python's
 # stdin/subprocess codec ascii+surrogateescape on any OS, mimicking cp1252.
 FORCED_NON_UTF8_ENV = {
-    **os.environ,
+    **_ambient_env(),
     "PYTHONUTF8": "0",
     "PYTHONCOERCECLOCALE": "0",
     "LC_ALL": "C",
@@ -357,7 +370,7 @@ def test_consolidate_staging_consumed_bytes_match_real_file_size(tmp_path, capsy
 # what Windows does: there the filesystem is UTF-8 (PEP 529) and only the
 # console codec is wrong. So keep the locale alone and force just the io codec
 # to a real ANSI codepage, which is exactly the shape #145 reported.
-ANSI_STDOUT_ENV = {**os.environ, "PYTHONIOENCODING": "cp1252"}
+ANSI_STDOUT_ENV = {**_ambient_env(), "PYTHONIOENCODING": "cp1252"}
 ANSI_STDOUT_ENV.pop("PYTHONUTF8", None)
 
 

--- a/tests/test_ndc_reject_gate.py
+++ b/tests/test_ndc_reject_gate.py
@@ -1,0 +1,181 @@
+"""NDC compression must gate on the model's verdict, not just non-empty text
+(review of 8d2cdab).
+
+`save-session.sh`'s NDC block runs its own Haiku call through the exact same
+IS_SKIP/IS_REJECTED contract as the main summarize call, but until this fix it
+never read the verdict: it appended to today-*.md whenever `NDC_TEXT` was
+non-empty. A refusal is non-empty text, so
+"I'm sorry, but I can't summarize this conversation without more context."
+got written into today-*.md as if it were a genuine day summary, with no log
+line — not lost memory, corrupted memory, permanently on record.
+
+The fix adds a reject branch mirroring the one the main summarize path already
+had (#136/#reject-gate-visibility), and resets IS_SKIP/IS_REJECTED right
+before parsing the NDC response — the subshell inherits whatever those
+variables held from the parent's own (already-consumed) summarize call, and a
+stale value must not be allowed to decide this gate.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from .test_save_session_gates import _make_env, _run, REPO_ROOT
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash subprocess + POSIX layout — not portable to Windows runners (#79)",
+)
+
+REFUSAL = "I'm sorry, but I can't summarize this conversation without more context.\n"
+
+# Same STUB_SHELL as test_save_session_gates, extended with independent control
+# over the NDC call's response (STUB_NDC_TEXT / STUB_NDC_REJECTED / STUB_NDC_SKIP).
+# The original stub always sent a valid "## 2026-07-25 ..." summary for the NDC
+# call and could not fail it — the reject gate literally could not be exercised.
+STUB_SHELL_NDC = '''\
+import os, sys, tempfile
+
+CALLS = os.environ["STUB_CALLS_LOG"]
+cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+with open(CALLS, "a") as f:
+    f.write(" ".join([cmd] + sys.argv[2:]) + "\\n")
+
+if cmd == "extract":
+    fd, path = tempfile.mkstemp(suffix="-extract")
+    with os.fdopen(fd, "w") as f:
+        f.write("Human: something\\nAssistant: something else\\n")
+    print(f"POSITION={os.environ['STUB_POSITION']}")
+    print(f"HUMAN_COUNT={os.environ['STUB_HUMAN_COUNT']}")
+    print("ASSISTANT_COUNT=1")
+    print(f"EXCHANGE_COUNT={os.environ['STUB_EXCHANGE_COUNT']}")
+    print(f"EXTRACT_FILE={path}")
+elif cmd == "save-position":
+    last_save_file, session_id, position = sys.argv[2], sys.argv[3], sys.argv[4]
+    import json
+    with open(last_save_file, "w") as f:
+        json.dump({"session": session_id, "line": int(position)}, f)
+elif cmd == "build-prompt":
+    with open(sys.argv[6], "w") as f:
+        f.write("a prompt with no placeholders\\n")
+elif cmd == "call-haiku":
+    if os.environ.get("STUB_HAIKU_FAIL") == "1":
+        sys.stderr.write("stub: simulated haiku failure\\n")
+        sys.exit(1)
+    is_ndc = len(sys.argv) > 3
+    if is_ndc and os.environ.get("STUB_APPEND_DURING_NDC"):
+        with open(os.environ["STUB_MEMORY_FILE"], "a") as f:
+            f.write(os.environ["STUB_APPEND_DURING_NDC"])
+    fd, path = tempfile.mkstemp(suffix="-haiku")
+    with os.fdopen(fd, "w") as f:
+        if is_ndc:
+            f.write(os.environ.get(
+                "STUB_NDC_TEXT", "## 2026-07-25\\n\\n- compressed summary\\n"))
+        elif os.environ.get("STUB_HAIKU_TEXT"):
+            f.write(os.environ["STUB_HAIKU_TEXT"])
+        elif os.environ.get("STUB_HAIKU_SKIP", "1") == "1":
+            f.write("SKIP\\n")
+        else:
+            f.write("## 10:00 | main\\n\\n- did some work\\n")
+    if is_ndc:
+        rejected = os.environ.get("STUB_NDC_REJECTED") == "1"
+        skipping = os.environ.get("STUB_NDC_SKIP") == "1"
+    else:
+        rejected = os.environ.get("STUB_HAIKU_REJECTED") == "1"
+        skipping = (os.environ.get("STUB_HAIKU_SKIP", "1") == "1"
+                    and not os.environ.get("STUB_HAIKU_TEXT"))
+    print("IS_SKIP=" + ("true" if (rejected or skipping) else "false"))
+    print("IS_REJECTED=" + ("true" if rejected else "false"))
+    print(f"HAIKU_TEXT_FILE={path}")
+    print("TK_IN=0"); print("TK_OUT=0"); print("TK_CACHE=0"); print("TK_COST=0")
+elif cmd == "build-ndc-prompt":
+    with open(sys.argv[3], "w") as f:
+        f.write("compress this now.md\\n")
+'''
+
+
+def _ndc_env(tmp_path: Path, **kwargs):
+    """Harness env with NDC enabled (0 cooldown) and the response-gate stub."""
+    env, project, plugin, calls, sid = _make_env(tmp_path, exchanges=6, humans=5, **kwargs)
+    # Real content from the main summarize call, so it reaches step 7/8
+    # instead of taking the SKIP exit at step 6.
+    env["STUB_HAIKU_SKIP"] = "0"
+    (plugin / "pipeline" / "shell.py").write_text(STUB_SHELL_NDC)
+    for cfg_path in (Path(env["REMEMBER_CONFIG"]), plugin / "config.json"):
+        cfg = json.loads(cfg_path.read_text())
+        cfg["cooldowns"]["ndc_seconds"] = 0
+        cfg_path.write_text(json.dumps(cfg))
+    return env, project, plugin, calls, sid
+
+
+def _wait_for_calls_to_settle(calls_log: Path, timeout: float = 30) -> str:
+    """The NDC subshell is disowned, so poll the calls log until it stops growing."""
+    import time
+    deadline = time.monotonic() + timeout
+    last = None
+    stable_since = None
+    while time.monotonic() < deadline:
+        current = calls_log.read_text() if calls_log.exists() else ""
+        if current == last:
+            if stable_since and time.monotonic() - stable_since > 1.0:
+                return current
+            stable_since = stable_since or time.monotonic()
+        else:
+            last, stable_since = current, None
+        time.sleep(0.2)
+    raise TimeoutError("NDC subshell never settled")
+
+
+class TestNdcRefusalIsRejectedNotAppended:
+    """The exact defect: a refusal is non-empty text, so the old `[ -n
+    "$NDC_TEXT" ]` gate alone appended it into today-*.md as a day summary."""
+
+    def test_refusal_does_not_reach_today_md(self, tmp_path):
+        env, project, plugin, calls, sid = _ndc_env(tmp_path)
+        env["STUB_NDC_TEXT"] = REFUSAL
+        env["STUB_NDC_REJECTED"] = "1"
+
+        result = _run(plugin, env, sid)
+        assert result.returncode == 0, result.stderr
+        _wait_for_calls_to_settle(calls)
+
+        today_files = list((project / ".remember").glob("today-*.md"))
+        written = "".join(f.read_text() for f in today_files)
+        assert REFUSAL.strip() not in written, (
+            f"the refusal reached today-*.md as though it were a real summary: "
+            f"{written!r}"
+        )
+
+    def test_refusal_is_logged_as_rejected(self, tmp_path):
+        env, project, plugin, calls, sid = _ndc_env(tmp_path)
+        env["STUB_NDC_TEXT"] = REFUSAL
+        env["STUB_NDC_REJECTED"] = "1"
+
+        _run(plugin, env, sid)
+        _wait_for_calls_to_settle(calls)
+
+        logs = "".join(p.read_text() for p in (project / ".remember" / "logs").glob("*.log"))
+        assert "ndc" in logs and "REJECTED" in logs, (
+            f"no REJECTED line logged for the NDC refusal:\n{logs}"
+        )
+
+    def test_now_md_is_not_truncated_on_refusal(self, tmp_path):
+        """A rejected NDC run must leave now.md intact so the next round retries."""
+        env, project, plugin, calls, sid = _ndc_env(tmp_path)
+        env["STUB_NDC_TEXT"] = REFUSAL
+        env["STUB_NDC_REJECTED"] = "1"
+
+        result = _run(plugin, env, sid)
+        assert result.returncode == 0, result.stderr
+        _wait_for_calls_to_settle(calls)
+
+        now_md = project / ".remember" / "now.md"
+        assert now_md.is_file() and now_md.stat().st_size > 0, (
+            "now.md was truncated despite the NDC response being rejected — "
+            "the next round can no longer retry this span"
+        )
+        assert "did some work" in now_md.read_text(), (
+            "the entry written by the main summarize call is gone from now.md"
+        )

--- a/tests/test_reject_gate_visibility.py
+++ b/tests/test_reject_gate_visibility.py
@@ -1,0 +1,145 @@
+"""A rejected summary must not look exactly like a legitimate SKIP.
+
+`_is_non_summary` catches refusal-shaped replies — text opening "I'm sorry",
+"Could you", "Please provide" — and folds them into `is_skip`. `save-session.sh`
+then takes the SKIP branch: logs `SKIP — position → N`, advances the position,
+clears the failure marker. Byte for byte what a genuinely empty span produces.
+
+So a span of real work is discarded, permanently, and nothing anywhere records
+that it happened. Memory quietly stops accumulating and every session start
+looks normal.
+
+It also slips past the safeguard built for exactly this. `max_summary_failures`
+(#147: "losing every future span is worse") only counts a non-zero exit from
+call-haiku. The reject gate returns successfully, so it never increments that
+counter and never trips the give-up warning — this failure mode is invisible
+because it resembles success.
+
+The span still has to be dropped rather than retried forever, so the position
+keeps advancing; what changes is that it is now visible and the text is kept.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "tests"))
+
+from pipeline.haiku import _parse_response  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash subprocess + POSIX layout — not portable to Windows runners (#79)",
+)
+
+from test_save_session_gates import _make_env, _run  # noqa: E402
+
+REFUSAL = "I'm sorry, but I can't summarize this conversation without more context."
+CLARIFY = "Could you provide the conversation you would like me to summarize?"
+
+
+def _response(text: str) -> str:
+    import json
+    return json.dumps({"result": text, "input_tokens": 1, "output_tokens": 1,
+                       "cache_read_input_tokens": 0})
+
+
+def test_a_refusal_is_marked_rejected_not_merely_skipped():
+    """The parsed result must say WHICH of the two happened."""
+    rejected = _parse_response(_response(REFUSAL))
+    assert rejected.is_skip, "a refusal must still be kept out of memory"
+    assert rejected.is_rejected, "nothing distinguishes it from a model SKIP"
+
+
+def test_a_model_skip_is_not_marked_rejected():
+    """The ordinary SKIP must stay ordinary."""
+    skipped = _parse_response(_response("SKIP"))
+    assert skipped.is_skip
+    assert not skipped.is_rejected, "a real SKIP was misreported as a rejection"
+
+
+def test_a_clarifying_question_is_also_rejected():
+    """The gate covers hedges, not just outright refusals."""
+    assert _parse_response(_response(CLARIFY)).is_rejected
+
+
+# The shell-level tests below drive the branch through the stub's IS_REJECTED,
+# not by feeding refusal text. Feeding the text does NOT reach the reject gate:
+# the stub stands in for pipeline.shell, so `_is_non_summary` never runs, the
+# response arrives as an ordinary entry, and it is the malformed-HEADER path
+# (#136) that quarantines it. Written that way these tests passed against
+# completely unfixed code, proving a different fix than the one they name.
+# test_the_real_pipeline_reports_a_refusal_as_rejected below closes the gap
+# between this contract and the code that actually produces it.
+
+def test_a_rejected_span_is_logged_distinctly(tmp_path):
+    """The log must not read identically to a content-free session."""
+    env, project, plugin, calls, sid = _make_env(tmp_path, exchanges=6, humans=5)
+    env["STUB_HAIKU_REJECTED"] = "1"
+    _run(plugin, env, sid)
+
+    logs = "".join(p.read_text(encoding="utf-8", errors="replace")
+                   for p in (project / ".remember" / "logs").glob("*.log"))
+    assert "REJECTED" in logs, (
+        f"a discarded span logged exactly like an empty one:\n{logs}"
+    )
+
+
+def test_a_rejected_span_is_kept_for_inspection(tmp_path):
+    """Dropped from memory, but not destroyed — as malformed output already is."""
+    env, project, plugin, calls, sid = _make_env(tmp_path, exchanges=6, humans=5)
+    env["STUB_HAIKU_REJECTED"] = "1"
+    env["STUB_HAIKU_TEXT"] = REFUSAL
+    _run(plugin, env, sid)
+
+    rejects = list((project / ".remember" / "tmp").glob("rejected-*.md"))
+    assert rejects, "the discarded text was not kept anywhere"
+    assert "I'm sorry" in rejects[0].read_text(encoding="utf-8")
+
+
+def test_a_rejected_span_still_advances_the_position(tmp_path):
+    """Otherwise the same span is retried forever — the #147 wedge."""
+    env, project, plugin, calls, sid = _make_env(tmp_path, exchanges=6, humans=5,
+                                                 position=777)
+    env["STUB_HAIKU_REJECTED"] = "1"
+    _run(plugin, env, sid)
+
+    import json
+    saved = json.loads((project / ".remember" / "tmp" / "last-save.json").read_text())
+    assert saved["line"] == 777
+
+
+def test_a_genuine_skip_leaves_no_reject_trail(tmp_path):
+    """The ordinary path must stay quiet: no warning, no file."""
+    env, project, plugin, calls, sid = _make_env(tmp_path, exchanges=6, humans=5)
+    env["STUB_HAIKU_SKIP"] = "1"
+    _run(plugin, env, sid)
+
+    logs = "".join(p.read_text(encoding="utf-8", errors="replace")
+                   for p in (project / ".remember" / "logs").glob("*.log"))
+    assert "REJECTED" not in logs, "a normal SKIP was reported as a rejection"
+    assert not list((project / ".remember" / "tmp").glob("rejected-*.md"))
+
+
+def test_the_real_pipeline_reports_a_refusal_as_rejected(tmp_path):
+    """Bridge: the real emitter must speak the contract the stub encodes."""
+    import io, contextlib
+    from pipeline.shell import _emit_haiku_result
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        _emit_haiku_result(_parse_response(_response(REFUSAL)))
+    out = buf.getvalue()
+
+    assert "IS_SKIP=true" in out, "a refusal must still be kept out of memory"
+    assert "IS_REJECTED=true" in out, "bash cannot tell this from a model SKIP"
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        _emit_haiku_result(_parse_response(_response("SKIP")))
+    assert "IS_REJECTED=false" in buf.getvalue()

--- a/tests/test_save_session_gates.py
+++ b/tests/test_save_session_gates.py
@@ -84,9 +84,11 @@ elif cmd == "call-haiku":
             f.write("SKIP\\n")
         else:
             f.write("## 10:00 | main\\n\\n- did some work\\n")
+    rejected = os.environ.get("STUB_HAIKU_REJECTED") == "1" and not is_ndc
     skipping = (os.environ.get("STUB_HAIKU_SKIP", "1") == "1"
                 and not os.environ.get("STUB_HAIKU_TEXT"))
-    print("IS_SKIP=" + ("false" if (is_ndc or not skipping) else "true"))
+    print("IS_SKIP=" + ("true" if (rejected or (not is_ndc and skipping)) else "false"))
+    print("IS_REJECTED=" + ("true" if rejected else "false"))
     print(f"HAIKU_TEXT_FILE={path}")
     print("TK_IN=0"); print("TK_OUT=0"); print("TK_CACHE=0"); print("TK_COST=0")
 elif cmd == "build-ndc-prompt":

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -337,9 +337,16 @@ def test_cmd_consolidate_with_staging_files(capsys):
         staging_paths_file = paths.get("STAGING_PATHS_FILE")
         assert staging_paths_file and os.path.exists(staging_paths_file)
         raw = open(staging_paths_file, "rb").read()
-        paths_from_file = [p.decode() for p in raw.split(b"\x00") if p]
+        # Records are path\0consumed_bytes\0 — the byte count is what lets the
+        # rename step keep anything appended while Haiku was running (#142's
+        # shape, for staging files).
+        fields = [p.decode() for p in raw.split(b"\x00") if p]
+        paths_from_file, counts = fields[0::2], fields[1::2]
         assert len(paths_from_file) == 1
         assert paths_from_file[0].endswith("today-2020-01-01.md")
+        assert counts[0].isdigit() and int(counts[0]) > 0, (
+            f"no consumed-byte count recorded: {counts!r}"
+        )
 
         # Cleanup temp files printed in output
         for key, path in paths.items():
@@ -493,8 +500,10 @@ def test_cmd_consolidate_staging_paths_file_handles_special_chars(capsys):
         assert staging_paths_file and os.path.exists(staging_paths_file)
 
         raw = open(staging_paths_file, "rb").read()
-        decoded_paths = [p.decode() for p in raw.split(b"\x00") if p]
+        fields = [p.decode() for p in raw.split(b"\x00") if p]
+        decoded_paths, counts = fields[0::2], fields[1::2]
         assert len(decoded_paths) == 3
+        assert all(c.isdigit() for c in counts), f"missing byte counts: {counts!r}"
 
         basenames = sorted(os.path.basename(p) for p in decoded_paths)
         assert basenames == sorted(tricky_names)


### PR DESCRIPTION
Closes nothing filed — both found by auditing for this project's recurring failure class, both written test-first.

**Consolidation sealed concurrent appends away.** It reads every `today-*.md`, calls Haiku (180s budget), then renames each to `.done.md` blind. A save landing in that window is sealed inside the rename: the next run's glob skips `.done.md` and session start never injects it. Written to disk, then unreachable forever. #142's shape one layer over — that fix kept bytes past the snapshot offset in `now.md`; staging never got it. The rename now retires exactly the consolidated span and keeps the tail.

**The reject gate was indistinguishable from a SKIP.** Refusal-shaped replies fold into `is_skip`, so a discarded span of real work logged `SKIP — position → N`, advanced, and cleared the failure marker — byte for byte what an empty session produces. Invisible to `max_summary_failures` too, which counts hard errors while this call succeeds. `HaikuResult` carries `is_rejected` now; bash gets `IS_REJECTED`; rejections are logged distinctly and quarantined like malformed output already is.

## The test that lied

My first draft of the reject-gate tests **passed against completely unfixed code**. The shared stub replaces `pipeline.shell`, so feeding it refusal text never reaches `_is_non_summary` — the response arrived as an ordinary entry and the *header* validator (#136) quarantined it. Six green tests proving a different fix than the one they named.

Writing them before the implementation is what exposed it: there was no fix yet, so green was obviously wrong. They now drive an explicit `IS_REJECTED` contract, with a bridge test asserting the real emitter speaks it.

695 passing (was 684). Two existing format tests updated for the new staging record shape — they assert the byte count now, which is stronger than before.