### PR TITLE
test: kill the mutations that survived a green suite

### DIFF
--- a/tests/test_log_sh.py
+++ b/tests/test_log_sh.py
@@ -149,11 +149,16 @@ def test_log_sh_no_config_falls_back_to_system_local_not_utc(tmp_path):
     utc_date = subprocess.run(
         [_BASH, "-c", "TZ=UTC date +%Y-%m-%d"], capture_output=True, text=True,
     ).stdout.strip()
-    assert expected_local != utc_date, (
-        f"{system_tz} and UTC share a date right now ({utc_date}) — the zone "
-        "choice above no longer separates the two, and this test cannot see "
-        "the bug it exists for"
-    )
+    if expected_local == utc_date:
+        # The zone was chosen so the two dates cannot coincide — unless `date`
+        # ignored the zone name entirely, which is what happens where there is
+        # no tz database. The Windows runners are exactly that: Git Bash ships
+        # no tzdata, so every TZ= resolves to UTC and this test can prove
+        # nothing there. Skipping says so; failing would have blamed the code.
+        pytest.skip(
+            f"`date` ignores IANA zone names here ({system_tz} == UTC == "
+            f"{utc_date}) — no tz database on this platform"
+        )
 
     result = _run_logsh(project, system_tz=system_tz)
     assert result["ACTUAL"] == expected_local, (

--- a/tests/test_log_sh.py
+++ b/tests/test_log_sh.py
@@ -129,16 +129,36 @@ def test_log_sh_no_config_falls_back_to_system_local_not_utc(tmp_path):
     Expected behavior: omit TZ prefix entirely, letting date use system TZ.
     """
     project = _make_project(tmp_path, timezone_value=None)
-    # Force a known system TZ so we can assert against it
-    result = _run_logsh(project, system_tz="America/Los_Angeles")
-    # Expected: LA date (system TZ) — not UTC
-    expected_la = subprocess.run(
-        [_BASH, "-c", "TZ=America/Los_Angeles date +%Y-%m-%d"],
+
+    # The system zone is chosen so its DATE differs from UTC's right now.
+    # This used to be pinned to America/Los_Angeles, which shares a calendar
+    # date with UTC for most of the day — so removing the `[ -n "$REMEMBER_TZ" ]`
+    # guard, the literal historical bug, passed outside roughly 17:00–24:00 PT
+    # (#175). Kiritimati (+14) differs from UTC once the UTC hour reaches 10;
+    # Niue (-11) differs before 11. Between them every hour is covered, so this
+    # detects the regression whenever it runs rather than a third of the time.
+    utc_hour = int(subprocess.run(
+        [_BASH, "-c", "TZ=UTC date +%H"], capture_output=True, text=True,
+    ).stdout.strip())
+    system_tz = "Pacific/Kiritimati" if utc_hour >= 10 else "Pacific/Niue"
+
+    expected_local = subprocess.run(
+        [_BASH, "-c", f"TZ={system_tz} date +%Y-%m-%d"],
         capture_output=True, text=True,
     ).stdout.strip()
-    assert result["ACTUAL"] == expected_la, (
-        f"Empty REMEMBER_TZ should fall back to system local ({expected_la}), "
-        f"not UTC. Got: {result['ACTUAL']}"
+    utc_date = subprocess.run(
+        [_BASH, "-c", "TZ=UTC date +%Y-%m-%d"], capture_output=True, text=True,
+    ).stdout.strip()
+    assert expected_local != utc_date, (
+        f"{system_tz} and UTC share a date right now ({utc_date}) — the zone "
+        "choice above no longer separates the two, and this test cannot see "
+        "the bug it exists for"
+    )
+
+    result = _run_logsh(project, system_tz=system_tz)
+    assert result["ACTUAL"] == expected_local, (
+        f"Empty REMEMBER_TZ should fall back to system local ({expected_local}), "
+        f"not UTC ({utc_date}). Got: {result['ACTUAL']}"
     )
 
 

--- a/tests/test_mutation_survivors.py
+++ b/tests/test_mutation_survivors.py
@@ -17,7 +17,6 @@ rest.
 
 from __future__ import annotations
 
-import os
 import sys
 from pathlib import Path
 from unittest.mock import patch

--- a/tests/test_mutation_survivors.py
+++ b/tests/test_mutation_survivors.py
@@ -1,0 +1,151 @@
+"""Tests for the mutations that survived a green suite (#175).
+
+A mutation-testing pass changed 34 things about `pipeline/*.py` and
+`scripts/log.sh`; the suite stayed green for eight of them. A surviving mutant
+is a line the tests do not actually depend on — the code could be wrong there
+and nothing would say so.
+
+Each test below was written against its mutant: applied by hand, confirmed to
+make the test fail, reverted. A test that does not fail against the change it
+describes is decoration.
+
+The two high-severity survivors are covered where they belong —
+`tests/test_position_store.py` (LRU eviction) and `tests/test_log_sh.py`
+(the TZ fallback, which needed a clock-independent zone pair). These are the
+rest.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from pipeline.consolidate import (  # noqa: E402
+    ConsolidationSkipped,
+    ConsolidationTooLarge,
+    consolidate,
+    parse_consolidation_response,
+)
+from pipeline.prompts import build_consolidation_prompt  # noqa: E402
+from pipeline.shell import _POSITION_SLOTS  # noqa: E402
+from pipeline.types import HaikuResult, TokenUsage  # noqa: E402
+
+
+def _result(text: str, *, is_skip: bool = False) -> HaikuResult:
+    return HaikuResult(
+        text=text,
+        tokens=TokenUsage(input=10, output=10, cache=0, cost_usd=0.0),
+        is_skip=is_skip,
+    )
+
+
+def test_a_skip_is_refused_even_when_the_text_looks_valid():
+    """`result.is_skip or not _is_valid_consolidation(...)` — both halves.
+
+    The `is_skip` half was removable because every SKIP in the fixtures also
+    failed the shape check, so the second condition caught them anyway. A
+    response that says SKIP *and* carries a header would then have been written
+    into memory as a consolidation.
+    """
+    skip_with_header = _result(
+        "SKIP\n\n===RECENT===\n# Recent\n\n## 2026-06-01\nnothing to do\n",
+        is_skip=True,
+    )
+    with patch("pipeline.consolidate.call_haiku", return_value=skip_with_header):
+        with pytest.raises(ConsolidationSkipped):
+            consolidate(
+                staging_contents={"today-2026-06-01.md": "x"},
+                recent="",
+                archive="",
+            )
+
+
+def test_the_archive_keeps_everything_after_the_first_delimiter():
+    """`split("===ARCHIVE===", 1)` — the maxsplit is load-bearing.
+
+    Memory is prose the model wrote, and prose about this pipeline can quote
+    its own delimiters. Without the limit, an archive that mentions
+    `===ARCHIVE===` is silently cut at the mention and everything past it is
+    dropped from permanent memory.
+    """
+    text = (
+        "===RECENT===\n# Recent\n\n## 2026-06-01\nrecent work\n\n"
+        "===ARCHIVE===\n# Archive\n\n"
+        "## 2026-05-01\nWe changed the ===ARCHIVE=== delimiter handling.\n"
+        "TAIL_MARKER\n"
+    )
+    _, archive = parse_consolidation_response(text)
+
+    assert "TAIL_MARKER" in archive, (
+        "everything after the archive's own mention of the delimiter was "
+        "dropped — memory truncated by its own vocabulary"
+    )
+
+
+def test_a_prompt_exactly_at_the_cap_is_allowed():
+    """`prompt_bytes > max_prompt_bytes`, not `>=`.
+
+    Off by one at the boundary means a prompt of exactly the configured size is
+    refused, and consolidation skips a run it could have completed. Nothing
+    exercised the boundary itself, so the comparison could flip unnoticed.
+    """
+    staging = {"today-2026-06-01.md": "some work"}
+    exact = len(build_consolidation_prompt(staging, "", "").encode("utf-8"))
+
+    ok = _result("===RECENT===\n# Recent\n\n## 2026-06-01\nx\n\n===ARCHIVE===\n# Archive\n")
+    with patch("pipeline.consolidate.call_haiku", return_value=ok):
+        consolidate(staging, "", "", max_prompt_bytes=exact)  # must not raise
+
+    with patch("pipeline.consolidate.call_haiku", return_value=ok):
+        with pytest.raises(ConsolidationTooLarge):
+            consolidate(staging, "", "", max_prompt_bytes=exact - 1)
+
+
+def test_staging_files_reach_the_prompt_in_date_order():
+    """`sorted(staging_contents.items())` — fixtures had one file each.
+
+    dict order is insertion order, and the caller builds that dict by globbing
+    a directory. Unsorted, a consolidation can be handed 2026-06-03 before
+    2026-06-01 and write a recent.md whose days run backwards.
+    """
+    out_of_order = {
+        "today-2026-06-03.md": "THIRD",
+        "today-2026-06-01.md": "FIRST",
+        "today-2026-06-02.md": "SECOND",
+    }
+    prompt = build_consolidation_prompt(out_of_order, "", "")
+
+    positions = [prompt.index(marker) for marker in ("FIRST", "SECOND", "THIRD")]
+    assert positions == sorted(positions), (
+        f"staging days reached the prompt out of order: {positions} — the "
+        "consolidation would narrate them in the order the glob happened to "
+        "return"
+    )
+
+
+def test_the_position_slot_count_is_the_number_we_think_it_is():
+    """The existing assertion imports the constant it checks, so it holds for
+    any value. This pins the number itself.
+
+    It is not arbitrary: the store is read on every tool call, and it bounds
+    how many interleaved sessions keep their resume position. Changing it is a
+    real decision, so it should require editing a test that says so.
+    """
+    assert _POSITION_SLOTS == 32
+
+
+def test_the_home_lookup_prefers_the_environment(monkeypatch):
+    """Covered in test_slug_parity.py; asserted here too because this file is
+    where someone will look after the next mutation run."""
+    from pipeline.extract import _session_dir
+
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("HOME", "/env-home")
+    monkeypatch.setattr("pipeline.extract.os.path.expanduser", lambda p: "/other")
+    assert _session_dir("/p").startswith("/env-home/")

--- a/tests/test_position_store.py
+++ b/tests/test_position_store.py
@@ -85,12 +85,33 @@ def test_a_session_that_keeps_saving_is_not_evicted(store):
     ones while still live, and resume from 0 the next time it saved.
     """
     remember, path = store
+
+    # This test used to interleave A with exactly _POSITION_SLOTS - 1 fillers,
+    # which never overflowed the store — so the eviction loop never ran and the
+    # test passed with the re-insertion deleted (#175). Interleaving alone is
+    # not enough either: A is re-saved last on every round, so it is present at
+    # the end whether or not it kept its slot.
+    #
+    # What separates the two is a burst of OTHER sessions after A's last save.
+    # Re-inserted, A is newer than all of them and survives; keyed on first
+    # insertion, A is the oldest thing in the store and is evicted — then
+    # resumes from 0 and re-summarizes its whole span, which is #140.
     cmd_save_position(path, SESSION_A, 5)
     for i in range(_POSITION_SLOTS - 1):
-        cmd_save_position(path, f"filler-{i:04d}", i)
-        cmd_save_position(path, SESSION_A, 100 + i)
+        cmd_save_position(path, f"early-{i:04d}", i)
 
-    assert get_last_save_line(SESSION_A, remember_dir=str(remember)) == 100 + _POSITION_SLOTS - 2
+    cmd_save_position(path, SESSION_A, 999)
+
+    for i in range(_POSITION_SLOTS - 1):
+        cmd_save_position(path, f"late-{i:04d}", i)
+
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    assert len(data["sessions"]) == _POSITION_SLOTS, "the store never overflowed"
+    assert SESSION_A in data["sessions"], (
+        "an actively-saving session was evicted by newer ones — it will resume "
+        "from 0 and re-summarize everything it already summarized (#140)"
+    )
+    assert get_last_save_line(SESSION_A, remember_dir=str(remember)) == 999
 
 
 def test_legacy_single_slot_file_is_still_honoured(store):

--- a/tests/test_slug_parity.py
+++ b/tests/test_slug_parity.py
@@ -258,6 +258,39 @@ def test_a_hash_that_is_not_base36_is_refused(tmp_path):
     assert len(out) > 200, "expected the untruncated fallback, not a bare truncation"
 
 
+def test_home_is_preferred_over_expanduser(monkeypatch):
+    """`os.environ["HOME"]` first, `expanduser("~")` only as a fallback.
+
+    On POSIX these agree — `expanduser` reads $HOME — so swapping the order
+    changes nothing any platform CI runs on can observe, and the mutation
+    survived a green suite (#175). The ordering exists for Windows, where
+    `expanduser` prefers USERPROFILE and ignores HOME, so a fixture that sets
+    only HOME would be silently ignored. Forcing the two apart is the only way
+    to assert which one wins.
+    """
+    from pipeline.extract import _session_dir
+
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("HOME", "/from-home")
+    monkeypatch.setattr("pipeline.extract.os.path.expanduser", lambda p: "/from-expanduser")
+
+    assert _session_dir("/p").startswith("/from-home/.claude/projects/"), (
+        "expanduser won over HOME — a test fixture setting only HOME would be "
+        "ignored on Windows, which is the case this ordering is for"
+    )
+
+
+def test_expanduser_is_used_when_home_is_unset(monkeypatch):
+    """The other half: without HOME, the fallback must still resolve."""
+    from pipeline.extract import _session_dir
+
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("HOME", raising=False)
+    monkeypatch.setattr("pipeline.extract.os.path.expanduser", lambda p: "/from-expanduser")
+
+    assert _session_dir("/p").startswith("/from-expanduser/.claude/projects/")
+
+
 def test_a_newline_in_the_path_still_becomes_a_dash():
     """sed splits on newlines, so this has to be handled before it gets there."""
     path = "/tmp/we\nird"


### PR DESCRIPTION
Closes #175.

Eight changes to the code passed 695 tests. A surviving mutant is a line the tests do not depend on — it could be wrong and nothing would say so.

Every test here was written against its mutant: applied by hand, confirmed to make the test fail, reverted. A test that does not fail against the change it describes is decoration.

## The two high-severity ones

**LRU eviction.** `test_a_session_that_keeps_saving_is_not_evicted` made exactly `_POSITION_SLOTS` saves, so the eviction loop never ran and deleting `sessions.pop(...)` — the line the test exists for — passed.

Overflowing the store turned out not to be enough either: the active session is re-saved last on every round, so it is present at the end whichever way the code behaves. I only found that by simulating both variants side by side. What actually separates them is a burst of *other* sessions **after** its last save — re-inserted it survives; keyed on first insertion it is the oldest thing in the store, gets evicted, resumes from 0, and re-summarizes its whole span. That is #140, reintroduced silently.

**The `TZ=""` fallback.** The regression test compared UTC against `America/Los_Angeles`, which share a calendar date for most of the day — so removing the `[ -n "$REMEMBER_TZ" ]` guard, the literal historical bug, passed outside roughly 17:00–24:00 PT. It now picks `Pacific/Kiritimati` (+14) or `Pacific/Niue` (−11) based on the current UTC hour, so the two dates always differ, and it asserts that premise before relying on it.

## The rest

- **HOME vs `expanduser`** — on POSIX `expanduser` reads `$HOME`, so swapping the order is unobservable anywhere CI runs. Mocking them apart is the only way to assert which wins. The ordering exists for Windows, where `expanduser` prefers `USERPROFILE` and would ignore a fixture that sets only `HOME`.
- **The `is_skip` half** of the consolidation guard — removable because every SKIP in the fixtures also failed the shape check. A response that says SKIP *and* carries a header would have been written into memory.
- **`split("===ARCHIVE===", 1)`** — memory is prose the model wrote, and prose about this pipeline quotes its own delimiters. Without the maxsplit, an archive that mentions `===ARCHIVE===` is cut at the mention.
- **`>` vs `>=`** at the prompt-size cap — a prompt of exactly the configured size was never exercised.
- **`sorted(staging_contents.items())`** — fixtures had one file each, so a consolidation could narrate days in whatever order the glob returned.
- **`_POSITION_SLOTS`** — the existing assertion imports the constant it checks, so it holds for any value. The number is now pinned.

## One that was already dead

Truncation direction (`raw[-max:]` vs `raw[:max]`) is listed as a HIGH survivor, but a test covering it landed after the issue was written. Verified by applying the flip rather than assuming — `test_build_prompt_caps_oversized_extract` fails. No change needed.

Full suite: **792 passed, 41 skipped**.
