### PR TITLE
fix(save-session): a failed last-entry read must not read as "(no previous entry)" (#251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A failed read of the last entry was handed to the summarizer as "(no previous entry)"** ([#251](https://github.com/Digital-Process-Tools/claude-remember/issues/251)) — `save-session.sh` built the summarizer's dedup context with `[ -n "$LAST_LINE" ] && tail … > "$TMP" || echo "(no previous entry)" > "$TMP"`, which is not if/else: when the guard holds and `tail` *fails*, the fallback runs as well, and its `>` overwrites whatever `tail` had written. So a read error was rendered as a factual claim about `now.md` — rc 0, nothing logged, no marker. Reproduced with a `tail` that fails only on that one invocation: `now.md` held a real entry and the prompt said there was none.
+
+  **The prompt is where that lands.** `save-session.prompt.txt` hands the previous entry to Haiku for two decisions — do not repeat it, and return `SKIP` if this span is the same work. A false empty removes both anchors at once, so the model writes the previous span back into `now.md` as new: the duplication #142/#224/#250 close from the other end, reached here through the prompt rather than through the file.
+
+  **Three states, not two.** There is genuinely no `## ` header yet; `now.md` cannot be read; the read failed. Only the first is `(no previous entry)`. The other two now send `(previous entry unavailable — now.md could not be read; earlier work may already be recorded)` and log an ERROR naming which one it was. The marker is written for a model, not a person: it says the field is missing rather than empty, and says what follows from that, so the summarizer does not treat a failed read as a fresh buffer. It deliberately does not push toward `SKIP` — nudging a model to skip on missing context spends a real span to protect the prompt.
+
+  **The save still completes.** Failing the run here would trade the loud bug for the quiet one: an entry written without dedup context is visible in `now.md` and recoverable, while a span that never reaches memory is neither. Same trade the NDC tail arm already makes — report the read you could not make, do not act on a value you do not have.
+
+  **The pipeline above it was wrong in the same way, and less visibly.** `grep -n '^## ' … | tail -1 | cut -d: -f1` returned `cut`'s exit status, and `cut` succeeds on empty input, so grep failing on an unreadable file was indistinguishable from grep finding no header — the same false empty, one line earlier, and it would have survived a fix aimed only at the `&&`/`||`. `grep` is now run for its own status (1 = no match, >1 = error) and the last line is taken with parameter expansion, removing two more unchecked processes rather than checking them.
+
+  Two further instances of the idiom remain in `scripts/log.sh` (lines 268 and 332), noted on the issue and not fixed here; there the two branches *concatenate*, so the caller receives the value followed by the default. [shellcheck SC2015](https://www.shellcheck.net/wiki/SC2015) flags all three.
 
 ## [0.12.2] — Too large to hand over
 

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -204,13 +204,60 @@ if [ "$DRY_RUN" = true ]; then
 fi
 
 # --- Step 2: Get last entry ---
+# Three states, not two (#251). This block used to answer with one of two
+# values, and "(no previous entry)" carried both *there is no entry yet* and
+# *the entry could not be read* — an absence this script produced, handed to
+# the summarizer as an absence in the world. The prompt asks the model to skip
+# work already covered by the previous entry, so a false empty removes its dedup
+# anchor and its SKIP anchor at once, and the previous span is written back into
+# now.md: the damage #142/#224/#250 close from the other end.
+#
+# The old line was `A && B || C`, which is not if/else: when `A` holds and `B`
+# *fails*, `C` runs too, and `C`'s `>` overwrites anything `B` wrote — including
+# a partial read. Rewritten as real branches so a failed read is its own case.
+#
+# The save is NOT failed on this: a span that never reaches memory cannot be
+# recovered, while a summary written without dedup context is visible in now.md
+# and can be. Same trade as the NDC tail arm below (see Step 8) — report the
+# read you could not make, do not act on a value you do not have.
+NO_PREVIOUS_ENTRY="(no previous entry)"
+LAST_ENTRY_UNAVAILABLE="(previous entry unavailable — now.md could not be read; earlier work may already be recorded)"
 TMP_LAST_ENTRY=$(mktemp "${TMPDIR:-/tmp}"/remember-last-entry-XXXXXX)
 CLEANUP_FILES+=("$TMP_LAST_ENTRY")
-if [ -f "$MEMORY_FILE" ]; then
-    LAST_LINE=$(grep -n '^## ' "$MEMORY_FILE" | tail -1 | cut -d: -f1)
-    [ -n "$LAST_LINE" ] && tail -n +"$LAST_LINE" "$MEMORY_FILE" > "$TMP_LAST_ENTRY" || echo "(no previous entry)" > "$TMP_LAST_ENTRY"
+if [ ! -f "$MEMORY_FILE" ]; then
+    printf '%s\n' "$NO_PREVIOUS_ENTRY" > "$TMP_LAST_ENTRY"
+elif [ ! -r "$MEMORY_FILE" ]; then
+    printf '%s\n' "$LAST_ENTRY_UNAVAILABLE" > "$TMP_LAST_ENTRY"
+    log "prompt" "ERROR: now.md exists but is not readable — last entry sent as unavailable, not as absent"
 else
-    echo "(no previous entry)" > "$TMP_LAST_ENTRY"
+    # `grep -n ... | tail -1 | cut` reported the exit status of `cut`, which
+    # succeeds on empty input, so grep failing on an unreadable or vanished
+    # file was indistinguishable from grep finding no header. grep is run on its
+    # own for its status (1 = no match, >1 = error), and the last line is picked
+    # with parameter expansion rather than two more unchecked processes.
+    LAST_ENTRY_HEADERS=""
+    HEADER_GREP_RC=0
+    LAST_ENTRY_HEADERS=$(grep -n '^## ' "$MEMORY_FILE") || HEADER_GREP_RC=$?
+    if [ "$HEADER_GREP_RC" -gt 1 ]; then
+        printf '%s\n' "$LAST_ENTRY_UNAVAILABLE" > "$TMP_LAST_ENTRY"
+        log "prompt" "ERROR: header search over now.md failed (grep rc ${HEADER_GREP_RC}) — last entry sent as unavailable, not as absent"
+    else
+        LAST_LINE="${LAST_ENTRY_HEADERS##*$'\n'}"
+        LAST_LINE="${LAST_LINE%%:*}"
+        case "$LAST_LINE" in ''|*[!0-9]*) LAST_LINE="" ;; esac
+        if [ -z "$LAST_LINE" ]; then
+            printf '%s\n' "$NO_PREVIOUS_ENTRY" > "$TMP_LAST_ENTRY"
+        elif tail -n +"$LAST_LINE" "$MEMORY_FILE" > "$TMP_LAST_ENTRY"; then
+            :
+        else
+            # Whatever tail managed to write is discarded deliberately: a
+            # half-read entry is still a claim about now.md that this script
+            # cannot stand behind, and a mid-word truncation reads to the
+            # summarizer as content rather than as damage.
+            printf '%s\n' "$LAST_ENTRY_UNAVAILABLE" > "$TMP_LAST_ENTRY"
+            log "prompt" "ERROR: reading the last entry from now.md failed — sent as unavailable, not as absent (this save may duplicate work already recorded)"
+        fi
+    fi
 fi
 
 # --- Step 3: Build prompt ---

--- a/tests/test_last_entry_read_failure_251.py
+++ b/tests/test_last_entry_read_failure_251.py
@@ -1,0 +1,207 @@
+"""A failed read of the last entry must not be handed to the summarizer as
+"(no previous entry)" (#251).
+
+`save-session.sh` Step 2 built the dedup context for the Haiku prompt with
+
+    [ -n "$LAST_LINE" ] && tail -n +"$LAST_LINE" "$MEMORY_FILE" > "$TMP" \\
+        || echo "(no previous entry)" > "$TMP"
+
+which is the `A && B || C` trap: when `A` holds but `B` *fails*, `C` runs as
+well, and `C`'s `>` overwrites whatever `B` managed to write. A read failure is
+therefore rendered as a factual claim about the memory file — the summarizer is
+told there is no previous entry when there is one, loses its dedup anchor and
+its SKIP anchor, and can write the previous span back into now.md. That is the
+damage class #142/#224/#250 have been closing from the other end.
+
+Three states, not two: (1) genuinely no `## ` header yet, (2) now.md exists but
+cannot be read, (3) the read itself failed. Only (1) is "(no previous entry)".
+(2) and (3) must say so — same shape as the NDC tail arm at save-session.sh:782,
+which reports rather than acting on a read it could not make.
+
+The save itself still succeeds: losing the save to protect the prompt would
+trade a loud bug for a quiet one, and a span that never reaches memory is not
+recoverable while a possibly-duplicated entry is.
+"""
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from test_save_session_gates import _make_env, _run, _suppress_ndc  # shared harness
+from subprocess_helpers import subprocess_failure_detail
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash subprocess + POSIX layout — not portable to Windows runners (#79)",
+)
+
+PREVIOUS_ENTRY = "## 09:00 | main\n\n- real previous entry, issue #251\n"
+
+# Fails only the exact invocation Step 2 uses (`tail -n +N MEMORY_FILE`), so the
+# `tail -1` inside the header pipeline and every other tail in the script still
+# run through the real binary and the run reaches Step 2 normally.
+#
+# `command -p` resolves against the shell's default PATH, not the directory this
+# stub was prepended to, so it cannot recurse into itself. It is deliberately
+# NOT prefixed with `exec`: Debian's dash (/bin/sh on every Ubuntu runner)
+# implements `exec` as a PATH search for an executable with no builtin
+# fallback, so `exec command -p tail` dies with exit 127 before any tail runs
+# (see test_ndc_tail_failure_no_truncate.py, where that cost a CI leg).
+TAIL_STUB = """#!/bin/sh
+if [ "$1" = "-n" ] && [ "$3" = "$STUB_TAIL_FAIL_FILE" ]; then
+    if [ -n "$STUB_TAIL_PARTIAL" ]; then
+        printf '%s' "$STUB_TAIL_PARTIAL"
+    fi
+    echo "stub tail: simulated read failure" >&2
+    exit 1
+fi
+command -p tail "$@"
+"""
+
+
+def _env_with_previous_entry(tmp_path: Path):
+    env, project, plugin, calls, sid = _make_env(tmp_path, exchanges=6, humans=5)
+    _suppress_ndc(project)
+    memory_file = project / ".remember" / "now.md"
+    memory_file.write_text(PREVIOUS_ENTRY, encoding="utf-8")
+    snapshot = tmp_path / "last-entry-as-sent.md"
+    env = dict(env)
+    env["STUB_LAST_ENTRY_SNAPSHOT"] = str(snapshot)
+    return env, project, plugin, calls, sid, memory_file, snapshot
+
+
+def _with_failing_tail(env: dict, tmp_path: Path, memory_file: Path, partial: str = ""):
+    bindir = tmp_path / "stub-bin"
+    bindir.mkdir(exist_ok=True)
+    stub = bindir / "tail"
+    stub.write_text(TAIL_STUB, encoding="utf-8")
+    stub.chmod(0o755)
+    env = dict(env)
+    env["PATH"] = f"{bindir}{os.pathsep}{env['PATH']}"
+    env["STUB_TAIL_FAIL_FILE"] = str(memory_file)
+    if partial:
+        env["STUB_TAIL_PARTIAL"] = partial
+    return env
+
+
+def _log_text(project: Path) -> str:
+    log_dir = project / ".remember" / "logs"
+    return "\n".join(f.read_text(errors="replace") for f in log_dir.glob("*.log"))
+
+
+class TestTailFailureIsNotAnEmptyBuffer:
+
+    def test_failed_tail_is_not_reported_as_no_previous_entry(self, tmp_path):
+        """The #251 case: a read failure must not read as a claim about now.md."""
+        env, project, plugin, calls, sid, memory_file, snapshot = _env_with_previous_entry(tmp_path)
+        env = _with_failing_tail(env, tmp_path, memory_file)
+
+        result = _run(plugin, env, sid)
+        assert result.returncode == 0, subprocess_failure_detail(result, project / ".remember")
+
+        assert snapshot.is_file(), (
+            "build-prompt was never called, so the run did not reach Step 2 and "
+            "this test proves nothing"
+        )
+        sent = snapshot.read_text(encoding="utf-8", errors="replace")
+        assert "(no previous entry)" not in sent, (
+            "now.md holds a real entry and tail failed to read it — telling the "
+            "summarizer there is no previous entry is a factual claim the script "
+            f"cannot make. sent={sent!r}"
+        )
+        assert "previous entry unavailable" in sent, (
+            "the summarizer must be told the context is missing rather than "
+            f"absent, so it does not treat this as a fresh buffer. sent={sent!r}"
+        )
+
+    def test_failed_tail_is_logged(self, tmp_path):
+        """Silent is how this survived: rc 0, nothing logged, no marker."""
+        env, project, plugin, calls, sid, memory_file, snapshot = _env_with_previous_entry(tmp_path)
+        env = _with_failing_tail(env, tmp_path, memory_file)
+
+        result = _run(plugin, env, sid)
+        assert result.returncode == 0, subprocess_failure_detail(result, project / ".remember")
+
+        log_text = _log_text(project)
+        assert "last entry" in log_text and "ERROR" in log_text, (
+            f"expected an error log naming the failed last-entry read, got: {log_text!r}"
+        )
+
+    def test_partial_tail_output_is_not_sent_as_the_entry(self, tmp_path):
+        """A half-written read is not a previous entry either."""
+        env, project, plugin, calls, sid, memory_file, snapshot = _env_with_previous_entry(tmp_path)
+        env = _with_failing_tail(env, tmp_path, memory_file, partial="## 09:00 | ma")
+
+        result = _run(plugin, env, sid)
+        assert result.returncode == 0, subprocess_failure_detail(result, project / ".remember")
+
+        sent = snapshot.read_text(encoding="utf-8", errors="replace")
+        assert "previous entry unavailable" in sent, (
+            "a truncated read must be replaced by the unavailable marker, not "
+            f"passed off as the entry. sent={sent!r}"
+        )
+        assert "(no previous entry)" not in sent
+
+    def test_save_still_completes_when_the_read_fails(self, tmp_path):
+        """Chosen failure: keep the save, mark the prompt — not the reverse."""
+        env, project, plugin, calls, sid, memory_file, snapshot = _env_with_previous_entry(tmp_path)
+        env = _with_failing_tail(env, tmp_path, memory_file)
+
+        result = _run(plugin, env, sid)
+        assert result.returncode == 0, subprocess_failure_detail(result, project / ".remember")
+        assert "call-haiku" in calls.read_text(), (
+            "the summarization must still run — losing the save to protect the "
+            "prompt trades a loud bug for a quiet one"
+        )
+
+
+class TestUnreadableMemoryFile:
+
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root ignores the permission bits this test relies on",
+    )
+    def test_unreadable_now_md_is_not_reported_as_empty(self, tmp_path):
+        """`grep | tail | cut` swallows grep's error: rc comes from cut, always 0."""
+        env, project, plugin, calls, sid, memory_file, snapshot = _env_with_previous_entry(tmp_path)
+        memory_file.chmod(0o000)
+        try:
+            result = _run(plugin, env, sid)
+            assert result.returncode == 0, subprocess_failure_detail(result, project / ".remember")
+
+            sent = snapshot.read_text(encoding="utf-8", errors="replace")
+            assert "(no previous entry)" not in sent, (
+                "an unreadable now.md is not an empty one — the header search "
+                f"failed, it did not come back empty. sent={sent!r}"
+            )
+            assert "previous entry unavailable" in sent
+        finally:
+            memory_file.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+class TestGenuinelyEmptyBufferStillReportsAbsence:
+    """The state that is legitimately "(no previous entry)" must stay that way —
+    otherwise the fix would just move the ambiguity to the other side."""
+
+    def test_no_memory_file_reports_no_previous_entry(self, tmp_path):
+        env, project, plugin, calls, sid = _make_env(tmp_path, exchanges=6, humans=5)
+        _suppress_ndc(project)
+        snapshot = tmp_path / "last-entry-as-sent.md"
+        env = dict(env)
+        env["STUB_LAST_ENTRY_SNAPSHOT"] = str(snapshot)
+
+        result = _run(plugin, env, sid)
+        assert result.returncode == 0, subprocess_failure_detail(result, project / ".remember")
+        assert snapshot.read_text(encoding="utf-8").strip() == "(no previous entry)"
+
+    def test_memory_file_without_headers_reports_no_previous_entry(self, tmp_path):
+        env, project, plugin, calls, sid, memory_file, snapshot = _env_with_previous_entry(tmp_path)
+        memory_file.write_text("some prose, no header yet\n", encoding="utf-8")
+
+        result = _run(plugin, env, sid)
+        assert result.returncode == 0, subprocess_failure_detail(result, project / ".remember")
+        assert snapshot.read_text(encoding="utf-8").strip() == "(no previous entry)"

