### PR TITLE
docs: the save.lock hold is measured now, so stop saying it is not (#226)

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,9 +422,13 @@ A few runtime overrides aren't in `config.json` because they're per-shell rather
 
 ## Measuring lock hold times
 
-The NDC commit waits up to `REMEMBER_NDC_COMMIT_LOCK_TIMEOUT` (default 30s) for `save.lock`, and [#226](https://github.com/Digital-Process-Tools/claude-remember/issues/226) points out that 30 is reasoned but never measured. `save-session.sh` holds that lock for the *whole* save, including its own summarize `claude -p` call, so if a save routinely holds it longer than the wait, the knob does less than its comment claims. The staging lock's 10s was set from real numbers ([#234](https://github.com/Digital-Process-Tools/claude-remember/pull/234)); `save.lock`'s 30s still is not.
+The NDC commit waits up to `REMEMBER_NDC_COMMIT_LOCK_TIMEOUT` (default 30s) for `save.lock`. [#226](https://github.com/Digital-Process-Tools/claude-remember/issues/226) filed 30 as reasoned but never measured; the **hold** has since been measured and the **default** is now defended by it rather than by intuition.
 
-This is how to produce those numbers on a real machine. Nothing here changes a default — the measurement comes first.
+`save-session.sh` holds that lock for the *whole* save, including its own summarize `claude -p` call, so the hold is roughly `1.2s + summarizer latency` (non-model floor p50 1.22s, n=10). 30s therefore covers the common case comfortably. It cannot cover the tail by construction — the summarizer's own wall is 120s — but a save that far out is already failing at its own bound, and the NDC skip is a second-order symptom of that rather than the problem. Raising the default is not free either: `lock_acquire` busy-spins at roughly 21% of a core while it waits, on the `PostToolUse` path.
+
+What #226 leaves open is structural, not a constant: taking the model call out from under `save.lock` at all. That is a design change to the save path, because the lock also serialises the summarizers themselves.
+
+This is how to reproduce those numbers on a real machine, and how to answer the one question holds alone cannot — how often the wait actually runs out.
 
 ```bash
 export REMEMBER_LOCK_TIMING=1        # in the shell Claude Code launches hooks from


### PR DESCRIPTION
Part of #226 — does **not** close it.

## What was stale

`README.md`'s "Measuring lock hold times" section told the reader:

> The staging lock's 10s was set from real numbers (#234); `save.lock`'s 30s still is not.

> Nothing here changes a default — the measurement comes first.

Both sentences were true when written. Neither is now. The hold was measured on 2026-07-31 and recorded on #226: non-model floor **p50 1.22s** (min 1.12, max 1.50, n=10), with hold ≈ `1.2s + summarizer latency`. The default is now defended by that measurement rather than by intuition.

A reader arriving at that section today would conclude nothing is known about this lock, which is the opposite of the truth. #226's own last comment flagged the docs as needing this.

## What the section now says

- the hold is measured, and what it measures to;
- why 30s is right for the common case and cannot cover the tail by construction (the summarizer's wall is 120s, and a save out there is already failing at its own bound — the NDC skip is a second-order symptom);
- why raising the default is not free: `lock_acquire` busy-spins at ~21% of a core while waiting, on the `PostToolUse` path that #227/#230/#204 are all about;
- that what #226 leaves open is **structural** — taking the model call out from under `save.lock` — and not a constant.

## What is deliberately unchanged

- **The default.** Still 30s. This is a docs commit; it changes no behaviour.
- **The section stays a how-to.** `timeouts` is the one question a hold distribution cannot answer — a wait that ran out leaves no hold — so reproducing the numbers on a real machine still has a point.
- **#226 stays open.** The structural question is a design change to the save path, because `save.lock` also serialises the summarizers themselves (#168, #204). That is the owner's call and not something to slip in under a tuning issue.

## Note on scope

One sentence crediting #234 for the staging lock's 10s was dropped as part of the rewrite; the staging lock still appears in the worked report output and the precision bullet below.
