### PR TITLE
fix(save-session): never let compression drop a blocked/pending status

### DIFF
--- a/prompts/save-session.prompt.txt
+++ b/prompts/save-session.prompt.txt
@@ -3,12 +3,13 @@ You are summarizing a Claude Code session for a daily memory log.
 Read the conversation extract below and write ONE memory entry in this exact format:
 
 ## {{TIME}} | {{BRANCH}}
-[One sentence: what was done. Be specific — mention files, MR numbers, issue numbers.]
+[One sentence: what was done. Be specific — mention files, MR numbers, issue numbers. If the work is blocked, incomplete, or waiting on a manual/human step (e.g., missing credentials, a manual upload, human approval), append that status as a short clause in the same sentence — never omit it.]
 
 Rules:
 - The first line MUST be exactly `## {{TIME}} | {{BRANCH}}` — these are concrete values already computed by the script (the time is the wall-clock time of this save). Copy them verbatim. Do NOT invent your own header (e.g., do not output `## unknown | unknown` even when the previous entry looks like that — that would be a regression).
 - ONE sentence only. Short and specific.
 - Apply non-destructive compression: for each word, use the shortest form that preserves the same meaning for a language model reader. Keep all facts, all refs, all specifics — just fewer tokens. Examples: "conf" not "configuration", "perms" not "permissions", "env" not "environment", "EM" not "EventsManager", "impl" not "implementation", "infra" not "infrastructure". Use your judgment — if a shorter form preserves the semantic vector, use it.
+- Blocking, pending, or "not yet live" status is a fact, not filler — never drop it. If work that was done still requires a manual/human step (missing key, manual upload/migration, approval, etc.) before it actually works or is visible, that must survive compression even if the sentence gets longer. Never turn "done, but blocked on X" into just "done."
 - Drop filler: "in order to", "that handle", "for proper", "successfully"
 - No fluff, no preamble — just the entry block
 - Do NOT include markdown fences or any other formatting


### PR DESCRIPTION
## Problem

`prompts/save-session.prompt.txt` compresses each save into exactly one sentence, but has no rule protecting "blocked / pending / not-yet-live" status from being treated as droppable filler alongside things like "successfully" or "in order to".

Real-world hit: a session deployed app code but was explicitly blocked on a manual step (a human running a data upload with credentials the assistant doesn't have access to). The assistant told the user clearly, twice, in chat. The saved `.remember/now.md` entry kept "...deployed" and silently dropped the entire "blocked on you" caveat. The user read the memory entry later, believed the feature was fully live, and only found out otherwise by checking the app directly.

## Fix

Two small, coordinated edits to `prompts/save-session.prompt.txt`, in its existing style:

- The format bracket now explicitly calls out appending blocked/incomplete/waiting-on-a-manual-step status as a short clause in the same sentence.
- A new rule bullet (next to the existing non-destructive-compression rule) states this plainly: blocking/pending/not-yet-live status is a fact, not filler, and must survive compression even if the sentence gets longer.

No changes to the `## {{TIME}} | {{BRANCH}}` header contract, the four `{{PLACEHOLDER}}`s, or the SKIP logic.

## Testing

- `tests/test_prompts.py` — all 10 tests pass unmodified (`python3 -m pytest tests/test_prompts.py -v --no-cov`), including `test_build_save_prompt_with_real_templates`, which loads this exact file.
- `scripts/run-tests.sh` section 6 ("Prompt templates") passes — file exists, `{{TIME}}` placeholder intact.
- Manually built a synthetic prompt via `pipeline.prompts.build_save_prompt()` against a "deployed but blocked on a manual step" transcript and confirmed the new rule text assembles correctly into the final prompt sent to the summarizer.