### PR TITLE
fix: a fallback that spoke over its own answer, and the marker it stranded (#198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`_lock_dir_age` always returned 0 on GNU/Linux, so no orphaned lock was ever adopted there** ([#198](https://github.com/Digital-Process-Tools/claude-remember/issues/198)) — the two `stat` probes shared one command substitution, and the failing one printed to stdout before exiting. They are captured separately now, GNU-native flag first so the noisy call is skipped on the more common platform. Reported by [@bonyohana](https://github.com/bonyohana), with the measurement that made it undeniable.
+- **An adopter killed mid-adoption wedged the lock permanently** ([#198](https://github.com/Digital-Process-Tools/claude-remember/issues/198)) — it left `adopt/` behind with no pid and no claim, so `_lock_try_steal` had nothing to judge and every later `_lock_try_adopt` failed at `mkdir`: the same silent, permanent outage adoption exists to answer, one level up. A marker that has sat untouched past the threshold is now cleared by rename and not recreated — a first cut that recreated it let an adopter which lost the clearing race displace the winner's fresh marker, at 4 double-wins in 40 rounds. Separately, the pid write is guarded with `noclobber`: that is not what closed the double-win, it is what stops an adopter from clobbering the pid a `_lock_try_steal` winner has just written, since the steal's rename leaves `pid` briefly absent and the adopter's entry guard reads that as "no holder".
+- **`grep -c` counted zero and failed at the same time** — `LINES=$(… | grep -c '^\[' || echo 0)` in `scripts/run-tests.sh` captured both branches and produced `"0\n0"`, the same stdout-contamination shape as the `stat` chain. Found by auditing for the reported defect's shape rather than its symptom; consequence was a garbled figure in one self-test log line.
+
 ## [0.8.8] — Rules that only agreed by accident
 
 Eleven issues, and most of them are one shape: a rule written down in more than one place, where the copies happened to agree until they did not. The session-directory slug existed three times and none of the three truncated. The entry-header pattern existed twice and disagreed about 12-hour times. `save.lock` and `consolidation.lock` were two copies of an acquisition that handed the lock to several processes at once. A config option was documented, shipped, and read by nothing.

--- a/scripts/lib-lock.sh
+++ b/scripts/lib-lock.sh
@@ -163,9 +163,21 @@ _LOCK_ADOPT_AFTER="${_LOCK_ADOPT_AFTER:-30}"
 # Seconds since <dir> was last modified. `stat` is BSD on macOS and GNU on
 # Linux with incompatible flags; try both, and report 0 (i.e. "fresh") if
 # neither works, so an unreadable mtime can never trigger an adoption.
+#
+# The two probes are captured SEPARATELY, and that is the whole point. Written
+# as `$(A || B)` the substitution captures the stdout of both: on GNU, `-f` is
+# *filesystem* status, so `%m` is read as a filename that does not exist — the
+# command exits 1, the fallback duly runs, but the real path has already
+# printed its filesystem block to stdout. The block and the correct mtime are
+# concatenated, the digits-only guard below rejects the result, and the
+# function returns 0 for a directory of any age. Every caller then reads
+# "fresh" forever and no orphan is ever adopted on Linux (#198).
 _lock_dir_age() {
     local _mtime _now
-    _mtime=$(stat -f %m "$1" 2>/dev/null || stat -c %Y "$1" 2>/dev/null) || true
+    _mtime=$(stat -c %Y "$1" 2>/dev/null) || _mtime=""
+    case "$_mtime" in
+        ''|*[!0-9]*) _mtime=$(stat -f %m "$1" 2>/dev/null) || _mtime="" ;;
+    esac
     case "$_mtime" in
         ''|*[!0-9]*) echo 0; return 0 ;;
     esac
@@ -180,7 +192,7 @@ _lock_dir_age() {
 # only by deleting the directory by hand. The window is a couple of shell
 # instructions wide, but "rare" and "unrecoverable" is a bad pair.
 _lock_try_adopt() {
-    local _dir="$1" _claim
+    local _dir="$1" _claim _owns_marker=0 _adopted=0
     [ -e "${_dir}/pid" ] && return 1
     for _claim in "${_dir}"/pid.stealing.*; do
         [ -e "$_claim" ] && return 1
@@ -188,10 +200,66 @@ _lock_try_adopt() {
     [ "$(_lock_dir_age "$_dir")" -lt "$_LOCK_ADOPT_AFTER" ] && return 1
 
     # Single winner by construction, same as acquisition: `mkdir` or nothing.
-    mkdir "${_dir}/adopt" 2>/dev/null || return 1
+    if ! mkdir "${_dir}/adopt" 2>/dev/null; then
+        # An adopter killed between `mkdir adopt` and writing the pid strands
+        # the marker: no pid, no claim, adopt/ present. `_lock_try_steal`
+        # returns early with nothing to judge and every later `_lock_try_adopt`
+        # fails here — the same permanent, silent outage this function exists
+        # to answer, one level up (#198). A live adopter holds the marker for
+        # two shell instructions, so one that has sat untouched past the
+        # threshold is debris by exactly the argument used for the lock itself.
+        #
+        # `mv` rather than `rmdir` does the clearing, so that two adopters both
+        # judging the same marker dead cannot both proceed on it: a rename
+        # fails for everyone but the first.
+        [ "$(_lock_dir_age "${_dir}/adopt")" -lt "$_LOCK_ADOPT_AFTER" ] && return 1
+        mv "${_dir}/adopt" "${_dir}/adopt.dead.$$" 2>/dev/null || return 1
+        rm -rf "${_dir}/adopt.dead.$$" 2>/dev/null || true
+    else
+        _owns_marker=1
+    fi
+
+    # The pid write, not the marker, is the single-winner test. A first cut at
+    # this cleared a stranded marker and then recreated it, which meant an
+    # adopter that lost the clearing race — having already read the marker as
+    # debris — went on to displace the *fresh* marker the winner was holding,
+    # and both adopted: 4 double-wins in 40 rounds. Not recreating the marker
+    # is what closed that one, so do not reintroduce a `mkdir` here.
+    #
+    # `noclobber` makes the redirect an O_EXCL create. It is not what fixed
+    # that race, and the concurrent test cannot reach it — with a marker
+    # present every contender funnels into the `mv` and only one gets this
+    # far. It covers the interleaving below instead.
+    #
+    # Refusing to overwrite is right for the adopter specifically: it entered
+    # only because there was no pid, so a pid appearing underneath it means
+    # somebody else legitimately took the lock and this adopter has lost. That
+    # covers the `_lock_try_steal` window too — the rename of `pid` to a claim
+    # is atomic, so one of the two always exists, and the only interleaving
+    # that passes both guards above is one where the steal has already
+    # finished and written its pid. Before this, the adopter would have
+    # clobbered that pid with a plain redirect.
+    #
+    # It does NOT make adoption safe against a *live* holder stalled between
+    # its `mkdir` and its own (plain, unguarded) pid write in `lock_acquire`.
+    # Nothing here can: the two are indistinguishable from outside. That is
+    # what _LOCK_ADOPT_AFTER is for, and the assumption it rests on is stated
+    # above it — a holder writes its pid microseconds after `mkdir`, so
+    # anything this old is debris.
     _lock_self_set
-    echo "$_LOCK_SELF" > "${_dir}/pid" 2>/dev/null || true
-    rmdir "${_dir}/adopt" 2>/dev/null || true
+
+    ( set -o noclobber; echo "$_LOCK_SELF" > "${_dir}/pid" ) 2>/dev/null && _adopted=1
+
+    # Only the process that created the marker removes it. An unguarded rmdir
+    # here deletes whatever is at that path, which after a lost pid race is the
+    # *winner's* live marker rather than this process's — reproducible, and
+    # harmless today only because the pid write above has already settled the
+    # lock and the guard at the top of this function turns away everyone who
+    # comes after. Relying on that would make the marker's stated meaning
+    # ("a live adopter holds this") false whenever the race is lost, and the
+    # clearing logic above reads that meaning back out.
+    [ "$_owns_marker" = 1 ] && rmdir "${_dir}/adopt" 2>/dev/null
+    [ "$_adopted" = 1 ] || return 1
     return 0
 }
 

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -273,7 +273,13 @@ echo "7. Dry-run save (full flow, no Haiku)"
 DRY_OUT=$(cd "$PIPELINE_DIR" && CLAUDE_PROJECT_DIR="$PIPELINE_DIR" bash scripts/save-session.sh --dry 2>/dev/null) || true
 DRY_EXIT=$?
 if echo "$DRY_OUT" 2>/dev/null | grep -q "DRY RUN"; then
-    LINES=$(echo "$DRY_OUT" | grep -c '^\[' 2>/dev/null || echo 0)
+    # `grep -c` prints its count and *still* exits 1 when the count is zero, so
+    # `$(grep -c … || echo 0)` captures both and yields "0\n0" — the same
+    # stdout-contamination shape as #198's `stat` chain, here in a log line.
+    LINES=$(echo "$DRY_OUT" | grep -c '^\[' 2>/dev/null) || true
+    case "$LINES" in
+        ''|*[!0-9]*) LINES=0 ;;
+    esac
     pass "save-session.sh --dry ($LINES exchanges shown)"
 else
     fail "save-session.sh --dry" "exit $DRY_EXIT"

--- a/tests/test_lock_primitive.py
+++ b/tests/test_lock_primitive.py
@@ -334,3 +334,240 @@ def test_lock_survives_set_e_in_the_caller(tmp_path):
     """)
     assert result.returncode == 0, result.stderr
     assert "SKIPPED" in result.stdout and "REACHED_END" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# #198 — _lock_dir_age, and the marker the adopter can strand
+#
+# The age bug is platform-shaped: `stat -f %m` succeeds on BSD and fails on GNU
+# *after printing a filesystem block to stdout*, and the old implementation
+# captured both probes through one command substitution. So it is broken on
+# Linux and fine on macOS, and a test that only calls the real `stat` proves
+# whichever answer the runner happens to hold. These shim `stat` on PATH so
+# both platforms' semantics are exercised everywhere.
+# ---------------------------------------------------------------------------
+
+_GNU_STAT_SHIM = """#!/bin/sh
+# GNU coreutils: `-f` is FILESYSTEM status, so `%m` is read as a filename.
+# That file does not exist -> exit 1, but the real path still prints its block.
+if [ "$1" = "-c" ]; then
+    python3 -c 'import os,sys;print(int(os.stat(sys.argv[1]).st_mtime))' "$3"
+    exit 0
+fi
+if [ "$1" = "-f" ]; then
+    printf '  File: "%s"\\n' "$3"
+    printf '    ID: 26b9871bc77c8277 Namelen: 255     Type: ext2/ext3\\n'
+    echo "stat: cannot read file system information for '%m'" >&2
+    exit 1
+fi
+exit 1
+"""
+
+_BSD_STAT_SHIM = """#!/bin/sh
+if [ "$1" = "-f" ]; then
+    python3 -c 'import os,sys;print(int(os.stat(sys.argv[1]).st_mtime))' "$3"
+    exit 0
+fi
+if [ "$1" = "-c" ]; then
+    echo "stat: illegal option -- c" >&2
+    exit 1
+fi
+exit 1
+"""
+
+
+def _stat_shim(tmp_path, flavour: str) -> Path:
+    """Install a fake `stat` and return the bin dir to prepend to PATH."""
+    bindir = tmp_path / f"bin-{flavour}"
+    bindir.mkdir()
+    shim = bindir / "stat"
+    shim.write_text(
+        _GNU_STAT_SHIM if flavour == "gnu" else _BSD_STAT_SHIM, encoding="utf-8"
+    )
+    shim.chmod(0o755)
+    return bindir
+
+
+def _age_dir(path: Path, seconds: int) -> None:
+    """Backdate a directory's mtime. os.utime rather than `touch`, whose
+    backdating flags differ between BSD (-t) and GNU (-d @epoch)."""
+    now = int(__import__("time").time())
+    os.utime(path, (now - seconds, now - seconds))
+
+
+@pytest.mark.parametrize("flavour", ["gnu", "bsd"])
+def test_lock_dir_age_reports_the_real_age_on_either_stat(flavour, tmp_path):
+    """The probe that fails must not contaminate the one that succeeds.
+
+    GNU `stat -f %m` writes a filesystem block to stdout *and* exits 1. Captured
+    through a single `$(A || B)`, that block is concatenated with the mtime B
+    printed, the digits-only guard rejects the result, and the function reports
+    0 — "fresh" — for a directory of any age. Every adoption check downstream
+    then reads `[ 0 -lt 30 ]` and refuses, forever.
+    """
+    target = tmp_path / "aged.lock"
+    target.mkdir()
+    _age_dir(target, 500)
+
+    result = _run(f"""
+    PATH="{_stat_shim(tmp_path, flavour)}:$PATH"
+    source {LIB_LOCK_SH}
+    _lock_dir_age "{target}"
+    """)
+    assert result.returncode == 0, result.stderr
+    age = int(result.stdout.strip())
+    assert 480 <= age <= 520, (
+        f"{flavour} stat: reported {age}s for a 500s-old directory — an age of 0 "
+        "means _lock_try_adopt can never fire at the shipped threshold"
+    )
+
+
+@pytest.mark.parametrize("flavour", ["gnu", "bsd"])
+def test_a_pidless_orphan_is_adopted_at_the_shipped_threshold(flavour, tmp_path):
+    """The existing adoption test sets _LOCK_ADOPT_AFTER=0, which makes the
+    comparison `[ 0 -lt 0 ]` — false — so it passes *through* a broken age
+    rather than exercising it. This one leaves the default at 30 and ages the
+    directory past it, so the age has to be real for adoption to happen.
+    """
+    lock_dir = tmp_path / "orphan.lock"
+    lock_dir.mkdir()
+    _age_dir(lock_dir, 3600)
+
+    result = _run(f"""
+    PATH="{_stat_shim(tmp_path, flavour)}:$PATH"
+    source {LIB_LOCK_SH}
+    lock_acquire "{lock_dir}" 0 && echo ACQUIRED || echo BLOCKED
+    """)
+    assert "ACQUIRED" in result.stdout, (
+        f"{flavour} stat: a one-hour-old pid-less orphan blocked acquisition at "
+        f"the default threshold — a permanent, silent outage of every save: "
+        f"{result.stdout} {result.stderr}"
+    )
+    assert (lock_dir / "pid").exists()
+
+
+def test_a_stranded_adopt_marker_does_not_wedge_the_lock_forever(tmp_path):
+    """`_lock_try_adopt` takes `${dir}/adopt` as its single-winner marker and
+    removes it after writing the pid. An adopter killed between those two steps
+    leaves no pid, no claim, and adopt/ present: `_lock_try_steal` returns early
+    with nothing to judge, and every later `_lock_try_adopt` fails at `mkdir`.
+    That is the same permanent outage adoption exists to answer, one level up.
+    """
+    lock_dir = tmp_path / "stranded.lock"
+    lock_dir.mkdir()
+    (lock_dir / "adopt").mkdir()
+    _age_dir(lock_dir / "adopt", 3600)
+    _age_dir(lock_dir, 3600)
+
+    result = _run(f"""
+    source {LIB_LOCK_SH}
+    lock_acquire "{lock_dir}" 0 && echo ACQUIRED || echo BLOCKED
+    """)
+    assert "ACQUIRED" in result.stdout, (
+        f"a stranded adopt marker wedged the lock permanently: "
+        f"{result.stdout} {result.stderr}"
+    )
+    assert (lock_dir / "pid").exists()
+
+
+def test_a_fresh_adopt_marker_is_left_alone(tmp_path):
+    """The same state means "an adopter is mid-adoption" for the first moments.
+    Clearing the marker then would let a second process adopt alongside it."""
+    lock_dir = tmp_path / "livemarker.lock"
+    lock_dir.mkdir()
+    (lock_dir / "adopt").mkdir()
+    _age_dir(lock_dir, 3600)
+
+    result = _run(f"""
+    source {LIB_LOCK_SH}
+    lock_acquire "{lock_dir}" 0 && echo ACQUIRED || echo REFUSED
+    """)
+    assert "REFUSED" in result.stdout, (
+        f"adopted past a marker another adopter had just created: "
+        f"{result.stdout} {result.stderr}"
+    )
+
+
+def test_an_adopter_refuses_a_pid_that_appears_after_its_guard(tmp_path):
+    """The `noclobber` write is what makes adoption safe against a pid that
+    lands between the entry guard and the write — most importantly a
+    `_lock_try_steal` winner, whose rename leaves `pid` briefly absent.
+
+    Deterministic because `_lock_dir_age` is called *after* the `[ -e pid ]`
+    guard, so overriding it to install a pid reproduces exactly that window.
+    The adopter must refuse, and must leave the other process's pid intact.
+
+    The concurrent race test below cannot reach this: with the marker already
+    present every contender funnels into the `mv`, which only one can win, so
+    only one process ever reaches the pid write at all.
+    """
+    lock_dir = tmp_path / "latepid.lock"
+    lock_dir.mkdir()
+    _age_dir(lock_dir, 3600)
+
+    result = _run(f"""
+    source {LIB_LOCK_SH}
+    _lock_dir_age() {{ echo 99999 > "{lock_dir}/pid"; echo 3600; }}
+    _lock_try_adopt "{lock_dir}" && echo ADOPTED || echo REFUSED
+    """)
+    assert "REFUSED" in result.stdout, (
+        f"adopted over a pid that appeared after the guard: {result.stdout} "
+        f"{result.stderr}"
+    )
+    assert (lock_dir / "pid").read_text().strip() == "99999", (
+        "clobbered another process's pid — this is the interleaving where a "
+        "steal winner loses the lock it just took"
+    )
+    assert not (lock_dir / "adopt").exists(), (
+        "left its marker behind after refusing, stranding the lock"
+    )
+
+
+def test_two_adopters_racing_on_stranded_debris_produce_one_winner(tmp_path):
+    """Clearing the marker is itself a race: if two adopters both judge it dead
+    and both clear it, the second removes the *fresh* marker the first just
+    made, and both adopt. The clear has to be a single-winner operation.
+
+    The round number goes into the winner line so this asserts exactly one
+    winner per round. `<= ROUNDS` would be satisfied by zero winners — a test
+    that passes because nothing works is the shape #198 was reported for.
+
+    What this actually covers is the *clearing* being single-winner, and the
+    lock not staying wedged. It does NOT cover the `noclobber` pid write:
+    because the marker already exists, every contender fails the opening
+    `mkdir` and funnels into the `mv`, which exactly one can win, so only one
+    process reaches the pid write. Removing `noclobber` leaves this test green
+    over 300 rounds at 8-way contention — verified. The guard is covered by
+    the injection test above instead.
+    """
+    winners = tmp_path / "winners"
+    script = f"""
+    source {LIB_LOCK_SH}
+    contend() {{
+        if lock_acquire "$1" 0; then echo "win $2" >> "{winners}"; fi
+    }}
+    for i in $(seq 1 {ROUNDS}); do
+        D="{tmp_path}/race.$i.lock"
+        mkdir -p "$D/adopt"
+        python3 -c 'import os,sys,time; t=int(time.time())-3600; os.utime(sys.argv[1],(t,t)); os.utime(sys.argv[2],(t,t))' "$D/adopt" "$D"
+        for j in 1 2 3 4; do contend "$D" "$i" & done
+        wait
+        rm -rf "$D"
+    done
+    """
+    result = _run(script)
+    assert result.returncode == 0, result.stderr
+    wins = winners.read_text().split() if winners.exists() else []
+    rounds_won = [w for w in wins if w != "win"]
+    from collections import Counter
+    counts = Counter(rounds_won)
+    doubled = {r: c for r, c in counts.items() if c > 1}
+    assert not doubled, (
+        f"rounds with more than one winner: {doubled} — two adopters cleared the "
+        "same stranded marker and both took the lock"
+    )
+    assert len(counts) == ROUNDS, (
+        f"only {len(counts)} of {ROUNDS} rounds were won at all — stranded debris "
+        "is still wedging the lock, and a max-one-winner assertion alone would "
+        "have called that a pass"
+    )


### PR DESCRIPTION
Closes #198. Reported by @bonyohana, with the measurement that made it undeniable.

## The age bug

`_lock_dir_age` was written as "try BSD, fall back to GNU" in a single command substitution. The exit codes behaved. The **stdout** did not: on GNU, `stat -f` is *filesystem* status, so `%m` is read as a filename that does not exist — the command exits 1 and the fallback duly runs, but the real path has already printed its filesystem block to stdout. The capture concatenated that block with the correct mtime, the digits-only guard rejected the result, and the function returned `0` — "fresh" — for a directory of any age.

Every adoption check downstream then read `[ 0 -lt 30 ]` and refused. So `_lock_try_adopt` could never fire on Linux at the shipped threshold, and the permanent, silent save outage it exists to prevent was still live on what is probably most installs.

The probes are captured separately now, GNU-native flag first so the noisy call is skipped on the more common platform.

## Why the suite was green over it

`test_a_pidless_orphan_is_adopted_not_blocked_forever` set `_LOCK_ADOPT_AFTER=0`, which makes the guarded comparison `[ 0 -lt 0 ]` false — so the test passed *through* the broken age rather than exercising it. Green on a code path that cannot work as shipped.

The new tests shim `stat` on `PATH` with both platforms' semantics, so the Linux defect reproduces on macOS and neither platform's answer depends on which runner happened to execute it. Adoption is asserted at the **shipped** threshold against a directory of known age, not with the threshold zeroed.

## The stranded marker

Same report, secondary. An adopter killed between `mkdir adopt` and writing the pid leaves no pid, no claim, and `adopt/` present: `_lock_try_steal` returns early with nothing to judge and every later `_lock_try_adopt` fails at `mkdir`. The same permanent outage adoption exists to answer, one level up.

The first fix for this was wrong and the tests caught it. Clearing the marker **cannot** be made atomic with the check that judged it stranded: an adopter that loses the clearing race has already read the marker as debris, so it goes on to displace the *fresh* marker the winner is holding, and both adopt. Measured at **4 double-wins in 40 rounds**.

So the marker is now advisory and the pid write is the single-winner test — cleared by rename (fails for everyone but the first), then `set -o noclobber` makes the pid redirect an `O_EXCL` create. Exactly one adopter can install a pid however the clearing race turned out, and adoption only runs when there is no pid, so refusing to overwrite one is never wrong there.

## Found by auditing for the shape

`scripts/run-tests.sh` had `LINES=$(… | grep -c '^\[' 2>/dev/null || echo 0)`. `grep -c` prints its count and *still* exits 1 when that count is zero, so both branches fired and the value was `"0\n0"` — the same stdout-contamination mechanism. Consequence is one garbled figure in a self-test log line; nothing branches on it.

The rest of the repo was swept for the same two shapes and is clean: `log.sh:265` and `log.sh:298` both put the native flag first (verified against real `gstat`/`gdate` — the failing probe prints nothing before exiting), `lib-memory-dir.sh` redirects to a file rather than capturing, and no second threshold-neutering test exists in `tests/`.

## Tests

`tests/test_lock_primitive.py`, 7 new cases (4 parametrized over gnu/bsd `stat`): real age reported under either `stat`; adoption at the shipped threshold; a stranded marker does not wedge the lock; a fresh marker is left alone; and 40 rounds of 4 concurrent adopters racing on stranded debris asserting exactly one winner *per round*.

That last assertion started as `len(wins) <= ROUNDS`, which zero winners would satisfy — the same shape as the bug being fixed. It counts per round now, and asserts every round was won.

Written first and run red before the fix. Full suite green after: **874 passed, 41 skipped**.

Version bumped to 0.8.9 with a CHANGELOG entry, per #133.
