### PR TITLE
release: 0.12.0 — It said it would retry

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remember",
   "description": "Continuous memory for Claude Code. Extracts, summarizes, and compresses conversations into tiered daily logs. Claude remembers what you did yesterday.",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] — It said it would retry
+
+Two external reports, three weeks apart, with the same shape underneath: an operation stopped doing its job and reported success. Neither reporter noticed for weeks, and in both cases the reason was not that the tool was quiet — it was that the tool was reassuring.
+
+`rotate_logs` had archived nothing since June on one Windows install ([#252](https://github.com/Digital-Process-Tools/claude-remember/issues/252)): GNU tar reads an `-f` argument whose colon precedes the first slash as `host:path`, so an absolute Windows archive path became a request to connect to a machine called `C`. The archive name is now relative, which no tar can parse as remote — deliberately not `--force-local`, which bsdtar rejects outright with exit 1, so the obvious fix would have repaired Windows by silently disabling the platform this is developed on. The larger half was that `2>/dev/null` discarded the reason and the failure branch returned 0, so "nothing to rotate" and "permanently broken" were the same event to every caller. There are three outcomes now instead of two, and `/remember:doctor` reports the third — chosen because that reporter's `hook-errors.log` was empty for all five weeks.
+
+The git backup had the same defect from the other side ([#253](https://github.com/Digital-Process-Tools/claude-remember/issues/253)): every push failure was logged as `push deferred (will retry next backup)`. That is true of a network blip and false of a non-fast-forward rejection, which cannot succeed on any later attempt — one store had drifted 15 commits ahead and 312 behind, missing twelve days of memory it had never seen. Rejections are now read from `git push --porcelain`'s per-ref status rather than from message text, which matters because a pre-push hook writes to the same streams and can produce a convincing fake; the parse requires git's own header, exactly three tab-delimited fields, and the `!` flag. The asymmetry is what makes it safe: an unreachable remote exits 128 with empty stdout, so a transient failure gives git nothing to say and stays a quiet retry. Reporting loudly requires positive evidence *from git*.
+
+Thanks to **@hubertrm** and **@jqit-ricky**. Both reports were specific enough to reproduce without their machines, and in both cases the second-order observation was the more valuable half — "it does not self-correct", and "that push cannot succeed on any later attempt". Those are the sentences that turned two bug reports into two fixes of a class.
+
+Manifest bumped per [#133](https://github.com/Digital-Process-Tools/claude-remember/issues/133) — the updater compares manifest versions and nothing else, so a release that forgets it ships nothing.
+
 ### Added
 
 - **A restore counterpart to the git backup, off by default** ([#253](https://github.com/Digital-Process-Tools/claude-remember/issues/253), part 2 of 2 — the feature half; part 1, the rejected-push classifier, landed separately) — the plugin pushed and never read back: `git pull|fetch|merge|rebase` appeared nowhere outside `tests/`. A store used from a second machine therefore reads its own stale memory, commits on top of it, and from then on can never push at all — which is how the divergence part 1 reports comes to exist in the first place. `hooks.d/before_session_start/50-git-restore.sh` closes the loop, on the empty dispatch point that has been wired at `session-start-hook.sh:86` all along.


### PR DESCRIPTION
Cuts **0.12.0 — It said it would retry**.

Two files, per the established shape: `.claude-plugin/plugin.json` version bump and the `CHANGELOG.md` section heading plus intro.

**The manifest bump is the release.** Per #133 the updater compares manifest versions and nothing else — a release that forgets it ships nothing, which is how v0.8.3→0.8.6 reached no users.

## What ships

Five entries, already written under `## [Unreleased]`:

- **#252** — log rotation failed permanently on Windows (GNU tar reading a drive letter as `host:path`), and a failed rotation now says so in three states rather than returning 0 either way.
- **#253 part 1** — a rejected push is no longer reported as `push deferred (will retry next backup)`; rejections are classified from `git push --porcelain` per-ref status, not message text.
- **#253 part 2** — a restore counterpart, **opt-in and off by default**: detached fetch, local fast-forward only, a diverged store refused out loud.
- **#247** — a session start can no longer read a half-written `now.md` entry.
- **#246** — the consolidation staging-tail `mv` is now a checked, same-directory rename.

## Verification

- Full suite run locally on this branch before commit: **1182 passed, 42 skipped**.
- `main` confirmed green on `72aadcc` before cutting — a PR's green is a statement about its merge-base, not about `main` after the squash.

## Known, shipping unfixed

None is a regression; all predate this release and are filed:

- **#255** `rotate_logs` truncates a month's archive after deleting the originals (data loss, all platforms)
- **#260** a store reached through a symlink gets no backup and no restore, with nothing in any log
- **#257** a failed commit is log-only, so memory is not committed even locally
- #258, #261, #251, #226

Tag and GitHub release follow the merge, per the recipe — v0.8.7 shipped by manifest with no tag and left the releases page two versions stale.
