### PR TITLE
fix: the summarizer erased the only proof it was a summarizer

### DIFF
--- a/pipeline/haiku.py
+++ b/pipeline/haiku.py
@@ -9,7 +9,8 @@ The CLI is invoked in a sandboxed configuration: ``cwd=tempdir``, no tools
 by default, ``max-turns`` configurable via ``REMEMBER_MAX_TURNS`` (default 4),
 and the parent Claude Code session env vars are stripped (``CLAUDECODE`` to
 allow a nested session; ``CLAUDE_JOB_DIR`` / ``CLAUDE_CODE_*`` so the child
-doesn't masquerade as the parent's session, #95).
+doesn't masquerade as the parent's session, #95), and ``REMEMBER_NESTED_SUMMARIZER``
+is set so the plugin's own hooks recognise the child and no-op (#204).
 
 Module-level constants:
     HAIKU_INPUT_PRICE: USD cost per input token.
@@ -101,6 +102,10 @@ def _resolve_claude_bin() -> str:
 # `claude setup-token` or runs under a hosted Agent SDK (#131). Keep it.
 _CHILD_ENV_KEEP = frozenset({"CLAUDE_CODE_OAUTH_TOKEN"})
 
+# Set on the child, read by scripts/resolve-paths.sh (#204). Shared here as a
+# constant so the tests pin one spelling against both sides of the contract.
+NESTED_SUMMARIZER_ENV = "REMEMBER_NESTED_SUMMARIZER"
+
 
 def _child_env() -> dict[str, str]:
     """Environment for the nested ``claude -p`` with the PARENT session vars
@@ -112,8 +117,17 @@ def _child_env() -> dict[str, str]:
     a resumable session to anything keying off them (#95). Everything else is
     passed through unchanged — including the credentials in ``_CHILD_ENV_KEEP``,
     which only share the prefix by accident.
+
+    ``REMEMBER_NESTED_SUMMARIZER`` is then set as the positive counterpart to
+    that stripping. Removing the parent markers is what lets the child start at
+    all, and it also erases every trace that it IS a child — so the plugin's own
+    hooks fire inside it, resolve a project from ``cwd=gettempdir()``, and
+    scaffold a memory directory for the temp dir (#204). The hooks were always
+    meant to no-op here; they were reading a signal this function had deleted.
+    A marker we set ourselves cannot be deleted by us and cannot false-positive
+    on an unrelated session, which ``CLAUDE_CODE_ENTRYPOINT=sdk-cli`` would.
     """
-    return {
+    env = {
         k: v
         for k, v in os.environ.items()
         if k in _CHILD_ENV_KEEP
@@ -123,6 +137,8 @@ def _child_env() -> dict[str, str]:
             and not k.startswith("CLAUDE_CODE_")
         )
     }
+    env[NESTED_SUMMARIZER_ENV] = "1"
+    return env
 
 
 def _usage_from_failure(stdout: object) -> TokenUsage | None:

--- a/scripts/resolve-paths.sh
+++ b/scripts/resolve-paths.sh
@@ -43,12 +43,34 @@
 # ENVIRONMENT (opt-in)
 #   REMEMBER_PATHS_SOFT_FAIL=1   Signal failure with `return 1` instead of
 #                                exiting the caller. Set by the hook scripts.
+#   REMEMBER_NESTED_SUMMARIZER   Set by pipeline/haiku.py on the nested
+#                                `claude -p` it spawns. There is no project
+#                                here — resolve nothing and stop.
 #
 # RETURN CODES
 #   1   Path resolution failed, and the caller opted into soft failure.
 #       Without the opt-in, resolution failure exits the caller with 1.
 #
 # ============================================================================
+
+# --- Nested summarizer: there is no project here (#204) ---
+# The Haiku call in pipeline/haiku.py runs `claude -p` with cwd=gettempdir().
+# Claude Code loads plugins in that child and derives its CLAUDE_PROJECT_DIR
+# from that cwd, so every hook this plugin registers fires inside the
+# summarizer with the temp dir as its "project" — scaffolding a memory
+# directory under the temp dir's slug and injecting session-start output into
+# the summarizer's own context.
+#
+# The guard belongs here rather than in any one hook: SessionStart,
+# UserPromptSubmit and PostToolUse are all registered, all source this file,
+# and each one alone is enough to create the directory. This is the only place
+# that covers all three, and the only place a fourth hook would inherit it.
+if [ -n "${REMEMBER_NESTED_SUMMARIZER:-}" ]; then
+    if [ "${REMEMBER_PATHS_SOFT_FAIL:-0}" = "1" ]; then
+        return 1
+    fi
+    exit 0
+fi
 
 # --- Restrict file creation permissions ---
 # Prevent log files, memory files, and temp files from being world/group readable.

--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -40,9 +40,14 @@
 # resolve-paths.sh exits its caller on failure by default (a caller that keeps
 # going with unresolved paths writes memory to the wrong place). This hook is
 # documented to never block session startup, so it opts into soft failure and
-# handles the status itself. Most likely to fail here for a NESTED `claude -p`
-# session (e.g. the remember pipeline's own Haiku call): it has no
-# CLAUDE_PROJECT_DIR and isn't a real project, so just no-op.
+# handles the status itself, no-oping on any unresolvable root.
+#
+# This used to claim the nested `claude -p` summarizer would fail here because
+# it "has no CLAUDE_PROJECT_DIR". It has one: Claude Code sets it afresh in the
+# child from that session's cwd, so resolution SUCCEEDED and the hook ran with
+# the temp dir as its project (#204). resolve-paths.sh now stops on the
+# REMEMBER_NESTED_SUMMARIZER marker instead, and returns 1 into the `|| exit 0`
+# below.
 REMEMBER_PATHS_SOFT_FAIL=1 source "$(dirname "$0")/resolve-paths.sh" || exit 0
 source "$(dirname "$0")/detect-tools.sh"
 source "$(dirname "$0")/bootstrap-dirs.sh"

--- a/tests/test_nested_summarizer.py
+++ b/tests/test_nested_summarizer.py
@@ -1,0 +1,206 @@
+"""The nested Haiku summarizer must not scaffold a memory directory (#204).
+
+pipeline/haiku.py spawns `claude -p` with cwd=tempfile.gettempdir() to keep the
+summarizer out of the user's repo. Claude Code loads plugins in that child and
+derives its CLAUDE_PROJECT_DIR from that cwd — so this plugin's own hooks fire
+inside the summarizer, resolve the temp dir as a project, and build a memory
+store under its slug:
+
+    ~/.remember/-private-var-folders-xr-...-T/
+    ├── logs/
+    └── tmp/
+
+Reported by @BlockX-P2P on 0.8.3 / 0.8.7 / 0.8.8, confirmed on Claude Code
+2.1.219: a nested `-p` run from a scratch cwd sets CLAUDE_PROJECT_DIR to that
+cwd's physical path, reports CLAUDE_CODE_ENTRYPOINT=sdk-cli, and fires both
+SessionStart and UserPromptSubmit.
+
+The guard was always intended — session-start-hook.sh documented a no-op for
+"the remember pipeline's own Haiku call" — but it keyed on the child having no
+CLAUDE_PROJECT_DIR, and the child has one. _child_env() now sets a positive
+marker that resolve-paths.sh stops on, so the signal is one we own rather than
+one we deleted.
+
+It lives in resolve-paths.sh because SessionStart, UserPromptSubmit and
+PostToolUse are all registered and each alone recreates the directory: guarding
+only session-start-hook.sh silences its log line and changes nothing on disk.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash subprocess + POSIX layout — not portable to Windows runners (#79)",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+sys.path.insert(0, str(REPO_ROOT))
+
+from pipeline.haiku import NESTED_SUMMARIZER_ENV, _child_env  # noqa: E402
+
+
+def _external_home(tmp_path: Path) -> tuple[Path, Path]:
+    """A home in external mode: the store is slugged per project, so a stray
+    project root becomes a visible directory beside the real ones."""
+    home = tmp_path / "home"
+    store = tmp_path / "store"
+    (home / ".remember").mkdir(parents=True)
+    (home / ".remember" / "config.json").write_text(
+        json.dumps({"data_dir": f"{store}/{{slug}}"}), encoding="utf-8"
+    )
+    store.mkdir()
+    return home, store
+
+
+def _slug_of(project_dir: Path) -> str:
+    """The slug the plugin itself would compute — asked of lib-slug.sh rather
+    than reimplemented, so the assertion pins the real directory name."""
+    script = f"""
+    source {REPO_ROOT}/scripts/lib-slug.sh
+    session_dir_slug "{project_dir}"
+    """
+    out = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, timeout=60, check=True
+    )
+    return out.stdout.strip()
+
+
+def _registered_hook_scripts() -> list[str]:
+    """Every hook this plugin registers, read from hooks.json.
+
+    Derived rather than hardcoded: a hook added later is covered by these tests
+    the day it is registered, which is the property that made a one-hook fix
+    insufficient in the first place.
+    """
+    hooks = json.loads((REPO_ROOT / "hooks" / "hooks.json").read_text())["hooks"]
+    scripts = []
+    for entries in hooks.values():
+        for entry in entries:
+            for hook in entry["hooks"]:
+                scripts.append(hook["command"].rsplit("/", 1)[-1].rstrip('"'))
+    return scripts
+
+
+def _run_hook(script: str, project_dir: Path, home: Path, nested: bool) -> subprocess.CompletedProcess:
+    """Run one hook exactly as Claude Code does: CLAUDE_PROJECT_DIR from the
+    session's cwd, CLAUDE_PLUGIN_ROOT at the install, stdin closed."""
+    env = {
+        "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+        "HOME": str(home),
+        "TMPDIR": str(project_dir),
+        "CLAUDE_PROJECT_DIR": str(project_dir),
+        "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
+    }
+    if nested:
+        env[NESTED_SUMMARIZER_ENV] = "1"
+    return subprocess.run(
+        ["bash", str(REPO_ROOT / "scripts" / script)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        cwd=str(project_dir),
+    )
+
+
+def test_child_env_marks_the_nested_summarizer():
+    """The spawn side of the contract: the marker is on the child env."""
+    assert _child_env()[NESTED_SUMMARIZER_ENV] == "1"
+
+
+def test_the_marker_does_not_escape_into_the_parent_environment(monkeypatch):
+    """_child_env() builds a dict; it must not mutate os.environ, or the
+    plugin would go silent in the user's real session too."""
+    monkeypatch.delenv(NESTED_SUMMARIZER_ENV, raising=False)
+    _child_env()
+    import os
+
+    assert NESTED_SUMMARIZER_ENV not in os.environ
+
+
+def test_the_temp_dir_project_is_reproduced_without_the_marker(tmp_path):
+    """The bug itself, pinned. Without the marker the hook builds a store for
+    the summarizer's cwd — this is the directory users find and delete."""
+    home, store = _external_home(tmp_path)
+    tmpdir_project = tmp_path / "T"
+    tmpdir_project.mkdir()
+
+    result = _run_hook("session-start-hook.sh", tmpdir_project, home, nested=False)
+
+    assert result.returncode == 0, result.stderr
+    assert (store / _slug_of(tmpdir_project)).is_dir(), (
+        "the reported behaviour did not reproduce — if the hook no longer "
+        "scaffolds here, the guard below is being tested against nothing"
+    )
+
+
+@pytest.mark.parametrize("script", _registered_hook_scripts())
+def test_no_registered_hook_scaffolds_for_the_nested_summarizer(script, tmp_path):
+    """Every hook in hooks.json, not just SessionStart.
+
+    Each one sources resolve-paths.sh then bootstrap-dirs.sh, so each one alone
+    recreates the directory; a guard in one hook only silences that hook's log
+    line. The post-condition is absolute — the slug directory does not exist —
+    not "the count did not grow".
+    """
+    home, store = _external_home(tmp_path)
+    tmpdir_project = tmp_path / "T"
+    tmpdir_project.mkdir()
+
+    result = _run_hook(script, tmpdir_project, home, nested=True)
+
+    assert result.returncode == 0, f"{script} must never block: {result.stderr}"
+    assert list(store.iterdir()) == [], (
+        f"{script} scaffolded {[p.name for p in store.iterdir()]} for the "
+        f"nested summarizer's temp-dir cwd"
+    )
+    assert not (tmpdir_project / ".remember").exists(), (
+        f"{script} left a legacy-mode store in the summarizer's cwd"
+    )
+
+
+def test_a_real_session_still_scaffolds_its_memory_directory(tmp_path):
+    """The guard must not pass by disabling the plugin.
+
+    A session with no marker is a user's session: the full tree is created and
+    the memory injection still runs.
+    """
+    home, store = _external_home(tmp_path)
+    project = tmp_path / "my-project"
+    project.mkdir()
+
+    result = _run_hook("session-start-hook.sh", project, home, nested=False)
+
+    assert result.returncode == 0, result.stderr
+    remember_dir = store / _slug_of(project)
+    for expected in ("tmp", "logs", "logs/autonomous"):
+        assert (remember_dir / expected).is_dir(), f"{expected} not created"
+    assert "=== HANDOFF ===" in result.stdout, (
+        "session-start no longer injects into a real session — the guard is "
+        "firing where it must not"
+    )
+
+
+def test_the_marker_leaves_a_real_session_untouched_when_only_it_is_set(tmp_path):
+    """Symmetry check on one hook: same project, same home, marker the only
+    difference. Nothing else about the environment decides the outcome."""
+    home, store = _external_home(tmp_path)
+    project = tmp_path / "my-project"
+    project.mkdir()
+
+    nested = _run_hook("user-prompt-hook.sh", project, home, nested=True)
+    assert nested.returncode == 0, nested.stderr
+    assert list(store.iterdir()) == []
+
+    real = _run_hook("user-prompt-hook.sh", project, home, nested=False)
+    assert real.returncode == 0, real.stderr
+    assert (store / _slug_of(project)).is_dir()


### PR DESCRIPTION
Part of #204.

## What I verified, versus what was claimed

The report came from outside the team, so every load-bearing claim was re-checked against the code and against a live Claude Code before anything was written.

**Confirmed, by experiment.** A nested `claude -p` launched from a scratch cwd with the plugin's own sandbox flags, on Claude Code 2.1.219, reports:

```
PROJECT_DIR=[/private/tmp/.../ccprobe]  ENTRYPOINT=[sdk-cli]  CWD=[/private/tmp/.../ccprobe]
```

— twice, once from `SessionStart` and once from `UserPromptSubmit`. So the child does get a `CLAUDE_PROJECT_DIR`, it is derived from the cwd, it is resolved to the physical path (hence `/private/var/...` on macOS), and more than one hook fires. Custom env set on the child reached the hook, which is what makes an env marker a usable signal.

**Confirmed, hook side.** Running `session-start-hook.sh` with `CLAUDE_PROJECT_DIR` pointed at a temp dir and an external `{slug}` store produces exactly the reported directory:

```
store/-private-tmp-...-sb-tmp/
├── logs/
└── tmp/
```

**Confirmed, and now pinned.** "A fix at one hook is not sufficient." With the guard removed, all three registered hooks fail the new test independently — `session-start-hook.sh`, `user-prompt-hook.sh`, `post-tool-hook.sh`.

**The one claim that was wrong is in our own source, not the report.** `session-start-hook.sh` said the nested Haiku call "has no `CLAUDE_PROJECT_DIR`". It has one. That comment is why this shipped: the guard was written, believed to be firing, and was not. Corrected in place.

**Not adopted:** the suggested `--setting-sources ''` on the spawn — see below.

## Severity: is a stray directory the only consequence?

The report says "low — cosmetic". Mostly right, and the ways it could have been much worse are closed by accident rather than by design, which is worth writing down.

- **No recursion.** The nested session's `SessionStart` reaches its own recovery block, which would spawn `save-session.sh --force` → another nested `claude -p`. It never fires: it requires `$REMEMBER_DIR/tmp/last-save.json`, which only a save writes, and no save ever runs against the temp-dir store. The consolidation trigger is gated the same way on `today-*.md`. Both preconditions are incidental — nothing states that a bootstrapped-but-empty store must stay empty.
- **No lock interaction.** `save.lock` and `consolidation.lock` both live under `$REMEMBER_DIR`, and the summarizer's `REMEMBER_DIR` is a different directory. The real project's save lock is never touched.
- **No memory is written there.** Only `logs/` and `tmp/` are created; the summarizer runs with `--allowedTools ""`, so `PostToolUse` has nothing to capture.
- **One thing that is not cosmetic:** `SessionStart` writes to stdout, and Claude Code injects hook stdout into the session's context. So the summarizer's context gets, unasked:

  ```
  === HANDOFF ===
  Write next handoff to: <store>/-private-tmp-.../remember.md

  === REMEMBER ===
  History in .remember/: now.md (buffer), today-*.md (daily), ...
  ```

  That is an instruction to write a handoff file, and a description of a memory layout, prepended to a call whose entire job is to summarize a transcript. `UserPromptSubmit` adds its timestamp line to the prompt on top. It costs tokens on every save and it is exactly the kind of stray instruction a summarizer should never see. No misbehaviour was observed — but "we send unrelated instructions to the model and it seems fine" is not a property worth keeping.

So: bounded, no data loss, agreed — and one degree worse than the report describes.

## The fix, and what I rejected

Set `REMEMBER_NESTED_SUMMARIZER=1` in `_child_env()`; stop on it in `resolve-paths.sh`.

Two decisions in that sentence.

**Why a marker rather than `--setting-sources ''`.** The suggested spawn-side fix works — I reproduced the A/B, run B creates nothing and still returns its answer. I did not take it. If a user's `claude` predates that flag, an unknown argument is a non-zero exit, which `call_haiku` raises on, which means *no session is ever saved again*. Trading a stray directory for a silent total save outage on older CLIs is the wrong trade, and this repo has taken CLI-compat damage before (#120, the cc2x `--max-turns` counting). A marker we set ourselves depends on no CLI surface at all, and unlike `CLAUDE_CODE_ENTRYPOINT=sdk-cli` it cannot false-positive and disable the plugin in someone's unrelated Agent SDK session.

**Why `resolve-paths.sh` rather than a hook.** Guarding `session-start-hook.sh` alone removes its log line and changes nothing on disk, because `user-prompt-hook.sh` scaffolds the directory anyway. `resolve-paths.sh` is the one file all three hooks source, and the one a fourth hook would inherit the guard from for free. It also reuses the failure convention already in that file: soft-fail callers get `return 1` into their existing `|| exit 0`, so no hook changed shape.

**Also considered:** pointing the child at a scratch `CLAUDE_PROJECT_DIR`. Rejected — it relocates the junk rather than removing it, and still pays the hook execution and the context injection.

## Tests

`tests/test_nested_summarizer.py`, 8 tests. The post-conditions are absolute — *the slug directory does not exist* — not "the count did not grow".

- The bug itself is reproduced first, so the guard is not being tested against nothing.
- The hook list is read from `hooks/hooks.json` and parametrized, so a hook registered later is covered the day it is registered. That is the property whose absence made a one-hook fix insufficient.
- The slug is computed by asking `lib-slug.sh`, not by reimplementing it, so the assertion names the real directory.
- Two tests exist specifically to stop the guard passing by disabling everything: a real session must still create `tmp/`, `logs/`, `logs/autonomous/` *and* still emit its `=== HANDOFF ===` injection; and a symmetry check runs the same hook against the same project twice with the marker as the only difference.

Would they pass if the fix did nothing? No — checked by stashing the guard: **4 failed, 4 passed**, the four failures being the three hooks and the symmetry check.

Full suite with the fix: **898 passed, 41 skipped**, coverage 93.74% (`pytest -q`).

## Notes for the reviewer

- **The report's secondary issue is not addressed here** — the `//.remember/.gitignore` write on a read-only root, where `2>/dev/null` on the `echo` cannot suppress a redirection-open failure. It is a real and separate defect in `bootstrap-dirs.sh` and deserves its own change; hence `Part of #204` rather than `Closes`.
- No `--no-verify` needed. The pre-push hook runs the suite, and `tests/conftest.py` already strips the `GIT_*` repo-selection vars autouse — this repo fixed that class of leak in 2026-07.
- `CHANGELOG.md` untouched: entries here are written at release time. #203 and #173 untouched.
