### PR TITLE
release: 0.10.0 — Nothing was counting

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remember",
   "description": "Continuous memory for Claude Code. Extracts, summarizes, and compresses conversations into tiered daily logs. Claude remembers what you did yesterday.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] — Nothing was counting
+
 ### Fixed
 
 - **The prompt hook spawned 27 processes to print a timestamp, and the user waited for all of them** ([#227](https://github.com/Digital-Process-Tools/claude-remember/issues/227)) — `scripts/user-prompt-hook.sh` sourced `resolve-paths.sh` → `bootstrap-dirs.sh` → `log.sh` on every prompt submission to emit one line, `[HH:MM TZ — username]`. That chain runs `git rev-parse --path-format=absolute`, a session slug, a three-layer `config.json` merge, `date` twice and `whoami`: **19 external processes on macOS, 27 on Windows 11 ARM64 under QEMU**.


### PR DESCRIPTION
Cuts **0.10.0 — Nothing was counting**. Version bump in `.claude-plugin/plugin.json` (0.9.0 → 0.10.0), `## [Unreleased]` rolled to `## [0.10.0] — Nothing was counting`, fresh empty `Unreleased` opened. No code changes.

Seven entries, all already merged and green on `main`. Five of them are the same omission — work nobody was counting:

| Issue | What was uncounted |
|---|---|
| [#204](https://github.com/Digital-Process-Tools/claude-remember/issues/204) | how many nested summarizers could exist — no limit in any layer, and a `--force` chain runs forever without two ever running at once |
| [#227](https://github.com/Digital-Process-Tools/claude-remember/issues/227) | 27 processes to print one line; p50 **8.7s** of blocked typing, 6 timeouts across 256 prompts |
| [#223](https://github.com/Digital-Process-Tools/claude-remember/issues/223) | the save lock was held for the read and not for the rewrite |
| [#221](https://github.com/Digital-Process-Tools/claude-remember/issues/221) | a handoff consumed by a session that never wrote one back |
| [#219](https://github.com/Digital-Process-Tools/claude-remember/issues/219) | a sibling worktree's change read as our own, failing the run |

Plus `bootstrap-dirs.sh` leaking a shell error at session start on an unwritable memory root, and `docs/verification.md` documenting the OAuth-token fallback that previously had no way to confirm it worked.

## Why this release matters more than its diff

**It is the last mile of three fixes that are already in `main` and are not running for anybody.**

The nested summarizer loads this plugin from the marketplace cache, not from a checkout. On this maintainer's own machine that cache is pinned at **0.7.1**, two minors behind — verified by the hook's own log line, which names `PIPELINE_DIR=…/cache/dpt-plugins/remember/0.7.1` on 36 nested session starts today. So the `--setting-sources` isolation ([#202](https://github.com/Digital-Process-Tools/claude-remember/issues/202)), the `REMEMBER_NESTED_SUMMARIZER` marker ([#205](https://github.com/Digital-Process-Tools/claude-remember/issues/205)) and the new spawn bound (#204) are all present in `main` and absent from the code that actually executes. Publishing is what closes that gap; `plugin.json` is the only thing the updater compares.

The same holds for the Windows reports. This repo has taken **ten Windows issues from seven external reporters**, nine of them fixed — but a user on a stale cache still lives with all nine. #227 is the newest and the most expensive: `UserPromptSubmit` is the one hook whose failure does not merely error, it erases what the user typed.

## Verification

- Full suite on this branch: **1008 passed, 42 skipped**, coverage 94.01% (gate 80%).
- The `#227` fix live-checked on stock macOS **bash 3.2.57 (arm64)**, the platform where the new `printf '%(…)T'` builtin does *not* exist and the `date` path is the only one: hook prints `[12:16 CEST — floriandavid]`, exit 0.
- The `#204` spawn bound live-checked on the same machine in a sandboxed `HOME`: four claims granted, the fifth declined naming the count, the limit and the env var to raise, capacity restored on release.

## Not in this release

- [#173](https://github.com/Digital-Process-Tools/claude-remember/pull/173) (external) — overlaps what #224 landed; needs an overlap decision and a lock-ordering answer first.
- [#225](https://github.com/Digital-Process-Tools/claude-remember/issues/225), [#226](https://github.com/Digital-Process-Tools/claude-remember/issues/226), [#230](https://github.com/Digital-Process-Tools/claude-remember/issues/230) — open, none of them user-facing regressions.
- #204 stays **open** deliberately: the code side is complete, and confirming the `$TMPDIR` directory stops reappearing needs a run against a cache that has actually rolled. That is a distribution question this PR cannot settle.
