### PR TITLE
fix(haiku): a marker outside the scanned fields read as no marker at all (#320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The marker scan's list of field names was assumed exhaustive, and the assumption failed silently** ([#320](https://github.com/Digital-Process-Tools/claude-remember/issues/320)) — [#318](https://github.com/Digital-Process-Tools/claude-remember/issues/318) narrowed `_failure_haystack` to the fields the CLI itself authors (`error` / `result` / `message`, the `errors` list, stderr) and kept the raw-stdout fallback behind `if not authored`. That guard needs **every** recognised field to be empty. So a terminal record reporting an auth failure in some field this does not read, while a field it does read holds something benign, is scanned, found clean, and reported as "not an isolation problem" — the un-isolated retry never runs, capture fails permanently, and nothing says why. [#316](https://github.com/Digital-Process-Tools/claude-remember/issues/316)'s outage exactly, reached through the field set instead of through the spelling list.
+
+  **Not a present defect, and it is fixed anyway.** Every input that reproduces it names a field the measured CLI does not emit. The point is that no test asserted the set was exhaustive and no comment recorded it as an assumption, so the day it stopped being true it would have stopped being true in silence — which is the one property this repo keeps paying for.
+
+  **The haystack is deliberately NOT widened.** Scanning the raw blob whenever the authored text holds no marker sounds like the fix and is a different bug: on a failing call the authored fields hold no marker in the ordinary case, so that branch would hand the retry decision back to arbitrary conversation content for essentially every non-auth failure — the whole of what #318 closed, reinstated. Three states instead of two: a marker in a field the CLI authors retries un-isolated, no marker anywhere is silence, and **a marker in the terminal record but outside the scanned set declines and says so**, naming the token, the field it sat in, the fields that were read, and what to do about it. The verdict is unchanged; the silence is what stops.
+
+  **Scoped to the terminal record, not the whole payload.** `_marker_missed_by_the_scan` reads only the last element of the CLI v2 array and only its unrecognised keys. Assistant content is what #318 removed from this decision, and a session that merely discusses an auth failure would otherwise put this notice in front of every ordinary network failure — a warning that fires on the common case is read as noise and stops carrying information.
+
+  Pinned by `tests/test_auth_marker_blind_spot_320.py`, which also holds the field set itself against a literal, so a schema change breaks a test rather than a user's capture. `unknown option` is covered alongside the auth markers: it decides the same retry through the same scan and goes blind the same way.
+
 ## [0.16.0] — When the checker cannot answer
 
 ### Fixed

--- a/pipeline/haiku.py
+++ b/pipeline/haiku.py
@@ -459,6 +459,17 @@ _AUTH_FAILURE_MARKERS = (
 )
 
 
+# The terminal record's fields that the CLI itself authors. This tuple is an
+# assumption about a schema, not a fact about one — it was cross-checked against
+# a measured CLI and against `_failure_detail`, which arrived at the same set
+# independently, and that is the whole of the evidence for it (#320). If the CLI
+# grows a new diagnostic field, everything below still runs and finds nothing,
+# which is why `_marker_missed_by_the_scan` exists: the set being wrong must not
+# be spelled the same way as there being nothing to find.
+_SCANNED_FAILURE_FIELDS = ("error", "result", "message")
+_SCANNED_FAILURE_LIST_FIELDS = ("errors",)
+
+
 def _failure_haystack(stdout: str, stderr: str) -> str:
     """The text the *CLI itself* wrote about why it failed, lowercased.
 
@@ -480,6 +491,15 @@ def _failure_haystack(stdout: str, stderr: str) -> str:
     refusing to look would fail *closed*, which is a permanent silent outage —
     the #316 shape exactly. The fallback applies only when nothing structured was
     found, so a payload that does explain itself is taken at its word.
+
+    **The field set is an assumption and cannot be widened here** (#320). A
+    terminal record that reports an auth failure in a field this does not read,
+    while a field it does read holds something benign, is scanned and found
+    clean — and the fallback cannot fire, because `authored` is non-empty.
+    Scanning the raw blob on that branch instead would restore the very
+    sensitivity to conversation content this docstring opens by rejecting. So
+    the caller reports that case rather than acting on it: see
+    `_marker_missed_by_the_scan`.
     """
     stdout = stdout or ""
     stderr = stderr or ""
@@ -494,19 +514,61 @@ def _failure_haystack(stdout: str, stderr: str) -> str:
 
     authored: list[str] = []
     if isinstance(payload, dict):
-        for key in ("error", "result", "message"):
+        for key in _SCANNED_FAILURE_FIELDS:
             value = payload.get(key)
             if isinstance(value, dict):
                 value = value.get("message")
             if isinstance(value, str) and value.strip():
                 authored.append(value)
-        errors = payload.get("errors")
-        if isinstance(errors, list):
-            authored.extend(e for e in errors if isinstance(e, str))
+        for key in _SCANNED_FAILURE_LIST_FIELDS:
+            values = payload.get(key)
+            if isinstance(values, list):
+                authored.extend(e for e in values if isinstance(e, str))
 
     if not authored:
         return f"{stdout}\n{stderr}".lower()
     return "\n".join(authored + [stderr]).lower()
+
+
+# The tokens that decide the un-isolated retry. Finding one of these outside the
+# scanned fields is the only case worth a line in the log: any other unscanned
+# text is, by construction, text this function was never going to act on.
+_DECIDING_TOKENS = _AUTH_FAILURE_MARKERS + ("unknown option",)
+
+
+def _marker_missed_by_the_scan(stdout: str, haystack: str) -> tuple[str, str] | None:
+    """A deciding token sitting in the terminal record, outside the scanned set.
+
+    Returns ``(token, field)`` or None. Reads **only** the terminal record — the
+    last element of the CLI v2 array, or the whole object — and only its
+    unrecognised keys. Deliberately not the conversation: assistant content is
+    what #318 removed from this decision, and a session that merely discusses an
+    auth failure would otherwise make this fire on every ordinary failure.
+
+    A token already present in ``haystack`` was scanned, so nothing was missed;
+    that also covers the raw-scan fallback, where the haystack is everything.
+    """
+    try:
+        payload = json.loads(stdout or "")
+    except ValueError:
+        return None
+    if isinstance(payload, list):
+        payload = payload[-1] if payload else None
+    if not isinstance(payload, dict):
+        return None
+
+    skip = set(_SCANNED_FAILURE_FIELDS) | set(_SCANNED_FAILURE_LIST_FIELDS)
+    for field, value in payload.items():
+        if field in skip:
+            continue
+        try:
+            text = json.dumps(value, default=str).lower()
+        except (TypeError, ValueError):
+            text = str(value).lower()
+        for token in _DECIDING_TOKENS:
+            if token in text and token not in haystack:
+                return token, field
+    return None
 
 
 def _isolation_may_be_the_cause(stdout: str, stderr: str) -> bool:
@@ -522,7 +584,29 @@ def _isolation_may_be_the_cause(stdout: str, stderr: str) -> bool:
         # disagrees about something we did not just add, and dropping this one
         # would not fix it.
         return _HOOK_ISOLATION_FLAG in haystack
-    return any(marker in haystack for marker in _AUTH_FAILURE_MARKERS)
+    if any(marker in haystack for marker in _AUTH_FAILURE_MARKERS):
+        return True
+
+    # Three states, not two. "No marker in the fields we read" and "the fields
+    # we read are the wrong ones" are different answers, and only the first is
+    # silence. The verdict below is unchanged either way: widening the scan on
+    # this branch would hand every non-auth failure back to the conversation,
+    # which is exactly what #318 closed. So this says so and declines.
+    missed = _marker_missed_by_the_scan(stdout, haystack)
+    if missed:
+        token, field = missed
+        _warn(
+            f"WARNING: this failure carries {token!r} in the terminal record's "
+            f"{field!r} field, which the marker scan does not read. It reads "
+            f"{', '.join(repr(f) for f in _SCANNED_FAILURE_FIELDS)}, the "
+            f"{_SCANNED_FAILURE_LIST_FIELDS[0]!r} list, and stderr (#318). NOT "
+            "retrying without hook isolation on the strength of an unrecognised "
+            "field — that decision may not be reachable from arbitrary content "
+            "(#202). If this is a genuine auth failure, capture is failing "
+            f"permanently and the fix is to add {field!r} to the scanned set: "
+            "please file it against #320."
+        )
+    return False
 
 
 def _build_cmd(tools: list[str] | None, isolate_hooks: bool) -> list[str]:

--- a/tests/test_auth_marker_blind_spot_320.py
+++ b/tests/test_auth_marker_blind_spot_320.py
@@ -1,0 +1,167 @@
+"""#320 — the recognised field set is an assumption, and it must say when it fails.
+
+`_failure_haystack` (#318) narrowed the marker scan to the fields the CLI
+authors — `error` / `result` / `message`, the `errors` list, stderr — and falls
+back to the raw stdout scan only `if not authored`, i.e. only when *every*
+recognised field is empty.
+
+So a terminal record that carries an auth failure in some **new** diagnostic
+field while a recognised field holds something benign is scanned, found clean,
+and reported as "not an isolation problem". The un-isolated retry never runs,
+capture fails permanently, and nothing says why — #316's shape, reached through
+the field set instead of through the spelling list.
+
+The fix is not to widen the haystack. Scanning the raw blob whenever the
+authored text holds no marker hands the decision back to the conversation for
+every non-auth failure, which is the whole of what #318 closed. Three states
+instead of two:
+
+  * a marker in a field the CLI authors      → retry un-isolated (unchanged)
+  * no marker anywhere                        → no retry, silently (unchanged)
+  * a marker in the terminal record but
+    outside the fields we scan                → no retry, and SAY SO
+
+The third is new. The decision stays exactly as narrow as #318 made it; what
+stops is the silence.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from pipeline import haiku
+from pipeline.haiku import _isolation_may_be_the_cause
+
+
+@pytest.fixture
+def warnings(monkeypatch):
+    recorded: list[str] = []
+    monkeypatch.setattr(haiku, "_warn", recorded.append)
+    return recorded
+
+
+UNRECOGNISED_FIELD_AUTH_FAILURE = json.dumps({
+    "type": "result",
+    "subtype": "error_during_execution",
+    "is_error": True,
+    # Recognised, non-empty, and benign — this is what keeps `authored` truthy
+    # and the raw-scan fallback unreachable.
+    "result": "Session ended before a reply was produced.",
+    # Not in the recognised set. The whole point of the issue.
+    # One marker, not two, so the assertion on *which* one is reported is not a
+    # statement about the tuple's iteration order.
+    "diagnostic": "Failed to authenticate: no credentials could be resolved.",
+})
+
+
+def test_a_marker_outside_the_scanned_fields_does_not_silently_read_as_clean(warnings):
+    """The one thing that must not happen: nothing at all."""
+    assert _isolation_may_be_the_cause(UNRECOGNISED_FIELD_AUTH_FAILURE, "") is False
+    assert warnings, (
+        "an auth marker sat in the terminal record and the scan reported "
+        "nothing — the #316 outage with no trace"
+    )
+
+
+def test_the_report_names_the_marker_and_the_fields_that_were_scanned(warnings):
+    _isolation_may_be_the_cause(UNRECOGNISED_FIELD_AUTH_FAILURE, "")
+    message = "\n".join(warnings).lower()
+    assert "failed to authenticate" in message, "the marker it found is not named"
+    assert "diagnostic" in message, "the field it found it in is not named"
+    for scanned in ("error", "result", "message", "errors"):
+        assert scanned in message, f"the scanned set does not name {scanned!r}"
+
+
+def test_reporting_it_does_not_retry_un_isolated(warnings):
+    """The report is a log line, not a decision.
+
+    Widening the haystack here would let any failing call whose recognised
+    fields hold no marker be scanned in full again — including the assistant
+    content #318 removed from this decision.
+    """
+    conversation_quoting_a_marker = json.dumps([
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "you hit 'not logged in'"}]},
+        },
+        {
+            "type": "result",
+            "subtype": "error_during_execution",
+            "is_error": True,
+            "errors": ["connect ECONNREFUSED 127.0.0.1:443"],
+        },
+    ])
+    assert _isolation_may_be_the_cause(conversation_quoting_a_marker, "") is False
+    assert warnings == [], (
+        "the conversation is not the terminal record, and flagging it would "
+        "make the report fire on every ordinary network failure"
+    )
+
+
+def test_an_ordinary_failure_reports_nothing(warnings):
+    stdout = json.dumps({
+        "type": "result",
+        "subtype": "error_during_execution",
+        "is_error": True,
+        "result": "API Error: 429 rate_limit_error",
+        "duration_ms": 812,
+    })
+    assert _isolation_may_be_the_cause(stdout, "") is False
+    assert warnings == []
+
+
+def test_a_recognised_auth_failure_reports_nothing_and_still_retries(warnings):
+    stdout = json.dumps({
+        "type": "result",
+        "subtype": "error_during_execution",
+        "is_error": True,
+        "result": "Failed to authenticate. API Error: 401 Invalid bearer token",
+        "diagnostic": "Failed to authenticate. API Error: 401 Invalid bearer token",
+    })
+    assert _isolation_may_be_the_cause(stdout, "") is True
+    assert warnings == [], "nothing was missed — the marker was in a scanned field"
+
+
+def test_a_flag_rejection_outside_the_scanned_fields_is_reported_too(warnings):
+    """Same blindness, other branch.
+
+    `unknown option` decides the same retry. A CLI that reports a rejected flag
+    in a new field while `result` holds something benign takes the same silent
+    path.
+    """
+    stdout = json.dumps({
+        "type": "result",
+        "is_error": True,
+        "result": "the nested call did not start",
+        "cli_error": "error: unknown option '--setting-sources'",
+    })
+    assert _isolation_may_be_the_cause(stdout, "") is False
+    assert warnings, "a rejected isolation flag went unreported"
+
+
+def test_the_recognised_field_set_is_pinned():
+    """A schema change breaks a test rather than a user's capture (#320, option 1).
+
+    These names are an assumption about the terminal-record schema, not a fact.
+    Adding one is correct; adding one without noticing that #316's recovery
+    depends on the set is not.
+    """
+    assert haiku._SCANNED_FAILURE_FIELDS == ("error", "result", "message")
+    assert haiku._SCANNED_FAILURE_LIST_FIELDS == ("errors",)
+
+
+def test_the_318_narrowing_is_unchanged():
+    """Regression guard: none of the above may widen the haystack."""
+    conversation_only = json.dumps([
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": "invalid api key"}]},
+        },
+        {"type": "result", "is_error": True, "errors": ["ECONNREFUSED"]},
+    ])
+    assert _isolation_may_be_the_cause(conversation_only, "") is False
+    assert _isolation_may_be_the_cause("Not logged in. Please run /login", "") is True


### PR DESCRIPTION
Closes #320

## The assumption that was never pinned

`_failure_haystack` scans a fixed set of fields on the terminal record. The set was three string literals inside a loop — never named, never asserted, and documented as something it is not: the docstring claimed the fallback covers unrecognised payloads, and it does not when a recognised field is non-empty.

So a deciding token arriving in a field nobody listed reads as **no marker present**, which is the same render as a genuinely clean record. The classic shape here: an absence produced by the scan, read as an absence in the world.

**Verified before building**: the issue's own claim that this is not a *present* defect holds — today's terminal-record schema has no unrecognised diagnostic field. Fixed anyway, because nothing stopped the next schema addition from reintroducing it silently.

## Three states, not a wider net

The issue offered widening the fallback — re-scan the raw payload when the authored text holds no marker. **Rejected**, and this is the judgment call worth reading:

on a failing call the authored fields hold no marker in the *ordinary* case. So that branch re-enables the full raw scan for essentially every non-auth failure, and the conversation regains the un-isolated-retry decision — which is the entirety of what #318 closed.

Instead: retry / silence / **decline and say so**. On "no marker found", `_marker_missed_by_the_scan` re-reads only the record's *unrecognised* keys, and if a deciding token sits there it emits a warning naming the token, the field, the scanned set and the fix — then returns `False` unchanged. It reports; it does not decide.

Scoped to the terminal record's unrecognised keys and deliberately **not** to the conversation: otherwise the notice fires on every ordinary network failure in a session that happened to discuss a login problem, and a warning that fires on the common case stops carrying information.

`unknown option` is covered alongside the auth markers — same scan, same decision, same blindness.

## Tests

RED, before the implementation:

```
FAILED tests/test_auth_marker_blind_spot_320.py::test_a_marker_outside_the_scanned_fields_does_not_silently_read_as_clean
FAILED tests/test_auth_marker_blind_spot_320.py::test_the_report_names_the_marker_and_the_fields_that_were_scanned
FAILED tests/test_auth_marker_blind_spot_320.py::test_a_flag_rejection_outside_the_scanned_fields_is_reported_too
FAILED tests/test_auth_marker_blind_spot_320.py::test_the_recognised_field_set_is_pinned
4 failed, 4 passed in 0.35s
```

The four passing are controls that must hold against the unfixed code.

GREEN, full suite:

```
1505 passed, 43 skipped in 852.76s
Total coverage: 94.27%
```

## Platform

Pure `str`/`json` — no paths, no separators, no `subprocess`, no platform-divergent exception types. `pipeline/haiku.py` carries `from __future__ import annotations`, so the new `tuple[str, str] | None` return annotation is not evaluated on the 3.9 floor, and `tests/test_pep604_floor_guard.py` passes.

Green on macOS. **Windows and the 3.9 leg unverified locally** — CI is the check.
