### PR TITLE
docs: name the install route a release reaches, and when (#264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The README now says which install route a release actually reaches, and when** ([#264](https://github.com/Digital-Process-Tools/claude-remember/issues/264)) — the delivery advice added in 0.12.0 assumed an install route it never named. `claude-plugins-official` pins by commit sha rather than by version, and that pin is advanced by an automated PR running roughly twice a day, so a release reaches a DPT-marketplace install immediately and an official-marketplace install up to twelve hours later. `FORCE_AUTOUPDATE_PLUGINS=1` cannot cross that boundary, because nothing on the user's side is stale — the CLI correctly reports the pinned version as current, and the input is old. The reporter spent the diagnosis establishing that their install genuinely could not see v0.12.0; it was true, and it was not a bug in either tool. The stale claim that the official catalogue was "stuck on v0.5.0" is gone, along with the advice to treat that as permanent.
+- **"Check your version" now says to read the manifest and not the directory name** ([#204](https://github.com/Digital-Process-Tools/claude-remember/issues/204)) — a cache directory is named from the version present when it was created and is never renamed, so one called `0.7.1` can hold a manifest saying `0.8.0`. The updater compares manifests. Every claim on #204 about which version was running had been read off the directory name and was wrong by a minor, which is this project's own defect class wearing a filename: a surface that appears to answer the question and does not.
+
 ## [0.12.0] — It said it would retry
 
 Two external reports, three weeks apart, with the same shape underneath: an operation stopped doing its job and reported success. Neither reporter noticed for weeks, and in both cases the reason was not that the tool was quiet — it was that the tool was reassuring.

--- a/README.md
+++ b/README.md
@@ -37,13 +37,17 @@ To update later:
 
 Claude Remember is also available in the official Anthropic Marketplace. In Claude Code, type `/plugin` and search for "remember".
 
-**Known issue — stuck on v0.5.0:** The Anthropic marketplace is still serving v0.5.0, which has known bugs ([#54](https://github.com/Digital-Process-Tools/claude-remember/issues/54) hook stderr redirect fails on first session, [#14](https://github.com/Digital-Process-Tools/claude-remember/issues/14) NDC subshell killed by `set -e`). Anthropic takes a long time to roll updates to the official marketplace. All of these are fixed in v0.8.2 — install from the DPT marketplace above to get the current version.
+**Releases reach this route on the catalogue's schedule, not ours.** `claude-plugins-official` pins each plugin by commit sha rather than by version, and that pin is advanced by an automated PR that runs roughly twice a day (observed at ~00:06 and ~18:14 UTC). So a release is available to a DPT-marketplace install immediately and to an official-marketplace install at the next bump — up to about twelve hours later, and more if a release lands just after a run.
 
-**Known issue — `plugin update`:** The official marketplace's `plugin update` command may report "already at latest version" even when it's not — it checks a stale local cache without pulling first ([#37252](https://github.com/anthropics/claude-code/issues/37252), [#38271](https://github.com/anthropics/claude-code/issues/38271)). Another reason to use our marketplace instead.
+**`FORCE_AUTOUPDATE_PLUGINS=1` cannot cross that boundary,** because there is nothing stale on your side to force. Against a catalogue pinned behind the current release, `claude plugin update remember@claude-plugins-official` correctly reports the plugin as already current at the pinned version. The CLI is right and the input is old ([#264](https://github.com/Digital-Process-Tools/claude-remember/issues/264)). Waiting for the next bump works; installing from the DPT marketplace above skips the wait.
+
+**Separately, `plugin update` can report "already at latest version" from a stale local cache** without pulling first ([#37252](https://github.com/anthropics/claude-code/issues/37252), [#38271](https://github.com/anthropics/claude-code/issues/38271)). That one is a client-side cache and is a different failure from the pin lag above, though both surface the same sentence.
 
 ### Check your version
 
-Look at the `version` field in `.claude-plugin/plugin.json`. The plugin location depends on your install type:
+Look at the `version` field in `.claude-plugin/plugin.json` — **not at the `<version>` directory name in the path below.** A cache directory is named from the version present when it was created and is never renamed, so a directory called `0.7.1` can hold a manifest saying `0.8.0`. The updater compares manifests, so the manifest is the answer and the directory name is a guess ([#204](https://github.com/Digital-Process-Tools/claude-remember/issues/204)).
+
+The plugin location depends on your install type:
 
 | Install type                       | Location                                                                          |
 | ---------------------------------- | --------------------------------------------------------------------------------- |


### PR DESCRIPTION
## What

Two README corrections, both prompted by [#264](https://github.com/Digital-Process-Tools/claude-remember/issues/264), plus the CHANGELOG entry.

**The install-route gap.** 0.12.0 added delivery advice — a fix that has not reached the install is not a fix — without ever naming which install route it assumed. `claude-plugins-official` pins each plugin by commit sha rather than by version, and that pin is advanced by an automated PR that runs about twice a day (observed at ~00:06 and ~18:14 UTC). So a release reaches a DPT-marketplace install immediately and an official-marketplace install at the next bump. `FORCE_AUTOUPDATE_PLUGINS=1` cannot cross that boundary, because nothing on the user's side is stale — the CLI correctly reports the pinned version as current and the input is old.

**The stale claim it replaces.** The README said the official catalogue was "stuck on v0.5.0", that "all of these are fixed in v0.8.2", and implied the lag was indefinite. All three are now false: the pin sits at `64cea0cc` (manifest `0.10.0`), the current release is 0.12.0, and the bump is automated rather than manual. A known-issue note that has itself gone stale is worse than none, because it is read as current.

**Manifest, not directory name.** A plugin cache directory is named from the version present when it was created and is never renamed, so one called `0.7.1` can hold a manifest saying `0.8.0` — which is exactly what happened on [#204](https://github.com/Digital-Process-Tools/claude-remember/issues/204), where every claim about which version was running had been read off the path and was wrong by a minor. The updater compares manifests. "Check your version" now says so.

## Why this closes the issue rather than fixing the lag

Nothing in the reporter's situation is a defect in this repo, and they said as much: the release is real, the code is right, and their install resolves to a sha from before it. The lag closes itself at the next scheduled bump — v0.12.0 was tagged at 12:11 UTC, between this morning's run and this evening's.

I checked whether a manual bump PR was worth opening and decided against it. Four community-submitted bumps for this plugin ([#1659](https://github.com/anthropics/claude-plugins-official/pull/1659), [#1710](https://github.com/anthropics/claude-plugins-official/pull/1710), [#1883](https://github.com/anthropics/claude-plugins-official/pull/1883), [#1630](https://github.com/anthropics/claude-plugins-official/pull/1630)) were all closed rather than merged, which reads as the automation being authoritative. It would buy a few hours and get closed.

What *was* ours is that the docs never told anyone this. That is the part this fixes.

## Verification

Docs only — no shell or Python changed. `test_version_manifest.py`, `test_config_contract.py` and `test_hooks_json.py` are the tests that read `README.md`/`CHANGELOG.md`: 22 passed, 40 skipped. The coverage gate fails on a subset run by construction and is not a signal here; the full suite runs in CI.

Closes #264
