### PR TITLE
fix(#316): the Bedrock-proxy 401 now reaches the retry that already existed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A Bedrock-proxy install could never save a memory, and the recovery path it needed was already there** ([#316](https://github.com/Digital-Process-Tools/claude-remember/issues/316)) — reported by [@peterurbanec](https://github.com/peterurbanec) with the mechanism traced end to end. `_child_env()` strips every `CLAUDE_CODE_*` var so the child does not look like a resumable parent session, which on a Bedrock install takes `CLAUDE_CODE_USE_BEDROCK` and `CLAUDE_CODE_SKIP_BEDROCK_AUTH` with it; `--setting-sources ''` then stops `~/.claude/settings.json`'s `env` block from putting them back. The nested CLI falls through to the real Anthropic API holding a proxy token, and gets `401 Invalid bearer token`.
+
+  **That is precisely the outage `_isolation_may_be_the_cause` exists to undo** — it retries once without the isolation flag, free, because the call died resolving credentials and nothing was billed. It never fired, because the four spellings in `_AUTH_FAILURE_MARKERS` did not include this one. So every capture on those installs failed, permanently, with the fix one string away and nothing in the log saying so.
+
+  **The tuple gained two entries, not one.** `invalid bearer token` closes the reported case. `failed to authenticate` is the CLI's own prefix for the whole family, and no rate limit or overload can produce it — the narrowness this tuple is documented to want is about not retrying failures that already cost money, and an auth failure never did. The next spelling of this should not need a sixth issue.
+
+  **Pinned by `tests/test_auth_failure_markers_316.py`**, which had nothing to extend: `_isolation_may_be_the_cause` had no test at all, so the negatives are pinned now too — 429, 529, 500 and a low credit balance still return False, because retrying any of those would double a real spend and hide the cause ([#129](https://github.com/Digital-Process-Tools/claude-remember/issues/129)/[#190](https://github.com/Digital-Process-Tools/claude-remember/issues/190)).
+
 ### Changed
 
 - **The lock recorder's own failure notice could abort the save it was measuring** ([#226](https://github.com/Digital-Process-Tools/claude-remember/issues/226)) — `_lock_timing_disclose` in `scripts/lib-lock.sh` picks between the pipeline `log` function and a bare stderr `printf`, and it picked with `command -v log`. That is not the question. The question its own comment states is *did the caller source `log.sh`*, and `command -v` asks whether anything named `log` exists anywhere — **on macOS, the platform `lib-lock.sh` exists for, `/usr/bin/log` is the system logging binary and ships on every machine**. So the function branch was taken unconditionally there, running `/usr/bin/log lock-timing "..."`, which prints a usage block and exits **64**. Under `set -e` — `save-session.sh:56` — that aborts the caller mid-save, with `save.lock` held, leaving the `EXIT` trap to clean up after a save that never finished.

--- a/pipeline/haiku.py
+++ b/pipeline/haiku.py
@@ -440,11 +440,22 @@ _HOOK_ISOLATION_FLAG = "--setting-sources"
 # So isolation fails OPEN: it is dropped, loudly, and the memory record stays
 # protected by the echo guard in consolidate.py. That is why there are two
 # independent layers — this one can be degraded away, and the other cannot.
+#
+# The tuple is a list of spellings, and a list of spellings is never finished:
+# #316 was a Bedrock proxy install where stripping CLAUDE_CODE_USE_BEDROCK and
+# then declining to reload the `env` block left the child sending a proxy token
+# to the real API, which answers "401 Invalid bearer token" — the exact outage
+# this fallback exists for, in words none of the first four markers matched, so
+# capture failed 100% of the time and never retried. "failed to authenticate"
+# is the CLI's own prefix for that whole family; no rate limit or overload can
+# produce it, so it costs nothing and does not need a fifth issue to be filed.
 _AUTH_FAILURE_MARKERS = (
     "not logged in",
     "please run /login",
     "invalid api key",
+    "invalid bearer token",
     "authentication_error",
+    "failed to authenticate",
 )
 
 

--- a/tests/test_auth_failure_markers_316.py
+++ b/tests/test_auth_failure_markers_316.py
@@ -1,0 +1,67 @@
+"""#316 — the isolation fallback must recognise the Bedrock-proxy 401.
+
+`_child_env()` strips every `CLAUDE_CODE_*` var and `--setting-sources ''`
+stops `~/.claude/settings.json`'s `env` block from restoring them, so a
+Bedrock/proxy install loses `CLAUDE_CODE_USE_BEDROCK` in the child and the
+nested CLI talks to the real API with a proxy token. The API answers
+
+    Failed to authenticate. API Error: 401 Invalid bearer token
+
+which is exactly the outage `_isolation_may_be_the_cause` exists to recover
+from — a different spelling of it was simply never in the marker tuple, so
+capture failed 100% of the time on those installs with no retry.
+
+The negative cases are the point of the tuple being narrow: a rate limit or an
+overload already cost money, and retrying them would double a spend while
+hiding the cause (#129/#190).
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from pipeline.haiku import _isolation_may_be_the_cause
+
+
+BEDROCK_401 = (
+    '{"type":"result","subtype":"error_during_execution","is_error":true,'
+    '"result":"Failed to authenticate. API Error: 401 Invalid bearer token"}'
+)
+
+
+def test_bedrock_proxy_401_is_recognised_as_an_isolation_failure():
+    assert _isolation_may_be_the_cause(BEDROCK_401, "") is True
+
+
+def test_bedrock_proxy_401_is_recognised_on_stderr_too():
+    assert _isolation_may_be_the_cause("", "API Error: 401 Invalid bearer token") is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Not logged in",
+        "Please run /login",
+        "Invalid API key · Fix external API key",
+        '{"error":{"type":"authentication_error"}}',
+    ],
+)
+def test_the_auth_failures_that_already_worked_still_do(text):
+    assert _isolation_may_be_the_cause(text, "") is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "API Error: 429 rate_limit_error",
+        "API Error: 529 overloaded_error",
+        "API Error: 500 internal server error",
+        "Credit balance is too low",
+        "",
+    ],
+)
+def test_a_failure_that_already_cost_money_is_never_retried(text):
+    assert _isolation_may_be_the_cause(text, "") is False


### PR DESCRIPTION
Closes #316.

## What was broken

On a Bedrock-proxy install, **capture never succeeded** — not intermittently, always. Reported by @peterurbanec with the mechanism traced end to end, and the trace is correct.

`_child_env()` strips every `CLAUDE_CODE_*` var so the nested CLI does not look like a resumable parent session. On a Bedrock install that takes `CLAUDE_CODE_USE_BEDROCK` and `CLAUDE_CODE_SKIP_BEDROCK_AUTH` with it. `--setting-sources ''` then stops `~/.claude/settings.json`'s `env` block from restoring them. The child falls through to the real Anthropic API holding a proxy token and gets:

```
Failed to authenticate. API Error: 401 Invalid bearer token
```

That is exactly the outage `_isolation_may_be_the_cause` exists to undo — one free retry without the isolation flag, free because the call died resolving credentials and nothing was billed. It never fired: `_AUTH_FAILURE_MARKERS` held four spellings and none of them was this one. Fix one string away, and nothing in the log saying so.

## Verified before building

`haiku.py:458` lowercases the haystack, so a marker must be lowercase; `"invalid bearer token"` was absent from the tuple; `_isolation_may_be_the_cause` therefore returns `False` and the retry is unreachable. Confirmed by reading, then by a red test.

## Two markers, not one

`invalid bearer token` closes the reported case. `failed to authenticate` is the CLI's own prefix for the whole family — no rate limit, overload or credit-balance failure can produce it. The tuple is documented as deliberately narrow, and the reason it is narrow is *not retrying failures that already cost money*; an auth failure never did. This is the judgment call in the diff: the next spelling of this should not need a sixth issue.

## Tests

`_isolation_may_be_the_cause` had **no test at all**, so this adds the first one and pins both directions.

- RED first: the two Bedrock cases failed, 9 pre-existing behaviours already passed.
- GREEN after the marker: 11/11.
- Negatives pinned: 429, 529, 500 and a low credit balance still return `False` — retrying any of those would double a real spend and hide the cause (#129/#190).

Full suite locally: **1487 passed, 43 skipped, coverage 94.26%** (floor 80).
