### PR TITLE
chore: declare a .supertool.json so preset ops exist in this repo

### DIFF
--- a/.supertool.json
+++ b/.supertool.json
@@ -1,0 +1,33 @@
+{
+  "defaults": {
+    "github_repo": "Digital-Process-Tools/claude-remember"
+  },
+  "compact": false,
+  "rtk": false,
+  "allow_outside_cwd": false,
+  "allow_vim_shell": false,
+  "presets": ["github", "git"],
+  "validators": {
+    "ruff": {
+      "cmd": "{python} {supertool_dir}/validators/ruff/ruff.py {file}",
+      "match": "*.py",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "append", "vim"],
+      "rollback_on_fail": false,
+      "timeout": 30
+    },
+    "jsonlint": {
+      "cmd": "{python} {supertool_dir}/validators/jsonlint/jsonlint.py {file}",
+      "match": "*.json",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "append", "vim"],
+      "rollback_on_fail": true,
+      "timeout": 10
+    },
+    "git-status": {
+      "cmd": "{python} {supertool_dir}/validators/git-status/git-status.py {file}",
+      "match": "*",
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "append", "vim"],
+      "rollback_on_fail": false,
+      "timeout": 10
+    }
+  }
+}


### PR DESCRIPTION
Without this file the preset ops — `gh-pr`, `gh-issue`, `git-trail` and the rest — are **not present** when working inside this checkout. That is `claude-supertool#614`; its fix `#617` improved the error message and nothing else.

The workaround has been to drive them from the supertool checkout with a `repo:OWNER/NAME` target. It works, which is precisely why the gap went unfiled through days of daily use — the fallback succeeding is what hides the defect.

## Declared from what this repo contains, not copied

- **`defaults.github_repo`** — the field that makes `gh-*` target the right repo. Getting it wrong is silent and produces confident answers about someone else's PRs, so it is set explicitly rather than inferred at call time.
- **`presets: ["github", "git"]`** — no `xml` (there is none here), no `mcp` or `watch`; both are opt-in, and `watch`'s only radar tier is GitLab-only (`claude-supertool#859`).
- **`allow_outside_cwd: false`, `allow_vim_shell: false`** — `claude-supertool` sets both `true` because it is the tool's own checkout. That is not a default a different repo should inherit; both widen what the tool may do.
- **`ruff` is declared although it is not installed here.** It reports `skipped (ruff not found on PATH — pip install ruff)` rather than passing silently — the three-state contract working as intended. A validator that cannot run must say so.

## Not declared

A **shellcheck** validator, which this repo would genuinely use — 23 shell scripts, and `shellcheck` is installed on the machine — because that validator does not exist yet (`claude-supertool#665`). Worth noting there: this repo is the strongest argument for building it.

## Verified

`gh-issue:226` run from inside this checkout resolves against `Digital-Process-Tools/claude-remember` and returns the right issue. Before this file, the op did not exist here at all.

Related: `claude-supertool#858` proposes an `init` op so the next repo does not need this written by hand.