### PR TITLE
release: 0.9.0 — Mistaken for someone else

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remember",
   "description": "Continuous memory for Claude Code. Extracts, summarizes, and compresses conversations into tiered daily logs. Claude remembers what you did yesterday.",
-  "version": "0.8.9",
+  "version": "0.9.0",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.0] — Mistaken for someone else
+
+Seven fixes, and four of them are the same question answered wrong: *whose is this?*
+
+The worst was the nested summarizer, which could not tell its own CLI's voice from the model's. A `UserPromptSubmit` hook that **blocks** does not make the call fail — the CLI writes its refusal to stdout, quotes the entire prompt back, reports `subtype: success`, and exits **0**. Nothing in the exit code, the status field or the usage figures separates that from an answer. Only the text does, and the guard reading that text was positive-only: accept if the envelope is present, else accept if an entry header is. Both are present, because the prompt embeds the staging files verbatim and prints the envelope in its own instructions. So a hook's refusal was written to `recent.md` as memory, and the next run quoted the poisoned file into a new prompt and nested one level deeper. The reporter reached 29,153 bytes and seven levels, with six days of real entries surviving only as quoted text.
+
+The general lesson is why it is documented rather than only patched: **a positive-only validity check cannot reject an echo of its own input**, because every signal it looks for is by construction present in that input. What separates a reply from an echo is not the content — the echo's content is real memory — but the *instructions*, which the model has no reason to reproduce.
+
+The other three mistaken identities were quieter. The capture-gap detector asked "was session X captured?" of a store that could only answer "which session most recently made a tool call" — so after `/clear`, which mints no new session id, it compared the current session against itself and warned that a perfectly healthy session had been lost. Every time, forever. `PostToolUse` inferred which session it was recording for from the newest transcript by mtime rather than from its own stdin, so two live sessions in one project could credit one's work to the other. And `/remember:doctor` inferred the project from nothing at all — `CLAUDE_PROJECT_DIR` reaches hooks but not the Bash tool that runs it — then reported a hard `FAIL` on a healthy install, while its own instructions told the reader never to contradict a `FAIL` line.
+
+The remaining three are about evidence rather than identity. NDC's failure path still carried the blind truncate that #142 removed from its success path, so a `tail` that errored erased the whole span unrecoverably and unlogged. The test harness printed an empty `stderr` on every failure, because these scripts redirect stderr into `hook-errors.log` — the message was always there, and never where anyone looked. And a warning that fires on every `/clear` trains you to stop reading it, which is how the one that matters gets skipped.
+
+Two things worth knowing about what ships. The hook isolation that closes the corruption uses `--setting-sources ''`, and it **fails open**: an older CLI rejects the flag outright, and excluding every setting source also excludes `apiKeyHelper` and the `env` block, which is how enterprise, Bedrock and proxy installs authenticate. Both resolve before the API is contacted and therefore cost nothing, so the call is retried once without isolation and says so loudly — because trading a corruption bug for a silent total outage is a worse deal, and this project has nearly made it before. The echo-rejecting guard holds either way; that is the whole argument for two layers rather than one good one. And the capture store gains an on-disk format, `tmp/capture-alive.d/`: the legacy single slot stays valid evidence, so the first run after upgrading behaves exactly as before instead of reading its own empty store as a fault.
+
+Thanks to [@kodown1k](https://github.com/kodown1k), who supplied the byte counts and nesting depth that made the recursion legible; [@Jutiphan](https://github.com/Jutiphan), whose diagnosis of the NDC truncate was correct even though its `flock`-based fix was not portable here; [@PedroHenriqueNS](https://github.com/PedroHenriqueNS), who found the doctor's false `FAIL`; [@ca-sringert](https://github.com/ca-sringert), whose independent reproduction proved the capture-gap defect was not `/clear`-specific; and [@BlockX-P2P](https://github.com/BlockX-P2P), who traced the nested summarizer scaffolding a memory directory in `$TMPDIR`.
+
+Manifest bumped per [#133](https://github.com/Digital-Process-Tools/claude-remember/issues/133).
 
 ### Fixed
 


### PR DESCRIPTION
Two files, the shape every release here takes: `.claude-plugin/plugin.json` and `CHANGELOG.md`. The full notes are in the CHANGELOG section this adds; what follows is what a reviewer needs before merging.

## What ships

Seven fixes since 0.8.9, four of which are the same question answered wrong — *whose is this?*

| | |
|---|---|
| [#202](https://github.com/Digital-Process-Tools/claude-remember/issues/202) | The nested summarizer could not tell its own CLI's voice from the model's, so a blocking hook's refusal was written to `recent.md` as memory and re-quoted one level deeper every run |
| [#206](https://github.com/Digital-Process-Tools/claude-remember/issues/206) | After `/clear` — which mints no new session id — the capture-gap detector compared the current session against itself and warned a healthy session was lost |
| [#212](https://github.com/Digital-Process-Tools/claude-remember/issues/212) | `PostToolUse` inferred its session from the newest transcript by mtime, so two live sessions in one project could credit one's work to the other |
| [#207](https://github.com/Digital-Process-Tools/claude-remember/issues/207) | `/remember:doctor` inferred the project from nothing and reported a hard `FAIL` on a healthy install — while its own instructions said never to contradict a `FAIL` line |
| [#173](https://github.com/Digital-Process-Tools/claude-remember/pull/173) (c) | NDC's failure path still carried the blind truncate #142 removed from its success path |
| [#210](https://github.com/Digital-Process-Tools/claude-remember/issues/210) | The test harness printed an empty `stderr` on every failure, because these scripts redirect stderr into `hook-errors.log` |
| [#204](https://github.com/Digital-Process-Tools/claude-remember/issues/204) (part) | The nested session scaffolded a memory directory in `$TMPDIR` |

## Two things a reviewer should weigh

**Hook isolation fails open, deliberately.** `--setting-sources ''` is rejected outright by an older CLI, and excluding every setting source also excludes `apiKeyHelper` and the `env` block — how enterprise, Bedrock and proxy installs authenticate. Both resolve *before* the API is contacted, so nothing is billed and the call is retried once without isolation, logging plainly that the nested call is now running with the user's hooks live. The echo-rejecting guard holds either way; that is the whole argument for two layers rather than one good one.

**The capture store gains an on-disk format**, `tmp/capture-alive.d/`. The legacy single slot remains valid evidence, so the first run after upgrading behaves exactly as before rather than reading its own empty store as a fault. That is the migration, and it is pinned by a test asserting the pre-upgrade state.

Those two are why this is `0.9.0` rather than a patch bump: an on-disk format and a changed CLI invocation are more than a fix.

## Why it matters now

The manifest version is the only thing the updater compares ([#133](https://github.com/Digital-Process-Tools/claude-remember/issues/133)). Until it moves, none of the above reaches the plugin cache — and [#204](https://github.com/Digital-Process-Tools/claude-remember/issues/204) is currently blocked on exactly that: the nested `claude -p` loads the plugin from `~/.claude/plugins/cache/…/remember/0.7.1`, so a fix merged to `main` cannot take effect there. This release is what unblocks it.

## Verification

Full suite on the release branch: **945 passed, 41 skipped**, coverage 93.98% (gate 80%).

## After merging

Tag the squash-merge commit and cut the GitHub release — `v0.8.7` shipped by manifest with no tag, and the public releases page sat two versions stale until it was backfilled:

```bash
git tag -a v0.9.0 -m "0.9.0 — Mistaken for someone else" <sha> && git push origin v0.9.0
gh release create v0.9.0 --title "v0.9.0 — Mistaken for someone else" --notes-file <changelog section> --latest
```
