### PR TITLE
fix(#225): give today-*.md its own lock so an NDC append cannot race consolidation's retire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`today-*.md` was written under one lock and retired under another** ([#225](https://github.com/Digital-Process-Tools/claude-remember/issues/225)) — `save-session.sh`'s NDC step appends a compressed day summary to `today-<day>.md` under **save.lock**; `run-consolidation.sh` reads that same file, calls Haiku, and renames it to `.done.md` under **consolidation.lock**. Each lock is sound on its own ([#182](https://github.com/Digital-Process-Tools/claude-remember/issues/182)). Holding one said nothing about the other.
+
+  The consumed-byte count added for the staging rename closes the *wide* window — the 180s Haiku call — by keeping whatever was appended past the offset it recorded. It does not close the retire loop itself. `wc -c`, `head`, `tail` and `mv` are four separate operations, and an NDC append landing among them goes into the inode about to become `.done.md`. Nothing globs `.done.md` again and session start never injects it, so the entry is written to disk and then unreachable, with no log line: [#142](https://github.com/Digital-Process-Tools/claude-remember/issues/142)'s signature in milliseconds instead of minutes, one file over.
+
+  Reachable, and not only across midnight in the abstract: `$NDC_DAY` comes from `tmp/now-day`, the [#141](https://github.com/Digital-Process-Tools/claude-remember/issues/141) marker recording which day now.md's content is from, so a session that crosses midnight compresses into `today-<yesterday>.md` — exactly the file consolidation considers eligible, since it excludes only *today's*. Reproduced against the shipped scripts with a real second process and a one-shot sync point on the retire loop's byte count: the appended entry ends up inside `today-2026-07-24.done.md` and nowhere else.
+
+  The fix is **a third lock, not one of the two that exist**. `scripts/lib-staging-lock.sh` owns `today-*.md` and is held by exactly two critical sections: the NDC append, and the retire loop. Consolidating onto save.lock was the obvious move and is the wrong one — `save-session.sh` holds save.lock across its own summarize call ([#226](https://github.com/Digital-Process-Tools/claude-remember/issues/226)), so consolidation's rename would have queued behind a model call, and a critical section containing a model call is how #142 happened. An ordering discipline over the two existing locks was the other option, and it holds only while every path obeys it; a path that does not is invisible until it deadlocks. Here **no path holds this lock while acquiring another, and none acquires it while holding save.lock** — there is no lock order to get wrong, which is also what keeps a dedicated now.md lock ([#173](https://github.com/Digital-Process-Tools/claude-remember/pull/173)) compatible rather than deadlock-prone.
+
+  Losing the wait is safe and logged on both sides, and both choices go the same way #142 and #223 went — a visible duplicate over an invisible erasure. The NDC round skips the append **and therefore the truncate**, so now.md keeps every byte and the next round re-summarizes the span with no duplicate at all; that is strictly better than the existing commit-skip, which appends first and duplicates. Consolidation leaves staging in place, so the next run re-consolidates a span already in recent.md and the merge prompt dedupes it.
+
+  `REMEMBER_STAGING_LOCK_TIMEOUT` defaults to **10s**, and unlike the 30s in #226 that number was measured rather than reasoned: polling the lock directory at 1ms while the real scripts run, the append holds it ~30ms and the retire loop ~200ms for a three-file backlog — ~65ms per file, fork cost rather than I/O. The longest hold scales with the backlog, so 10s covers ~150 staging files, and a backlog past that degrades to "retired next run", not to loss.
+
 ## [0.10.0] — Nothing was counting
 
 ### Fixed

--- a/scripts/lib-staging-lock.sh
+++ b/scripts/lib-staging-lock.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# lib-staging-lock.sh — the lock that owns today-*.md (#225).
+#
+# WHY A THIRD LOCK AND NOT ONE OF THE TWO THAT EXIST
+#
+#   today-<day>.md is written by save-session.sh's NDC step and read-then-
+#   retired by run-consolidation.sh. Those two took save.lock and
+#   consolidation.lock respectively — each internally sound (#182), neither
+#   saying anything about the other. So an NDC append could land between
+#   consolidation's `wc -c` of the staging file and its `mv` to .done.md, and
+#   be sealed inside a file nothing globs again and session start never
+#   injects: written to disk, then unreachable, with nothing logged.
+#
+#   Consolidating onto save.lock was the obvious move and is the wrong one.
+#   save-session.sh holds save.lock for the WHOLE save, including its own
+#   summarize Haiku call — which is why #226 exists at all. Making
+#   consolidation's retire step wait on that means waiting behind a model
+#   call, and a critical section that contains a model call is how #142
+#   happened in the first place.
+#
+#   An ordering discipline over the two existing locks was the other option,
+#   and it only holds while every path obeys it. A path that does not is
+#   invisible until it deadlocks — and PR #173 proposes a third lock for
+#   now.md, so "every path" is not a closed set.
+#
+#   So: give the shared resource its own lock, and hold it only for the
+#   operations that touch the resource. Both critical sections are file ops
+#   with no model call — an append of one Haiku summary, or N renames. Nothing
+#   holds this lock while acquiring another, and nothing acquires it while
+#   holding save.lock, so there is no lock ORDER to get wrong anywhere. That
+#   property is what keeps #173 acceptable: a now.md lock is orthogonal to
+#   this one, and no path can hold both.
+#
+# USAGE
+#   source "$(dirname "$0")/lib-lock.sh"          # required: the primitive
+#   source "$(dirname "$0")/lib-staging-lock.sh"
+#   if staging_lock_acquire; then
+#       staging_append "$TODAY_FILE" "$TEXT_FILE"
+#       staging_lock_release
+#   fi
+#
+# TIMEOUT
+#   REMEMBER_STAGING_LOCK_TIMEOUT, default 10s. Unlike the 30s in #226 this
+#   number has a bound behind it rather than an intuition: the only two
+#   holders are the append above (one `cat` of a summary) and
+#   run-consolidation.sh's retire loop (a `wc`/`head`/`tail`/`mv` per staging
+#   file). Measured by polling the lock directory at 1ms while the real
+#   scripts run: the append holds it ~30ms, and the retire loop ~200ms for a
+#   3-file backlog — ~65ms per file, which is fork cost, not I/O. So the
+#   longest hold scales with the backlog: 10s covers ~150 staging files,
+#   about five months of unconsolidated days. Losing the wait is safe on both
+#   sides and logged on both sides (see the callers), so a backlog past that
+#   degrades to "retire it next run", not to data loss. Re-measure before
+#   changing this number — that is the whole point of #226.
+#
+
+[ -n "${_REMEMBER_LIB_STAGING_LOCK_SOURCED:-}" ] && return 0
+_REMEMBER_LIB_STAGING_LOCK_SOURCED=1
+
+STAGING_LOCK_TIMEOUT="${REMEMBER_STAGING_LOCK_TIMEOUT:-10}"
+
+# One lock for the whole staging set, not one per day file. Consolidation
+# retires several files in one loop and the NDC round does not know which of
+# them it is about to append to, so per-file locks would need an ordering
+# between them — the thing this design exists to avoid.
+staging_lock_dir() {
+    printf '%s\n' "${REMEMBER_DIR}/tmp/staging.lock"
+}
+
+# Safe in $( ): it only prints. Unlike lib-lock.sh's _lock_self_set, which
+# assigns and must never be called that way.
+staging_lock_acquire() {
+    lock_acquire "$(staging_lock_dir)" "${1:-$STAGING_LOCK_TIMEOUT}"
+}
+
+# `|| true`: release returns 1 when the lock is not ours, and every caller
+# runs under `set -e` or inside a trap where that would rewrite the exit
+# status of the work that just succeeded.
+staging_lock_release() {
+    lock_release "$(staging_lock_dir)" || true
+}
+
+# staging_append <today_file> <text_file>
+# The NDC append, verbatim from what save-session.sh did inline: a blank-line
+# separator when the file already has content, then the summary. Two appends,
+# which is precisely why they belong inside a critical section — a reader
+# landing between them sees a file ending in a blank line with no summary.
+# Call only while holding the lock.
+staging_append() {
+    local _today="$1" _text="$2"
+    [ -s "$_today" ] && echo "" >> "$_today"
+    cat "$_text" >> "$_today"
+}

--- a/scripts/run-consolidation.sh
+++ b/scripts/run-consolidation.sh
@@ -40,6 +40,7 @@ source "$(dirname "$0")/detect-tools.sh"
 source "$(dirname "$0")/bootstrap-dirs.sh"
 source "$(dirname "$0")/log.sh"
 source "$(dirname "$0")/lib-lock.sh"
+source "$(dirname "$0")/lib-staging-lock.sh"
 log "hook" "run-consolidation: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR PYTHON=$PYTHON REMEMBER_DIR=$REMEMBER_DIR"
 rotate_logs
 
@@ -56,7 +57,10 @@ fi
 # Installed only after acquisition, so it can only ever release our own lock.
 # `|| true` on the release: it can return 1, and under `set -e` that would
 # abort the trap before $REMEMBER_CONFIG is cleaned and rewrite the exit status.
-trap 'lock_release "$LOCK_DIR" || true; rm -f "$REMEMBER_CONFIG"' EXIT
+# staging.lock is released explicitly after the retire loop; the trap covers
+# the case where the script dies inside it. `lock_release` returns 1 when the
+# lock is not ours, which is the normal case on every other exit path.
+trap 'staging_lock_release; lock_release "$LOCK_DIR" || true; rm -f "$REMEMBER_CONFIG"' EXIT
 
 STAGING_DIR="${REMEMBER_DIR}"
 RECENT_FILE="${STAGING_DIR}/recent.md"
@@ -116,6 +120,26 @@ log_tokens "consolidation" "$TK_IN" "$TK_OUT" "$TK_CACHE" "$TK_COST"
 # Haiku call runs (180s budget, and this script is disowned so it runs
 # alongside live sessions). A blind rename sealed those bytes inside the
 # .done.md, which the next run's glob skips and session start never injects.
+# Under staging.lock for the whole loop (#225). The consumed-byte count above
+# closes the 180s window around the Haiku call — an append landing there is
+# kept as the tail. It does NOT close this loop: `wc -c`, `head`, `tail` and
+# `mv` are four separate operations, and an NDC append landing among them goes
+# into the inode this loop is about to rename to .done.md. Nothing globs those
+# again and session start never injects them, so the entry is unreachable and
+# no line is logged — #142's shape, in milliseconds instead of minutes, one
+# file over. save.lock could not serve here: save-session.sh holds it across
+# its own summarize call (#226), so waiting on it would mean waiting behind a
+# model call. See lib-staging-lock.sh.
+#
+# Losing the wait leaves staging exactly as it is. recent.md/archive.md
+# already hold this span, so the next run consolidates it again and the merge
+# prompt dedupes it — a visible duplicate, chosen over sealing a concurrent
+# append into a file nothing reads. Same trade as the NDC tail-failure branch.
+if ! staging_lock_acquire "$STAGING_LOCK_TIMEOUT"; then
+    log "consolidation" "ERROR: staging.lock held for the whole ${STAGING_LOCK_TIMEOUT}s wait — staging files NOT retired; recent.md/archive.md already hold this span so the next run re-consolidates it (a duplicate the merge dedupes, chosen over sealing a concurrent append inside .done.md)"
+    rm -f "$STAGING_PATHS_FILE"
+    exit 0
+fi
 while IFS= read -r -d '' staging_path && IFS= read -r -d '' staging_consumed; do
     if [ ! -f "$staging_path" ]; then
         log "consolidation" "WARN: $(basename "$staging_path") disappeared"
@@ -139,6 +163,7 @@ while IFS= read -r -d '' staging_path && IFS= read -r -d '' staging_consumed; do
         mv "$staging_path" "$staging_done"
     fi
 done < "$STAGING_PATHS_FILE"
+staging_lock_release
 rm -f "$STAGING_PATHS_FILE"
 
 log "consolidation" "done: ${STAGING_COUNT} files consolidated"

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -62,6 +62,7 @@ source "$(dirname "$0")/detect-tools.sh"
 source "$(dirname "$0")/bootstrap-dirs.sh"
 source "$(dirname "$0")/log.sh"
 source "$(dirname "$0")/lib-lock.sh"
+source "$(dirname "$0")/lib-staging-lock.sh"
 log "hook" "save-session: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR PYTHON=$PYTHON REMEMBER_DIR=$REMEMBER_DIR"
 
 LOCK_DIR="${REMEMBER_DIR}/tmp/save.lock"
@@ -524,8 +525,32 @@ if [ "$RUN_NDC" = true ]; then
                     log "ndc" "REJECTED (not a summary — refusal or clarification): $(head -c 80 "$HAIKU_TEXT_FILE" 2>/dev/null)"
                     keep_rejected_text "$HAIKU_TEXT_FILE" "ndc"
                 elif [ -n "$NDC_TEXT" ]; then
-                    [ -s "$TODAY_FILE" ] && echo "" >> "$TODAY_FILE"
-                    cat "$HAIKU_TEXT_FILE" >> "$TODAY_FILE"
+                    # Under staging.lock, not save.lock and not nothing (#225).
+                    # today-*.md is the file run-consolidation.sh reads and then
+                    # retires to .done.md, and it holds a DIFFERENT lock while
+                    # doing it. Unlocked, this append could land between that
+                    # script's byte count of the file and its `mv`, and be
+                    # sealed inside the .done.md — which nothing globs again
+                    # and session start never injects. Written to disk, then
+                    # unreachable, with nothing logged: #142's signature one
+                    # file over. The append is also two operations, so a reader
+                    # landing between them sees a trailing blank line and no
+                    # summary. lib-staging-lock.sh explains why this is a third
+                    # lock rather than save.lock.
+                    #
+                    # Losing the wait skips the WHOLE round — no append, and
+                    # therefore no truncate below either. That is strictly
+                    # better than the commit-skip further down: now.md keeps
+                    # every byte, the next round re-summarizes the same span,
+                    # and today-*.md never sees the duplicate at all.
+                    if ! staging_lock_acquire "$STAGING_LOCK_TIMEOUT"; then
+                        NDC_STAGED=false
+                        log "ndc" "SKIPPED: staging.lock held for the whole ${STAGING_LOCK_TIMEOUT}s wait (a consolidation is retiring staging files) — today-${NDC_DAY}.md not appended and now.md left untouched, so the next round re-summarizes this span with no duplicate"
+                    else
+                        NDC_STAGED=true
+                        staging_append "$TODAY_FILE" "$HAIKU_TEXT_FILE"
+                        staging_lock_release
+                    fi
                     # Drop exactly the bytes that were compressed, not the whole
                     # file (#142). now.md was snapshotted before the Haiku call
                     # above, which can take up to 180s — and by then the parent
@@ -558,7 +583,7 @@ if [ "$RUN_NDC" = true ]; then
                     # It cannot steal the lock from a live save either — steal
                     # needs a dead pid, adoption needs no pid at all — so losing
                     # the wait means someone is genuinely holding it.
-                    if lock_acquire "$LOCK_DIR" "$NDC_COMMIT_LOCK_TIMEOUT"; then
+                    if [ "$NDC_STAGED" = true ] && lock_acquire "$LOCK_DIR" "$NDC_COMMIT_LOCK_TIMEOUT"; then
                         # Re-read the size under the lock. The offset stays valid as
                         # the START of the kept range no matter what happened during
                         # the Haiku call, but only while now.md still HAS that many
@@ -630,7 +655,7 @@ if [ "$RUN_NDC" = true ]; then
                         # Released before the summary log line below —
                         # nothing past this point touches now.md.
                         lock_release "$LOCK_DIR" || true
-                    else
+                    elif [ "$NDC_STAGED" = true ]; then
                         log "ndc" "SKIPPED commit: another save held the lock for the whole ${NDC_COMMIT_LOCK_TIMEOUT}s wait, now.md left untouched (today-${NDC_DAY}.md now holds a duplicate of this span — the routine outcome of losing this race, not an error)"
                     fi
                     NDC_OUT_BYTES=$(wc -c < "$HAIKU_TEXT_FILE" | tr -d ' ')

--- a/tests/test_consolidation_append_race.py
+++ b/tests/test_consolidation_append_race.py
@@ -92,7 +92,8 @@ def _make_env(tmp_path: Path):
     (plugin / "pipeline" / "shell.py").write_text(STUB_SHELL)
     for script in ("run-consolidation.sh", "resolve-paths.sh", "detect-tools.sh",
                    "bootstrap-dirs.sh", "log.sh", "lib-memory-dir.sh",
-                   "lib-lock.sh", "lib-slug.sh", "lib-clock.sh"):
+                   "lib-lock.sh", "lib-staging-lock.sh", "lib-slug.sh",
+                   "lib-clock.sh"):
         (plugin / "scripts" / script).write_text((REPO_ROOT / "scripts" / script).read_text())
     (plugin / "config.json").write_text('{"cooldowns": {}, "thresholds": {}}')
 

--- a/tests/test_save_session_gates.py
+++ b/tests/test_save_session_gates.py
@@ -149,7 +149,8 @@ def _make_env(tmp_path: Path, *, exchanges: int, humans: int, position: int = 50
     (plugin / "pipeline" / "shell.py").write_text(STUB_SHELL)
     for script in ("save-session.sh", "resolve-paths.sh", "detect-tools.sh",
                    "bootstrap-dirs.sh", "log.sh", "lib-memory-dir.sh",
-                   "lib-lock.sh", "lib-slug.sh", "lib-clock.sh"):
+                   "lib-lock.sh", "lib-staging-lock.sh", "lib-slug.sh",
+                   "lib-clock.sh"):
         (plugin / "scripts" / script).write_text((REPO_ROOT / "scripts" / script).read_text())
 
     cfg = {"cooldowns": {"save_seconds": 0, "ndc_seconds": 999999},

--- a/tests/test_save_session_lock_ownership.py
+++ b/tests/test_save_session_lock_ownership.py
@@ -89,7 +89,8 @@ def _make_env(tmp_path: Path, name: str, extract_sleep: float = 0.0):
     (plugin / "pipeline" / "shell.py").write_text(STUB_SHELL)
     for script in ("save-session.sh", "resolve-paths.sh", "detect-tools.sh",
                    "bootstrap-dirs.sh", "log.sh", "lib-memory-dir.sh",
-                   "lib-lock.sh", "lib-slug.sh", "lib-clock.sh"):
+                   "lib-lock.sh", "lib-staging-lock.sh", "lib-slug.sh",
+                   "lib-clock.sh"):
         (plugin / "scripts" / script).write_text((REPO_ROOT / "scripts" / script).read_text())
 
     cfg = {"cooldowns": {"save_seconds": 0, "ndc_seconds": 999999},

--- a/tests/test_staging_lock.py
+++ b/tests/test_staging_lock.py
@@ -1,0 +1,311 @@
+"""today-*.md is written by one lock's holder and retired by another's (#225).
+
+`save-session.sh`'s NDC step appends a compressed day summary to
+`today-<day>.md` while holding **save.lock** (and, since #223, re-taking it for
+the now.md truncate). `run-consolidation.sh` reads that same file, calls Haiku,
+and renames it to `.done.md` while holding **consolidation.lock**. Both locks
+are sound (#182). Neither says anything about the other.
+
+The consumed-byte count added for the staging rename closes the wide window —
+the 180s Haiku call — by keeping whatever was appended past the offset it
+recorded. It does not close the retire loop itself: `wc -c`, `head`, `tail` and
+`mv` are four separate operations, and an NDC append landing among them lands
+in the inode about to become `.done.md`. Nothing globs `.done.md` again and
+session start never injects it, so the entry is written to disk and then
+unreachable, with no log line. #142's signature, in milliseconds instead of
+minutes, one file over.
+
+Reachable because `$NDC_DAY` legitimately names a past day: it comes from
+`tmp/now-day`, the #141 marker recording which day now.md's content is from, so
+a session that crosses midnight compresses into `today-<yesterday>.md` — the
+exact file consolidation considers eligible (it excludes only *today's*). See
+`test_ndc_day_boundary.py::test_compression_files_content_under_the_stamped_day`.
+
+The fix gives the file its own lock (`scripts/lib-staging-lock.sh`), held only
+by the NDC append and by the retire loop. Neither critical section contains a
+model call, and no path holds this lock while taking another — so there is no
+lock order to get wrong, which is what keeps a separate now.md lock (PR #173)
+compatible rather than deadlock-prone.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from .test_consolidation_append_race import _make_env, _run
+from .test_save_session_gates import _run as _run_save
+from .test_ndc_truncate_race import _ndc_env, _wait_for_background_ndc
+from .subprocess_helpers import subprocess_failure_detail
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash subprocess + POSIX layout — not portable to Windows runners (#79)",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LIB_LOCK = REPO_ROOT / "scripts" / "lib-lock.sh"
+LIB_STAGING_LOCK = REPO_ROOT / "scripts" / "lib-staging-lock.sh"
+
+ENTRY = "## 23:59 | main\n\n- NDC summary of yesterday\n"
+
+# One-shot sync point on the retire loop's `wc -c` (run-consolidation.sh). The
+# real `wc` runs FIRST, so the byte count the loop will act on is already
+# taken; only then does the gate open and the stub wait for the competing
+# appender. Anything that appender writes therefore lands strictly between the
+# byte count and the rename — the window this file is about, which is
+# microseconds wide in real time and so not reachable from another process
+# without help. `wc -l` (log rotation) passes straight through, and `command -p`
+# resolves against the shell's default PATH so the stub cannot recurse.
+WC_STUB = """#!/bin/sh
+case "$1" in
+    -c)
+        command -p wc "$@" || exit $?
+        if [ -n "$STUB_WC_GATE" ] && [ ! -e "$STUB_WC_GATE" ]; then
+            : > "$STUB_WC_GATE"
+            _i=0
+            while [ ! -e "$STUB_WC_DONE" ] && [ "$_i" -lt "${STUB_WC_TICKS:-40}" ]; do
+                sleep 0.05
+                _i=$((_i + 1))
+            done
+        fi
+        exit 0
+        ;;
+esac
+command -p wc "$@"
+"""
+
+# A competing NDC round: waits for the gate, then appends through the SHIPPED
+# protocol — the same two functions save-session.sh calls. Nothing is
+# special-cased for the test. With the retire loop holding staging.lock this
+# blocks until the loop is finished; without it, it appends immediately and the
+# pending rename seals the entry away.
+APPENDER = """#!/usr/bin/env bash
+set -u
+source "$LIB_LOCK"
+source "$LIB_STAGING_LOCK"
+while [ ! -e "$GATE" ]; do sleep 0.02; done
+printf '%s' "$ENTRY_TEXT" > "$ENTRY_FILE"
+if staging_lock_acquire "${WAIT:-30}"; then
+    staging_append "$TODAY_FILE" "$ENTRY_FILE"
+    staging_lock_release
+    printf 'appended\n' > "$RESULT_FILE"
+else
+    printf 'timeout\n' > "$RESULT_FILE"
+fi
+: > "$DONE_FILE"
+"""
+
+# Holds staging.lock from outside and does not let go, so the retire loop has
+# to decide what to do when it cannot have it.
+HOLDER = """#!/usr/bin/env bash
+set -u
+source "$LIB_LOCK"
+source "$LIB_STAGING_LOCK"
+staging_lock_acquire 5 || exit 1
+: > "$HELD_FILE"
+while [ ! -e "$RELEASE_FILE" ]; do sleep 0.05; done
+staging_lock_release
+"""
+
+
+def _install(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+def _log_text(remember: Path) -> str:
+    return "\n".join(f.read_text(encoding="utf-8")
+                     for f in (remember / "logs").glob("*.log"))
+
+
+def _live_staging(remember: Path) -> str:
+    return "".join(p.read_text(encoding="utf-8")
+                   for p in remember.glob("today-*.md")
+                   if not p.name.endswith(".done.md"))
+
+
+def _retired_staging(remember: Path) -> str:
+    return "".join(p.read_text(encoding="utf-8")
+                   for p in remember.glob("today-*.done.md"))
+
+
+def _wait_for(path: Path, timeout: float = 10) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return True
+        time.sleep(0.02)
+    return False
+
+
+class TestConsolidationRetireVersusNdcAppend:
+    """The reported loss, as an actual race between two processes."""
+
+    def test_an_ndc_append_racing_the_retire_is_not_sealed_away(self, tmp_path):
+        env, project, plugin, remember = _make_env(tmp_path)
+        staging = remember / "today-2026-07-24.md"
+        staging.write_text("# Day\n\n## 10:00 | main\n\n- earlier work\n",
+                           encoding="utf-8")
+
+        gate, done, result_file = (tmp_path / "wc-gate", tmp_path / "appended",
+                                   tmp_path / "appender-result")
+        bindir = tmp_path / "stub-bin"
+        _install(bindir / "wc", WC_STUB)
+        env = dict(env)
+        env["PATH"] = f"{bindir}{os.pathsep}{env['PATH']}"
+        env["STUB_WC_GATE"] = str(gate)
+        env["STUB_WC_DONE"] = str(done)
+
+        appender = _install(tmp_path / "appender.sh", APPENDER)
+        proc = subprocess.Popen(
+            ["bash", str(appender)],
+            env={
+                **os.environ,
+                "REMEMBER_DIR": str(remember),
+                "LIB_LOCK": str(LIB_LOCK),
+                "LIB_STAGING_LOCK": str(LIB_STAGING_LOCK),
+                "GATE": str(gate),
+                "DONE_FILE": str(done),
+                "RESULT_FILE": str(result_file),
+                "TODAY_FILE": str(staging),
+                "ENTRY_FILE": str(tmp_path / "ndc-text.md"),
+                "ENTRY_TEXT": ENTRY,
+            },
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+        try:
+            result = _run(plugin, env)
+            assert result.returncode == 0, result.stderr
+            proc.wait(timeout=60)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+
+        assert gate.is_file(), (
+            "the sync point never fired — the retire loop was never reached, "
+            "so this test proves nothing"
+        )
+        assert result_file.read_text().strip() == "appended", (
+            "the competing NDC round never appended, so the interleave this "
+            "test exists for did not happen"
+        )
+        assert "NDC summary of yesterday" in _live_staging(remember), (
+            "an NDC append that landed after consolidation measured the "
+            "staging file was sealed inside .done.md — nothing globs those "
+            "again and session start never injects them, so the entry is "
+            "unreachable memory and nothing was logged (#225)"
+        )
+        assert "earlier work" in _retired_staging(remember), (
+            "the consolidated span must still be retired — a fix that stops "
+            "retiring is a no-op with extra steps, and the next run would "
+            "re-consolidate work already in recent.md"
+        )
+
+    def test_the_retire_step_refuses_to_run_without_the_lock(self, tmp_path):
+        """Losing the wait must leave staging alone, and say so."""
+        env, project, plugin, remember = _make_env(tmp_path)
+        staging = remember / "today-2026-07-24.md"
+        staging.write_text("# Day\n\n## 10:00 | main\n\n- earlier work\n",
+                           encoding="utf-8")
+
+        held, release = tmp_path / "held", tmp_path / "release"
+        holder = _install(tmp_path / "holder.sh", HOLDER)
+        proc = subprocess.Popen(
+            ["bash", str(holder)],
+            env={
+                **os.environ,
+                "REMEMBER_DIR": str(remember),
+                "LIB_LOCK": str(LIB_LOCK),
+                "LIB_STAGING_LOCK": str(LIB_STAGING_LOCK),
+                "HELD_FILE": str(held),
+                "RELEASE_FILE": str(release),
+            },
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+        try:
+            assert _wait_for(held), "the holder never took staging.lock"
+            env = dict(env)
+            env["REMEMBER_STAGING_LOCK_TIMEOUT"] = "1"
+            result = _run(plugin, env)
+            assert result.returncode == 0, result.stderr
+        finally:
+            release.write_text("")
+            try:
+                proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+        assert not _retired_staging(remember), (
+            "staging was retired to .done.md while another process held "
+            "staging.lock — that process is entitled to be appending an NDC "
+            "summary right now, and the rename would seal it away (#225)"
+        )
+        assert "earlier work" in _live_staging(remember), (
+            "the staging file must be left in place for the next run"
+        )
+        assert "staging.lock" in _log_text(remember), (
+            "a consolidation that consolidated but did not retire leaves a "
+            "duplicate for the next run; a duplicate that is never logged is "
+            "indistinguishable from a bug"
+        )
+
+
+class TestNdcAppendTakesTheStagingLock:
+    """The other half: the append side must respect the same lock."""
+
+    def test_the_append_and_the_truncate_are_both_skipped_without_the_lock(
+        self, tmp_path
+    ):
+        env, project, plugin, calls, sid = _ndc_env(tmp_path)
+        remember = project / ".remember"
+        memory_file = remember / "now.md"
+
+        held, release = tmp_path / "held", tmp_path / "release"
+        holder = _install(tmp_path / "holder.sh", HOLDER)
+        proc = subprocess.Popen(
+            ["bash", str(holder)],
+            env={
+                **os.environ,
+                "REMEMBER_DIR": str(remember),
+                "LIB_LOCK": str(LIB_LOCK),
+                "LIB_STAGING_LOCK": str(LIB_STAGING_LOCK),
+                "HELD_FILE": str(held),
+                "RELEASE_FILE": str(release),
+            },
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        )
+        try:
+            assert _wait_for(held), "the holder never took staging.lock"
+            env = dict(env)
+            env["REMEMBER_STAGING_LOCK_TIMEOUT"] = "1"
+            result = _run_save(plugin, env, sid)
+            assert result.returncode == 0, subprocess_failure_detail(result, remember)
+            remaining = _wait_for_background_ndc(memory_file)
+        finally:
+            release.write_text("")
+            try:
+                proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+        assert not list(remember.glob("today-*.md")), (
+            "the NDC summary was appended to today-*.md while a consolidation "
+            "held staging.lock — that consolidation may be renaming this very "
+            "file, which would seal the append inside .done.md (#225)"
+        )
+        assert "did some work" in remaining, (
+            "now.md must keep every byte when the append did not happen — "
+            "truncating a span that was never staged loses it outright"
+        )
+        assert "SKIPPED" in _log_text(remember), (
+            "skipping a compression round silently is indistinguishable from "
+            "a compression that never fired"
+        )


### PR DESCRIPTION
## The premise held, with one correction

`save-session.sh`'s NDC step appends to `today-<day>.md` under **save.lock**. `run-consolidation.sh` reads that same file, calls Haiku, and renames it to `.done.md` under **consolidation.lock**. Genuinely two different locks (`tmp/save.lock` vs `tmp/consolidation.lock`, same `lib-lock.sh` primitive), and holding one says nothing about the other.

The correction: the *wide* window is already serialized, by discipline rather than by a lock. The consumed-byte count `cmd_consolidate` records means an append landing during the 180s Haiku call is kept as the tail, not lost. So "nothing serializes an append against a merge" overstates it for the merge itself.

What is genuinely unprotected is the **retire loop**. `wc -c`, `head`, `tail` and `mv` are four separate operations, and an NDC append landing among them goes into the inode about to become `.done.md` — which nothing globs again and session start never injects. Written to disk, then unreachable, with no log line. #142's signature in milliseconds instead of minutes, one file over.

**Reachability** is not exotic. `$NDC_DAY` comes from `tmp/now-day`, the #141 marker recording which day now.md's content is from, so a session crossing midnight compresses into `today-<yesterday>.md` — exactly the file consolidation considers eligible, since it excludes only *today's*. That path is already shipped and tested (`test_ndc_day_boundary.py::test_compression_files_content_under_the_stamped_day`), and consolidation is spawned `nohup … & disown` from session start, so it runs alongside live saves by design.

Reproduced against the shipped scripts with a real second process, before any fix:

```
--- live today-*.md ---
(none)
--- retired .done.md ---
# Day

## 10:00 | main

- earlier work

## 23:59 | main

- NDC summary of yesterday
```

The entry exists only inside `today-2026-07-24.done.md`. Unreachable.

## One lock, an ordering, or a third lock

A third lock, and the reasoning is about *hold time*, not about elegance.

- **Consolidating onto save.lock** is the obvious move and the wrong one. `save-session.sh` acquires save.lock at line 102 and releases it from its `EXIT` trap, so it holds it across its own summarize Haiku call — the exact observation #226 is about. Making consolidation's rename queue behind that puts a model call inside the path, which is how #142 happened in the first place.
- **An ordering discipline** over the two existing locks holds only while every path obeys it, and a path that does not is invisible until it deadlocks. With #173 proposing a lock of its own, "every path" is not a closed set.
- **A lock that owns the resource**, held only for the operations that touch it. Both critical sections are file ops with no model call. Crucially: **no path holds this lock while acquiring another, and none acquires it while holding save.lock.** There is no lock order to get wrong anywhere, so there is no ordering for a future path to violate.

## What this means for #173

Nothing blocking. #173 gives `now.md` its own `flock`-based lock; this gives `today-*.md` its own `mkdir`-based one. Different files, and by construction no path holds both — so the opposite-order deadlock is not reachable between them.

Two notes for that PR, neither a rejection:

1. Its `now_locked` uses `flock`, which this repo deliberately does not use — `lib-lock.sh` documents why (`flock` is absent on macOS and on the GitHub macos runner image). The *analysis* in #173 is right and is what #223/#224 acted on; the mechanism would need porting to `lib-lock.sh`.
2. #173 replaces the save.lock re-acquisition around the NDC commit with `now.lock`. That is still compatible here: this PR's serialization runs through `staging.lock` around the *append*, which #173 does not touch. If that substitution lands, keep the append under `staging.lock` and the ordering property stays intact.

## #226

Touched, and answered with a number rather than avoided. The new timeout defaults to **10s**, measured by polling the lock directory at 1ms while the real scripts run: the append holds it ~30ms, the retire loop ~200ms for a three-file backlog (~65ms per file, fork cost rather than I/O). The longest hold scales with the backlog, so 10s covers ~150 staging files. This does not widen what #226's 30s has to cover — save.lock's hold is unchanged.

One incidental improvement in #226's direction: losing the staging lock skips the append **and therefore the truncate**, so now.md keeps every byte and the next round re-summarizes with no duplicate. That is strictly better than the existing commit-skip, which appends first and duplicates.

## Red, then green

Three tests in `tests/test_staging_lock.py`. Red is with the library present but neither caller using it — the "would this still pass if the code did nothing" check:

```
E  AssertionError: an NDC append that landed after consolidation measured the staging file was sealed inside .done.md — nothing globs those again and session start never injects them, so the entry is unreachable memory and nothing was logged (#225)
E  assert 'NDC summary of yesterday' in ''
E  AssertionError: staging was retired to .done.md while another process held staging.lock — that process is entitled to be appending an NDC summary right now, and the rename would seal it away (#225)
E  assert not '# Day\n\n## 10:00 | main\n\n- earlier work\n'
E  AssertionError: the NDC summary was appended to today-*.md while a consolidation held staging.lock — that consolidation may be renaming this very file, which would seal the append inside .done.md (#225)
E  assert not [PosixPath('.../today-2026-07-30.md')]
```

3/3, reliably — the race test is deterministic in both directions via a one-shot sync point on the retire loop's byte count (the real `wc` runs first, so the count is already taken; the gate then waits for the competing appender, which blocks on the lock once the fix is in). Green, three consecutive runs:

```
3 passed in 10.39s
3 passed in 9.80s
3 passed in 9.74s
```

Full suite: **1011 passed, 42 skipped**, coverage 94.01%.

## Known residual, not fixed here

`cmd_consolidate`'s *read* of the staging files is still outside the lock. An append landing mid-read splits one summary: part goes into recent.md, the rest is kept as the tail and consolidated next round. That is corruption of one entry's boundary, not loss, and closing it means holding the lock across a Python call that also contains the Haiku round — the thing this design refuses to do. Worth its own issue rather than a wider critical section here.

Closes #225