--- a/tests/test_save_session_gates.py
+++ b/tests/test_save_session_gates.py
@@ -67,6 +67,12 @@ elif cmd == "save-position":
         json.dump({"session": session_id, "line": int(position)}, f)
 elif cmd == "build-prompt":
     # argv: build-prompt <extract> <last_entry> <time> <branch> <out> <max_bytes>
+    if os.environ.get("STUB_LAST_ENTRY_SNAPSHOT"):
+        # The only place the last-entry context can be observed as the
+        # summarizer receives it: the temp file is unlinked by the script's
+        # cleanup trap, so reading it afterwards is not possible (#251).
+        import shutil
+        shutil.copyfile(sys.argv[3], os.environ["STUB_LAST_ENTRY_SNAPSHOT"])
     with open(sys.argv[6], "w") as f:
         f.write("a prompt with no placeholders\\n")
 elif cmd == "call-haiku":


### PR DESCRIPTION
## What

`save-session.sh` Step 2 built the summarizer's dedup context with

```sh
[ -n "$LAST_LINE" ] && tail -n +"$LAST_LINE" "$MEMORY_FILE" > "$TMP" || echo "(no previous entry)" > "$TMP"
```

`A && B || C` is not if/else. When the guard holds and `tail` **fails**, `C` runs as well and its `>` overwrites whatever `B` wrote. A read failure was therefore rendered as a factual claim about `now.md` — rc 0, nothing logged, no marker.

