### PR TITLE
fix(slug): fold the Windows drive letter on the Python side too (#268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`pipeline/slug.py` did not fold the Windows drive letter that `scripts/lib-slug.sh` has folded since #263** ([#268](https://github.com/Digital-Process-Tools/claude-remember/issues/268)) — `resolve-paths.sh` normalises `CLAUDE_PROJECT_DIR` to the native Win32 form with an UPPER-case drive before either side ever sees it. Bash then lower-cases that drive letter unconditionally; Python is a faithful transcription of Claude Code's own JXA slug routine, which never receives a raw drive letter at all (the host folds before calling it), so the transcription had nothing to fold either — and slugged the upper-case drive literally. `C--Users-…` from Python against `c--Users-…` from bash, for the same directory. NTFS resolves both, so nothing failed and nothing reported it; `extract.py` uses the Python slug to find the session directory, so it read a differently-cased path than the store the git-backup hook tracks.
+
+  `pipeline/slug.py` now folds a leading drive letter the same way, in the same direction (lower case — not a free choice; see #263's PR: Git for Windows ships cygpath, so the working majority's on-disk stores are already spelled that way). `tests/test_slug_parity.py` is extended to assert bash and Python agree across both cases and all three shapes `CLAUDE_PROJECT_DIR` is known to arrive in (`C:\…`, `c:/…`, `/c/…`), rather than adding the one input that was missing — the guarantee now spans the normalisation step, which is the same shape of gap #263 itself was.
+
+  Two pre-existing tests in `tests/test_path_resolution.py` (predating #263, from the original Windows-compat issue) asserted the old un-folded upper-case slug as correct; they are updated to the now-verified value.
+
 ## [0.12.3] — One bad byte
 
 Five fixes in the backup path and one in the machinery that was supposed to report them, and the one worth leading with inverts an issue we filed ourselves.

--- a/pipeline/slug.py
+++ b/pipeline/slug.py
@@ -75,8 +75,34 @@ def path_hash(path: str) -> str:
     return _to_base36(abs(acc))
 
 
+def _fold_drive_letter(path: str) -> str:
+    """Lower-case a leading Windows drive letter, matching lib-slug.sh (#268).
+
+    scripts/lib-slug.sh folds this unconditionally since #263; this module
+    did not fold at all, because it is a transcription of Claude Code's own
+    JXA routine, which never sees a raw drive letter — the host normalises
+    before calling it. On Windows, CLAUDE_PROJECT_DIR reaches this function
+    already normalised to the native Win32 form with an UPPER-case drive
+    (resolve-paths.sh's own regex uppercases), so this slugged it literally
+    and disagreed with the shell side by one character's case.
+
+    The direction is not a free choice (see #263's PR): Git for Windows
+    ships cygpath, so the working majority's on-disk stores are already
+    spelled with the lower-case drive; folding the other way would fix the
+    minority and rename every other store.
+
+    Anchored to position 0 only, matching lib-slug.sh's `case "$path" in
+    ?:*)`: an embedded ``X:`` elsewhere in a path is an ordinary colon, not a
+    drive letter, and must not be touched.
+    """
+    if len(path) >= 2 and path[1] == ":" and "A" <= path[0] <= "Z":
+        return path[0].lower() + path[1:]
+    return path
+
+
 def session_dir_slug(path: str) -> str:
     """The directory name Claude Code uses for ``path``."""
+    path = _fold_drive_letter(path)
     slug = "".join(
         c if c.isascii() and c.isalnum() else "-" * (2 if ord(c) > 0xFFFF else 1)
         for c in path

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -524,8 +524,9 @@ def _make_real_session(home_dir: str, project_dir: str, session_id: str) -> str:
 
     Returns the JSONL file path.
     """
-    import re as remod
-    slug = remod.sub(r'[^a-zA-Z0-9]', '-', project_dir)
+    from pipeline.slug import session_dir_slug
+
+    slug = session_dir_slug(project_dir)
     sdir = os.path.join(home_dir, ".claude", "projects", slug)
     os.makedirs(sdir, exist_ok=True)
     jsonl_path = os.path.join(sdir, session_id + ".jsonl")

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -1191,11 +1191,17 @@ class TestWindowsCompatIssue11:
         assert ":" not in result, "Colons not replaced"
 
     def test_session_dir_matches_bash_slug(self):
-        """Python slug matches bash sed 's/[^a-zA-Z0-9]/-/g' for all path types."""
+        """Python slug matches bash sed 's/[^a-zA-Z0-9]/-/g' for all path types.
+
+        The drive letter is lower-cased (#268): bash's session_dir_slug folds
+        it unconditionally since #263, and pipeline/slug.py now does the same
+        — Git for Windows ships cygpath, so the working majority's on-disk
+        stores are already spelled that way.
+        """
         for path, expected_slug in [
             ("/home/user/project", "-home-user-project"),
-            ("D:\\Users\\dev\\project", "D--Users-dev-project"),
-            ("D:/Users/dev/project", "D--Users-dev-project"),
+            ("D:\\Users\\dev\\project", "d--Users-dev-project"),
+            ("D:/Users/dev/project", "d--Users-dev-project"),
             ("/Users/dev/My Project", "-Users-dev-My-Project"),
         ]:
             result = _session_dir(path)
@@ -1271,10 +1277,11 @@ class TestWindowsCompatIssue11:
         """End-to-end: a /c/Users/... path post-normalization slugs to the same folder Claude Code uses."""
         # After resolve-paths.sh normalizes /c/Users/dev/project → C:\Users\dev\project,
         # the Python _session_dir (and bash sed) must produce the same slug Claude Code
-        # uses to store session JSONLs on Windows.
+        # uses to store session JSONLs on Windows — with the drive letter lower-cased
+        # (#268), matching bash's session_dir_slug fold (#263).
         normalized = r"C:\Users\dev\project"
         slug = _session_dir(normalized).rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
-        assert slug == "C--Users-dev-project", (
+        assert slug == "c--Users-dev-project", (
             f"Normalized Win32 path slug mismatch: got {slug!r}"
         )
 

--- a/tests/test_slug_parity.py
+++ b/tests/test_slug_parity.py
@@ -156,6 +156,64 @@ def test_a_bmp_character_costs_one_dash():
     assert bash_slug("/tmp/日x") == "-tmp--x"
 
 
+# ── Drive-letter fold parity (#268) ─────────────────────────────────────────
+#
+# scripts/lib-slug.sh folds a leading Windows drive letter to lower case
+# (#263); pipeline/slug.py did not fold at all — it is a faithful
+# transcription of Claude Code's own JXA routine, which never sees a raw
+# drive letter, so a transcription of it has nothing to fold either. On
+# Windows, CLAUDE_PROJECT_DIR reaches the Python side already normalised to
+# the native Win32 form with an UPPER-case drive (resolve-paths.sh:174), and
+# pipeline.slug slugged that literally: `C--Users-...` from Python against
+# `c--Users-...` from bash, for the same directory. NTFS resolves both, so
+# nothing failed and nothing reported it.
+#
+# The JS oracle cannot pin this step: the fold happens to the input BEFORE
+# Claude Code's own regex ever runs, so js_slug() has no concept of a drive
+# letter at all. These compare bash and python directly instead, across both
+# cases and all three shapes CLAUDE_PROJECT_DIR is known to arrive in, so the
+# guarantee spans the normalisation step rather than a list of remembered
+# inputs — extending test_bash_and_python_agree the same way it already
+# covers everything else.
+DRIVE_PATHS = [
+    r"C:\Users\dev\project",
+    r"c:\Users\dev\project",
+    "C:/Users/dev/project",
+    "c:/Users/dev/project",
+    "/c/Users/dev/project",
+    "/C/Users/dev/project",
+    r"D:\Data\x",
+    "C:/",
+]
+
+
+@pytest.mark.parametrize("path", DRIVE_PATHS)
+def test_bash_and_python_agree_on_drive_letter_paths(path):
+    """#268: bash already folds the drive letter; python must agree."""
+    assert bash_slug(path) == py_slug(path)
+
+
+@pytest.mark.parametrize("path", [r"C:\Users\dev\project", "C:/Users/dev/project"])
+def test_the_drive_letter_folds_to_lower_case(path):
+    """The direction is pinned explicitly, not just cross-checked (#263's PR):
+    cygpath already lower-cases, so the working majority's on-disk stores are
+    already spelled that way — uppercasing would "fix" the minority and
+    rename every other store. A bare bash==python equality would still pass
+    if both sides folded to upper case instead."""
+    assert py_slug(path).startswith("c--"), py_slug(path)
+    assert bash_slug(path).startswith("c--"), bash_slug(path)
+
+
+def test_a_drive_letter_not_at_the_start_is_left_alone():
+    """The fold is anchored to position 0. An embedded 'C:' elsewhere in a
+    path is an ordinary colon to both implementations, not a drive letter —
+    folding it would be scope creep past what #263 established."""
+    path = "/tmp/weird:C:embedded"
+    expected = "-tmp-weird-C-embedded"
+    assert py_slug(path) == expected
+    assert bash_slug(path) == expected
+
+
 def test_external_storage_dir_uses_the_real_slug_without_detect_tools():
     """#158: lib-memory-dir.sh carried a naive copy of its own.
 


### PR DESCRIPTION
`scripts/lib-slug.sh` has folded a leading drive letter to lower case
unconditionally since #263. `pipeline/slug.py` did not fold at all — it is a
transcription of Claude Code's own JXA routine, which never sees a raw drive
letter because the host normalises first. On Windows `resolve-paths.sh` hands
both sides the native Win32 form with an UPPER-case drive, so bash computed
`c--Users-…` and Python computed `C--Users-…`, and `extract.py` located the
session directory by the Python spelling.

NTFS resolves a case-only difference, so nothing failed and nothing reported a
difference. The exposure is that it stops being benign the moment anything
compares the two slugs as strings rather than using them as paths — which is
precisely what #263 turned out to be, in git rather than in the filesystem.

The direction is not a free choice (#263's PR): Git for Windows ships cygpath,
so the working majority's on-disk stores already carry the lower-case spelling,
and folding the other way would fix one reporter while renaming every other
store. The fold is anchored at position 0, matching bash's `?:*` case, so an
embedded `X:` mid-path is left alone. It runs before the slug characters and
before `path_hash`, mirroring bash capturing `_orig` after its own fold — so
the over-long-path branch agrees too.

`tests/test_slug_parity.py` existed to keep these two implementations
identical and was doing its job for every step except the one where they
drifted. It now spans both cases and all three shapes (`C:\…`, `c:/…`, `/c/…`),
pins the direction so the two cannot agree on the wrong case, and guards
against the fold overreaching into an ordinary mid-path colon.

Two pre-existing tests in `tests/test_path_resolution.py` hardcoded the old
upper-case slug as expected — stale fixtures never updated when bash's fold
shipped in #263. Corrected.

Closes #268

Co-Authored-By: Max <noreply>