### PR TITLE
declare batch in .supertool.json, so the op that collapses N calls into one is discoverable

### DIFF
--- a/.supertool.json
+++ b/.supertool.json
@@ -6,28 +6,60 @@
   "rtk": false,
   "allow_outside_cwd": false,
   "allow_vim_shell": false,
-  "presets": ["github", "git"],
+  "presets": [
+    "github",
+    "git"
+  ],
   "validators": {
     "ruff": {
       "cmd": "{python} {supertool_dir}/validators/ruff/ruff.py {file}",
       "match": "*.py",
-      "hooks_into": ["edit", "replace", "replace_lines", "paste", "append", "vim"],
+      "hooks_into": [
+        "edit",
+        "replace",
+        "replace_lines",
+        "paste",
+        "append",
+        "vim"
+      ],
       "rollback_on_fail": false,
       "timeout": 30
     },
     "jsonlint": {
       "cmd": "{python} {supertool_dir}/validators/jsonlint/jsonlint.py {file}",
       "match": "*.json",
-      "hooks_into": ["edit", "replace", "replace_lines", "paste", "append", "vim"],
+      "hooks_into": [
+        "edit",
+        "replace",
+        "replace_lines",
+        "paste",
+        "append",
+        "vim"
+      ],
       "rollback_on_fail": true,
       "timeout": 10
     },
     "git-status": {
       "cmd": "{python} {supertool_dir}/validators/git-status/git-status.py {file}",
       "match": "*",
-      "hooks_into": ["edit", "replace", "replace_lines", "paste", "append", "vim"],
+      "hooks_into": [
+        "edit",
+        "replace",
+        "replace_lines",
+        "paste",
+        "append",
+        "vim"
+      ],
       "rollback_on_fail": false,
       "timeout": 10
+    }
+  },
+  "builtin-ops": {
+    "batch": {
+      "syntax": "batch:@file.json",
+      "description": "Run array of ops in one call. Mix read+edit+grep in one round-trip. Payload: array of {op,...} or {continue_on_error, ops}. A call carries one @- payload, so without this N edits are N calls.",
+      "example": "batch:@.max/ops.json",
+      "hint": true
     }
   }
 }

--- a/.supertool.json
+++ b/.supertool.json
@@ -6,50 +6,26 @@
   "rtk": false,
   "allow_outside_cwd": false,
   "allow_vim_shell": false,
-  "presets": [
-    "github",
-    "git"
-  ],
+  "presets": ["github", "git"],
   "validators": {
     "ruff": {
       "cmd": "{python} {supertool_dir}/validators/ruff/ruff.py {file}",
       "match": "*.py",
-      "hooks_into": [
-        "edit",
-        "replace",
-        "replace_lines",
-        "paste",
-        "append",
-        "vim"
-      ],
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "append", "vim"],
       "rollback_on_fail": false,
       "timeout": 30
     },
     "jsonlint": {
       "cmd": "{python} {supertool_dir}/validators/jsonlint/jsonlint.py {file}",
       "match": "*.json",
-      "hooks_into": [
-        "edit",
-        "replace",
-        "replace_lines",
-        "paste",
-        "append",
-        "vim"
-      ],
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "append", "vim"],
       "rollback_on_fail": true,
       "timeout": 10
     },
     "git-status": {
       "cmd": "{python} {supertool_dir}/validators/git-status/git-status.py {file}",
       "match": "*",
-      "hooks_into": [
-        "edit",
-        "replace",
-        "replace_lines",
-        "paste",
-        "append",
-        "vim"
-      ],
+      "hooks_into": ["edit", "replace", "replace_lines", "paste", "append", "vim"],
       "rollback_on_fail": false,
       "timeout": 10
     }
@@ -57,7 +33,7 @@
   "builtin-ops": {
     "batch": {
       "syntax": "batch:@file.json",
-      "description": "Run array of ops in one call. Mix read+edit+grep in one round-trip. Payload: array of {op,...} or {continue_on_error, ops}. A call carries one @- payload, so without this N edits are N calls.",
+      "description": "Run array of ops in one call. Mix read+edit+grep in one round-trip. Payload: array of {op,...} or {continue_on_error, ops}. A call carries one @- payload, so without this N edits cost N calls.",
       "example": "batch:@.max/ops.json",
       "hint": true
     }


### PR DESCRIPTION
`batch` runs an array of ops in one call. A supertool call carries **one** `@-` payload, so without it N edits cost N calls — and every call re-reads the caller's whole context, which is where the cost actually is.

It was not discoverable from this repo. `.supertool.json` here declares no `builtin-ops` section at all, so `ops` listed **33 entries, every one of them a preset**. An agent working in this repo could not find `batch`, and could not find `read`, `grep` or `edit` either.

Verified before and after, rather than assumed:

```
before:  33 ops listed,  `batch` absent
after:   34 ops listed,  `- `batch:@file.json` — Run array of ops in one call…
```

## Context

`claude-supertool#1124` measured 232 agent transcripts and found **1.45 ops per call** against a documented 6–7, with 70–73% of calls carrying exactly one op. Of the single-op calls, 39% are payload mutations — structurally single unless the author knows `batch`.

That issue's fix (`claude-supertool#1133`) makes `ops` derive its own gaps, so any dispatchable op no config describes names itself. Once that ships, this repo will surface the rest automatically. This adds the one that matters most, now.

## Scope

One key, eight added lines, nothing removed. The wider gap — this repo describes none of the core ops — is left for the derived listing to solve rather than hand-maintained here, since a hand-written list of 36 ops is the thing that rots.