Reproduced before fixing, with a `tail` shim that fails only that one invocation: `now.md` held a real entry and the prompt said there was none.

## Why it matters

`prompts/save-session.prompt.txt` gives the previous entry to Haiku for two decisions — do not repeat it, and return `SKIP` when the span is the same work. A false empty removes both anchors at once, so the model writes the previous span back into `now.md` as new. That is the duplication #142/#224/#250 close from the other end, reached through the prompt rather than through the file.

## Three states, not two

| state | sent to the summarizer |
| --- | --- |
| no `## ` header yet (or no `now.md`) | `(no previous entry)` — unchanged |
| `now.md` exists but is not readable | `(previous entry unavailable — …)` + ERROR log |
| the read itself failed | `(previous entry unavailable — …)` + ERROR log |

The marker is written for a model, not a person: it says the field is *missing* rather than *empty*, and states the consequence (`earlier work may already be recorded`) so a failed read is not treated as a fresh buffer. It deliberately does **not** push toward `SKIP` — nudging a model to skip on missing context spends a real span to protect the prompt.

## The failure chosen

The save still completes, rc 0. Failing here would trade the loud bug for the quiet one: an entry written without dedup context is visible in `now.md` and recoverable; a span that never reaches memory is neither. Same trade the NDC tail arm at Step 8 already makes.

