### PR TITLE
release: 0.8.8 — Rules that only agreed by accident

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remember",
   "description": "Continuous memory for Claude Code. Extracts, summarizes, and compresses conversations into tiered daily logs. Claude remembers what you did yesterday.",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.8.8] — Rules that only agreed by accident
+
+Eleven issues, and most of them are one shape: a rule written down in more than one place, where the copies happened to agree until they did not. The session-directory slug existed three times and none of the three truncated. The entry-header pattern existed twice and disagreed about 12-hour times. `save.lock` and `consolidation.lock` were two copies of an acquisition that handed the lock to several processes at once. A config option was documented, shipped, and read by nothing.
+
+The rest are failures that reported nothing: a refused compression and a timed-out call, both billed and both logged as costing zero; an OAuth token refused in silence; and eight mutations a green suite never noticed.
+
+None of these were reported by users. They came out of audits and out of adversarial review of the fixes themselves — six of seven review passes found a real defect, several of them in work that had already passed CI. Three things were found only by measuring rather than reading: an `iconv` fork on every non-ASCII path, a glob that matched almost everything because bash cannot hold a NUL in a string, and a locale-dependent range that only failed on CI.
+
+Manifest bumped per [#133](https://github.com/Digital-Process-Tools/claude-remember/issues/133).
 
 ### Fixed
 


### PR DESCRIPTION
Manifest bump + CHANGELOG heading. Two files, same shape as `release: 0.8.7` (#172).

`.claude-plugin/plugin.json` is the part that ships: the updater compares manifest versions and nothing else, which is why 0.8.3 → 0.8.6 reached no users (#133).

## What is in it

Eleven issues, and most are one shape: **a rule written down in more than one place, where the copies agreed until they didn't.**

- the session-directory slug existed three times, and none of the three truncated at 200 characters (#157, #158, #174)
- the entry-header pattern existed twice and disagreed about 12-hour times (#177)
- `save.lock` and `consolidation.lock` were two copies of an acquisition that handed the lock to several processes at once (#182)
- `CLAUDE_CONFIG_DIR` was normalised in one builder and not the other (#169, #194)
- a config option was documented, shipped, and read by nothing (#176)

The rest reported nothing while failing: a refused compression and a timed-out call, both billed and both logged as costing zero (#180, #190); an OAuth token refused in silence (#184's follow-up); malformed UTF-8 resolving to a directory that never existed (#186); and eight mutations a green suite never noticed (#175).

## Where they came from

Not from users. Audits, and adversarial review of the fixes themselves — **six of seven review passes found a real defect**, several in work that had already gone green on CI.

Three were found only by measuring rather than reading, which is the part worth remembering:

- an `iconv` fork on **every** non-ASCII path, on platforms that can never need the check — found by benchmarking a claim I had just written
- a glob that matched almost everything, because `$'\000'` expands to nothing (bash cannot hold a NUL in a string) — found by a probe counting real forks, not by reading the glob
- a locale-dependent bracket range that failed only on the macOS runner — found by CI, and still not reproducible locally, so it ships labelled *empirically necessary, mechanism unconfirmed* rather than with a diagnosis I can't demonstrate

## Note on tags

`v0.8.7` bumped the manifest but has no git tag and no GitHub release — `gh release list` stops at `v0.8.6`. Once this merges I can tag `v0.8.8` and, if you want, backfill `v0.8.7`. Say which.

Full suite: **867 passed, 41 skipped**.
