### PR TITLE
docs: name hook-errors.log where people read, not only where it is written (#281)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,6 +33,11 @@ What did you expect to happen?
 What happened instead? Include hook output / error messages / contents of
 `.remember/now.md` if relevant.
 
+**Please attach `<your memory store>/logs/hook-errors.log`** — `/remember:doctor`
+tails it under "Recent errors". It carries the stderr of any hook that failed,
+with its exit status, and is usually the difference between one round of
+questions and three.
+
 ## Environment
 
 - claude-remember version: (see `.claude-plugin/plugin.json`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **`hook-errors.log` is named where people read, not only where it is written** ([#281](https://github.com/Digital-Process-Tools/claude-remember/issues/281)) — the file appeared nowhere in `README.md`, `docs/` or `commands/`, while `bootstrap-dirs.sh` points every hook's stderr into it, `/remember:doctor` tails it under "Recent errors", and #277 now writes a failing hook's exit status and own first lines there. The plugin went to real trouble making hook failures speak, into a file nobody had been told about — an error written where no one looks is not much louder than one discarded. Now documented in README §Diagnostics with its path and what it holds, and requested outright in the bug-report template.
+
 ### Fixed
 
 - **`pipeline/slug.py` did not fold the Windows drive letter that `scripts/lib-slug.sh` has folded since #263** ([#268](https://github.com/Digital-Process-Tools/claude-remember/issues/268)) — `resolve-paths.sh` normalises `CLAUDE_PROJECT_DIR` to the native Win32 form with an UPPER-case drive before either side ever sees it. Bash then lower-cases that drive letter unconditionally; Python is a faithful transcription of Claude Code's own JXA slug routine, which never receives a raw drive letter at all (the host folds before calling it), so the transcription had nothing to fold either — and slugged the upper-case drive literally. `C--Users-…` from Python against `c--Users-…` from bash, for the same directory. NTFS resolves both, so nothing failed and nothing reported it; `extract.py` uses the Python slug to find the session directory, so it read a differently-cased path than the store the git-backup hook tracks.

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Available on plugin installs, which auto-discover `commands/`. If you set the pl
 
 Reach for it whenever memory is not appearing and nothing says why — the two silent failures it names outright are a slug mismatch ([#144](https://github.com/Digital-Process-Tools/claude-remember/issues/144)) and hooks that were never registered ([#200](https://github.com/Digital-Process-Tools/claude-remember/issues/200)).
 
+Its "Recent errors" section tails **`<your memory store>/logs/hook-errors.log`**. That file is where a hook's own stderr goes: `bootstrap-dirs.sh` points every Claude Code hook's stderr at it, and a hook that exits non-zero is reported there with its exit status and its own first lines ([#277](https://github.com/Digital-Process-Tools/claude-remember/issues/277)). It is the single most useful thing to attach to a bug report — most of what makes a plugin failure hard to diagnose from the outside is already written in it, and a report that includes it usually skips a whole round of questions.
+
 ## Handoff between sessions (`/remember`)
 
 Before clearing context or ending a session, type `/remember`. The agent writes a short handoff note to `.remember/remember.md` — what's done, what's next, any non-obvious context. The next session reads it and picks up where you left off. This is complementary to the automatic pipeline: the pipeline captures what happened, the handoff captures what matters next.


### PR DESCRIPTION
Found in a docs audit rather than by a user, which is the point: the file
appeared nowhere in README.md, docs/ or commands/ (verified two ways — a
citation grep and a concept grep), while three things depend on it.

`bootstrap-dirs.sh:140` points every Claude Code hook's stderr into
`$REMEMBER_DIR/logs/hook-errors.log`. `/remember:doctor` tails it under
"Recent errors" — six references in doctor.sh. And #277 now reports a failing
hook there with its exit status and its own first lines, deliberately, in
addition to the daily log.

So the plugin goes to real trouble making hook failures speak, and lands them
in a file nobody had been told about. An error written where no one looks is
not meaningfully louder than an error discarded, which is the thing #277 set
out to fix.

README §Diagnostics now names the path and says what the file holds. The
bug-report template asks for it outright, next to the hook output and now.md
it already requests — this repo has taken ten Windows issues from seven
external reporters, and it is the artefact that would have shortened most of
them.

Closes #281

Co-Authored-By: Max <noreply>