## What else that block did wrong

`grep -n '^## ' … | tail -1 | cut -d: -f1` returned **`cut`'s** exit status, and `cut` succeeds on empty input — so grep failing on an unreadable file was indistinguishable from grep finding no header. The same false empty, one line earlier, and it would have survived a fix aimed only at the `&&`/`||`. `grep` now runs for its own status (1 = no match, >1 = error) and the last line is taken with parameter expansion, removing `tail` and `cut` from that path rather than checking them.

## Correction to the issue's second half

The issue and the brief describe `>` truncating *before* `tail` writes as a second defect. It is not reachable: `$TMP_LAST_ENTRY` comes straight from `mktemp` and is always empty, so the truncate destroys nothing. The partial-write concern is real but its only cause is `C` overwriting `B` — one defect, not two. A test pins the partial case anyway, since the fix's handling of it is a deliberate choice (discard the partial, send the marker).

## Tests

`tests/test_last_entry_read_failure_251.py` — 7 tests, RED before the fix on the 4 that assert the new behaviour (the 3 guards for the legitimately-empty states passed before and after, which is the point of having them). Uses the repo's existing PATH-shim idiom from `test_ndc_tail_failure_no_truncate.py`, narrowed to `tail -n +N <now.md>` so `tail -1` elsewhere still runs the real binary; `command -p` without `exec` for the dash-on-Ubuntu reason documented there.

`STUB_LAST_ENTRY_SNAPSHOT` added to the shared `build-prompt` stub — env-gated, no effect on existing tests. It is the only way to observe the last-entry file as the summarizer receives it; the script's cleanup trap unlinks it.

Full suite: **1223 passed, 42 skipped** locally (bash 3.2, macOS). `bash -n` and `shellcheck` clean on the edited region.

## Not in this PR

Two more `A && B || C` instances in `scripts/log.sh` (268, 332), noted in the issue comment. There the branches *concatenate*, so the caller gets the value **followed by** the default — a different and arguably worse consequence, and they are config readers with their own callers. Left for the sweep the comment proposes; `claude-supertool#665` (shellcheck SC2015) would catch all three at edit time.

Closes #251
