### PR TITLE
fix(ndc): the tail-failure path no longer truncates now.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **NDC's failure path truncated `now.md` — the exact bug its success path had already been fixed to avoid** ([#173](https://github.com/Digital-Process-Tools/claude-remember/issues/173)) — `now.md` is snapshotted before a Haiku call that can run 180s, and by the time it returns the parent has released the save lock and exited, so a newer save may have appended entries (#142). The success path keeps everything past the snapshot offset via `tail -c +N` for exactly that reason. But if `tail` itself failed — disk, permissions, a full `$TMPDIR` — the `else` arm fell back to `: > "$MEMORY_FILE"`: the same blind truncate #142 removed, reintroduced as the one error case where it erases the whole span, including anything appended after the snapshot, unrecoverably and unlogged. `now.md` is now left completely untouched on a `tail` failure, with an error logged. Cost: the span was already appended to `today-*.md` before the `tail` step runs, so leaving it in `now.md` too means the next NDC round can summarize it a second time — a duplicated entry. Rolling back the `today-*.md` append instead was considered and rejected: that file can itself receive concurrent appends during the same 180s window, and truncating it back to a byte count captured earlier would risk erasing exactly that concurrent write — the same #142 class of bug, moved one file over. A duplicated, visible summary beats an erased, silent one. Reported against `flock`-based locking in [#173](https://github.com/Digital-Process-Tools/claude-remember/issues/173) by [@Jutiphan](https://github.com/Jutiphan), whose diagnosis of the defect was correct; that PR's fix mechanism wasn't portable here (`lib-lock.sh` rejects `flock` — absent on macOS, no util-linux on the GitHub macOS runner, and a Python `fcntl.flock` workaround dies with its child process while the shell believes it still holds the lock), so the fix here is a straight patch of the existing `mv`-based lock primitive's blast radius rather than a rework of the locking itself.
+
 ## [0.8.9] — Silence, mistaken for success
 
 Two issues, both reported from outside the team, and they are the same bug wearing different clothes: something produced no signal, and the absence of a signal was read as a good one.

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -537,9 +537,28 @@ if [ "$RUN_NDC" = true ]; then
                         fi
                         [ "$NDC_KEPT" -gt 0 ] && log "ndc" "kept ${NDC_KEPT}b appended during compression"
                     else
+                        # tail failed (disk, permissions, a full $TMPDIR — #173).
+                        # This branch used to be `: > "$MEMORY_FILE"`, the exact
+                        # blind truncate #142 removed from the success path above,
+                        # reintroduced here as the failure path. now.md is left
+                        # completely untouched instead: whatever tail could not
+                        # read is safer sitting in now.md than erased.
+                        #
+                        # Cost: the span already appended to $TODAY_FILE above
+                        # (line ~502) stays there, and since now.md keeps every
+                        # byte, the next NDC round can summarize the same span
+                        # again — a duplicated entry in today-*.md. That trade is
+                        # deliberate: a duplicated summary is visible and
+                        # recoverable; erased entries are neither. Rolling back
+                        # the TODAY_FILE append instead was considered and
+                        # rejected — TODAY_FILE can itself receive concurrent
+                        # appends during this same 180s window (any other save's
+                        # own NDC round, or a future flush), and truncating it
+                        # back to a byte count captured earlier would risk
+                        # erasing exactly that concurrent write: the same #142
+                        # class of bug, moved one file over.
                         rm -f "$NDC_TAIL"
-                        : > "$MEMORY_FILE"
-                        rm -f "$NOW_DAY_FILE"
+                        log "ndc" "ERROR: tail failed, now.md left untouched (today-${NDC_DAY}.md may now hold a duplicate of this span)"
                     fi
                     NDC_OUT_BYTES=$(wc -c < "$HAIKU_TEXT_FILE" | tr -d ' ')
                     [ "$NDC_SRC_BYTES" -gt 0 ] && log "ndc" "${NDC_SRC_BYTES}→${NDC_OUT_BYTES}b (-$(( (NDC_SRC_BYTES - NDC_OUT_BYTES) * 100 / NDC_SRC_BYTES ))%)"

