### PR TITLE
release: 0.15.0 — What the check actually saw

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remember",
   "description": "Continuous memory for Claude Code. Extracts, summarizes, and compresses conversations into tiered daily logs. Claude remembers what you did yesterday.",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] — What the check actually saw
+
+Three of the four changes here are the same shape: something reported a clean result it was not in a position to give.
+
+The one with a user behind it is [@jackneil](https://github.com/jackneil)'s. This plugin has always printed `[14:30 CEST — jack — 45%]` into the model's context on every prompt, with no way to turn it down, and operators were rewriting that line in flight with a regex to get rid of it. `prompt_stamp` makes it a choice — `full` (the unchanged default), `stable`, or `off`. The half of the report that was wrong is the half that decided the design: the context percentage is *not* byte-stable between turns, so dropping only the clock would have shipped the same problem under a shorter name.
+
+The other three are ours. Nothing asserted that the shipped shell scripts **parse**, while a syntax error in a hook silently discards whatever the user just typed — and the construct that caused exactly that during this release fails to parse only on bash 3.2, so a gate running under a modern bash would have reported `ok` on the offending file. The lock primitive's concurrency test counted *acquisitions* rather than measuring *overlap*, which meant it recorded four legitimate sequential lock-takes as four concurrent winners. And the store-spelling check added in 0.14.0 now has its precondition measured rather than assumed: it never occurs in any store anybody has, and the disclosure stays as the detector.
+
+Manifest bumped per [#133](https://github.com/Digital-Process-Tools/claude-remember/issues/133) — the updater compares manifest versions and nothing else, so this line is the part that reaches anyone.
+
+
 ### Changed
 
 - **The lock primitive's concurrency test measures overlap instead of counting acquisitions** ([#293](https://github.com/Digital-Process-Tools/claude-remember/issues/293)) — `test_at_most_one_winner_per_round` tallied how many processes acquired a lock in a round and asserted the tally was 1. That is not a property of `lock_acquire`. Its winner released after 150ms, so a contender the OS did not schedule until after that release took the free lock by plain `mkdir` — a second acquisition, legitimate, sequential, and not a race — and the harness recorded it as a concurrent winner. **Reproduced on a stock macOS laptop, and worse than the issue reported: 4 contenders at a 0.4s stagger, 4 winners, zero overlap.** The test passed in CI only because the runners it met happened to schedule contenders inside 150ms of each other — the same property that made [#291](https://github.com/Digital-Process-Tools/claude-remember/issues/291) fail on one ubuntu leg in twelve and never on a laptop.


### PR DESCRIPTION
Cuts **0.15.0 — What the check actually saw**.

Two files, twelve lines: `.claude-plugin/plugin.json` `0.14.0` → `0.15.0`, and the `[Unreleased]` CHANGELOG section becomes `[0.15.0]` with an intro.

**The manifest bump is the release.** The updater compares manifest versions and nothing else ([#133](https://github.com/Digital-Process-Tools/claude-remember/issues/133)) — v0.8.3→0.8.6 shipped nothing to users because the manifest still read 0.8.3. The tag, the GitHub release and this CHANGELOG are for humans.

## What ships

| Issue | |
|---|---|
| [#301](https://github.com/Digital-Process-Tools/claude-remember/issues/301) | `prompt_stamp` — the injected `UserPromptSubmit` line becomes a choice. **The only externally reported item**, from [@jackneil](https://github.com/jackneil). Default `full` is byte-for-byte unchanged. |
| [#302](https://github.com/Digital-Process-Tools/claude-remember/issues/302) | Every shipped `.sh` is asserted to parse, under every bash present — a parse error in a hook discards the user's typed prompt. |
| [#293](https://github.com/Digital-Process-Tools/claude-remember/issues/293) | The lock concurrency test measures overlap instead of counting acquisitions. |
| [#300](https://github.com/Digital-Process-Tools/claude-remember/issues/300) | Session-start disclosure of a store known by two spellings differing only in case (merged before 0.14.0 was tagged, so it lands here). |

Minor rather than patch: `prompt_stamp` is a new public config key.

## Why this version has a theme

Three of the four are the same defect wearing different clothes — a check reporting a clean result it was not in a position to give. Nothing asserted the shell parsed; the parse gate would itself have said `ok` under the wrong bash; the lock test counted the wrong thing entirely. The fourth, #301, is the inverse: output the plugin emits that its users could not turn off.

## Verification

`main` is green on the commits this releases (`29670b3` confirmed `success`; `dc5669b`'s run gated before merge). No code changes here — the 12-leg matrix on this PR runs the full suite against the released content.

After merge: tag `v0.15.0` on the squash commit, GitHub release with notes extracted from this CHANGELOG section rather than retyped, then check the `claude-plugins-official` pin — a tag is a statement about this repo, not about anyone's install.