--- a/tests/test_ndc_tail_failure_no_truncate.py
+++ b/tests/test_ndc_tail_failure_no_truncate.py
@@ -40,6 +40,14 @@ pytestmark = pytest.mark.skipif(
 # not the one this stub directory was prepended to, so it cannot recurse into
 # itself.
 #
+# `command -p` is deliberately NOT prefixed with `exec`. Debian's dash — which
+# is `/bin/sh` on every Ubuntu runner — implements `exec` as a PATH search for
+# an *executable*, with no fallback to builtins, so `exec command -p tail` dies
+# with "exec: command: not found" and exit 127 before any tail runs. Bash (macOS
+# `/bin/sh`) and Apple's dash both accept it, which is why this only ever showed
+# up on Linux CI. Without `exec` the builtin runs normally and the stub exits
+# with tail's own status; the only cost is one extra live process.
+#
 # Before failing, it snapshots the exact bytes of $3 (MEMORY_FILE) into
 # $STUB_TAIL_SNAPSHOT if set. That snapshot — taken synchronously, inside the
 # call the fix must not mutate around — is the only race-free ground truth
@@ -56,7 +64,7 @@ case "$1" in
         exit 1
         ;;
 esac
-exec command -p tail "$@"
+command -p tail "$@"
 """
 
 

--- a/tests/test_ndc_tail_failure_no_truncate.py
+++ b/tests/test_ndc_tail_failure_no_truncate.py
@@ -1,0 +1,124 @@
+"""NDC must not erase now.md when the tail-forward step fails (#173).
+
+`save-session.sh` snapshots `now.md`'s byte length before handing it to a
+Haiku call that can run up to 180s, then keeps everything past that offset
+with `tail -c +N`. #142 fixed the success path so a *newer* save's entry
+survives. But the failure path — `tail` erroring on disk pressure, a
+permissions problem, or a full `$TMPDIR` — used to fall back to
+`: > "$MEMORY_FILE"`: the exact blind truncate #142 removed from the success
+arm, reintroduced as the one error case where the whole span, including
+anything appended after the snapshot, is destroyed with nothing to recover it.
+
+Reported in PR #173 (Jutiphan) against `flock`-based locking that this repo
+does not use (see lib-lock.sh and CHANGELOG); the analysis of the defect was
+correct even though that fix's mechanism was not portable here.
+
+The fix: on tail failure, now.md is left completely untouched and an error is
+logged. The known trade is a duplicated entry in today-*.md (the span was
+already appended there before the tail step runs) — visible and recoverable,
+unlike the erased-and-unlogged alternative.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from .test_save_session_gates import _make_env, _run  # shared harness
+from .test_ndc_truncate_race import _ndc_env, _wait_for_background_ndc
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash subprocess + POSIX layout — not portable to Windows runners (#79)",
+)
+
+# Fails only the exact invocation NDC uses (`tail -c +N MEMORY_FILE`), so
+# every other `tail` call in the script (header extraction, entry
+# normalization) still runs through the real binary and the run reaches the
+# NDC step normally. `command -p` resolves against the shell's default PATH,
+# not the one this stub directory was prepended to, so it cannot recurse into
+# itself.
+#
+# Before failing, it snapshots the exact bytes of $3 (MEMORY_FILE) into
+# $STUB_TAIL_SNAPSHOT if set. That snapshot — taken synchronously, inside the
+# call the fix must not mutate around — is the only race-free ground truth
+# for "what now.md held right before tail ran". Reading now.md from the test
+# process at any point around the backgrounded NDC subshell cannot be trusted
+# for that: the subshell has no artificial delay, so it may already have
+# finished (successfully or not) before or after any read the test attempts.
+TAIL_STUB = """#!/bin/sh
+case "$1" in
+    -c)
+        if [ -n "$STUB_TAIL_SNAPSHOT" ]; then
+            cp "$3" "$STUB_TAIL_SNAPSHOT" 2>/dev/null || true
+        fi
+        exit 1
+        ;;
+esac
+exec command -p tail "$@"
+"""
+
+
+def _with_failing_tail(env: dict, tmp_path: Path, snapshot: Path) -> dict:
+    bindir = tmp_path / "stub-bin"
+    bindir.mkdir(exist_ok=True)
+    stub = bindir / "tail"
+    stub.write_text(TAIL_STUB, encoding="utf-8")
+    stub.chmod(0o755)
+    env = dict(env)
+    env["PATH"] = f"{bindir}{os.pathsep}{env['PATH']}"
+    env["STUB_TAIL_SNAPSHOT"] = str(snapshot)
+    return env
+
+
+class TestNdcTailFailureNoTruncate:
+
+    def test_now_md_untouched_when_tail_fails(self, tmp_path):
+        """The #173 case: tail erroring must not blank now.md."""
+        env, project, plugin, calls, sid = _ndc_env(tmp_path)
+        memory_file = project / ".remember" / "now.md"
+        snapshot = tmp_path / "tail-snapshot.md"
+        env = _with_failing_tail(env, tmp_path, snapshot)
+
+        result = _run(plugin, env, sid)
+        assert result.returncode == 0, result.stderr
+
+        # No tail-forward can succeed, so now.md never changes again once the
+        # NDC subshell reaches (and fails) the tail step. Settling just means
+        # waiting out the subshell's own lifetime.
+        _wait_for_background_ndc(memory_file)
+        after = memory_file.read_bytes()
+
+        assert snapshot.is_file(), (
+            "the tail stub never ran (-c branch) — the run did not reach the "
+            "NDC tail step at all, so this test proves nothing"
+        )
+        before = snapshot.read_bytes()
+        assert before, "the tail stub's snapshot of now.md was empty"
+
+        assert after == before, (
+            "tail failing must leave now.md byte-for-byte identical to what "
+            "it held the instant tail was invoked — any diff means the "
+            "failure path truncated or otherwise mutated a file it could not "
+            f"safely rewrite; before={before!r} after={after!r}"
+        )
+
+    def test_tail_failure_is_logged(self, tmp_path):
+        """A silent failure here is as bad as the truncate itself."""
+        env, project, plugin, calls, sid = _ndc_env(tmp_path)
+        snapshot = tmp_path / "tail-snapshot.md"
+        env = _with_failing_tail(env, tmp_path, snapshot)
+
+        result = _run(plugin, env, sid)
+        assert result.returncode == 0, result.stderr
+
+        memory_file = project / ".remember" / "now.md"
+        _wait_for_background_ndc(memory_file)
+
+        log_files = list((project / ".remember" / "logs").glob("*.log"))
+        assert log_files, "expected a log file to exist"
+        log_text = "\n".join(f.read_text() for f in log_files)
+        assert "tail failed" in log_text, (
+            f"expected an error log naming the tail failure, got: {log_text!r}"
+        )


### PR DESCRIPTION
## The defect

`save-session.sh`'s NDC step drops the compressed span from `now.md` with a `tail -c` into a temp file plus an `mv`. The `else` arm of that `if` — taken when `tail` fails — was:

```sh
else
    rm -f "$NDC_TAIL"
    : > "$MEMORY_FILE"
    rm -f "$NOW_DAY_FILE"
fi
```

That is the blind truncate #142 removed from the success path, alive as the failure path. The comment directly above the `if` explains why #142 removed it: `now.md` is snapshotted before a Haiku call that can run 180s, by which time the parent has released the save lock and exited, so a newer save may have appended entries. Truncating erases them, their position has already advanced so they are unrecoverable, and nothing is logged.

So on any `tail` failure — disk, permissions, a full `$TMPDIR` — the code path added to prevent data loss produced exactly that data loss.

## The fix

`now.md` is now left **completely untouched** and the failure is logged. `$NOW_DAY_FILE` is left alone too, since the day stamp describes contents that no longer changed.

**The trade, stated plainly:** the summary has already been appended to `today-*.md` by the time `tail` runs, and `now.md` now keeps every byte — so the next NDC round can summarize the same span again, producing a duplicated entry. That is deliberate. **A duplicated summary is visible and recoverable; erased entries are neither.** The log line names the affected daily file so an operator can see what happened.

Rolling back the `today-*.md` append instead — making the round atomic — was considered and rejected: that file can receive concurrent appends during the same 180s window, and truncating it back to a byte count captured earlier would risk erasing exactly that concurrent write. The same #142 bug class, moved one file over.

## Tests

Two pins, both verified red against the unfixed code and green with the fix:

```
$ git show main:scripts/save-session.sh > scripts/save-session.sh   # true unfixed version
$ python3 -m pytest tests/test_ndc_tail_failure_no_truncate.py -q --no-cov
FAILED ...::test_now_md_untouched_when_tail_fails
FAILED ...::test_tail_failure_is_logged
2 failed
```

They force `tail` to fail deterministically and assert the post-condition — `now.md` byte-for-byte identical to what it was, and the failure logged — rather than the proxy "now.md is non-empty", which passes on the broken code whenever `tail` happens to succeed.

Full suite: **892 passed, 41 skipped**, coverage 93.71% against an 80% gate.

## Credit

The analysis is **@Jutiphan's**, from #173 — this defect is item (c) of that report, and it was correct. That PR is not being merged as written because its locking is built on `flock`, which `scripts/lib-lock.sh:27-32` rejects by design (absent on macOS, and the GitHub macos runner does not ship util-linux; the same comment pre-rejects the `python3 fcntl.flock` workaround). Items (a) and (b) of #173 — serializing the snapshot and the commit — remain open and are not addressed here; they need a critical section built on this repo's own `lib-lock.sh` primitive.

Part of #173.
