### PR TITLE
release: 0.19.0 — a compaction is not a new session

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "remember",
   "description": "Continuous memory for Claude Code. Extracts, summarizes, and compresses conversations into tiered daily logs. Claude remembers what you did yesterday.",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "author": {
     "name": "Digital Process Tools"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.19.0] — A compaction is not a new session
 
 ### Changed
 
@@ -19,7 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   **Nothing else narrows.** `startup`, `resume`, `clear` and `fork` are untouched, and so are `=== HANDOFF ===`, `=== LAST HANDOFF ===`, the history hint, the consolidation trigger and the `hooks.d/` dispatches, at every source. `fork` in particular is left at the full recap deliberately: what a fork inherits from its parent's context was not established, and an unverified belief is not grounds for withholding memory. Neither the recovery block nor the capture-gap check branches on `source` — #206 settled that by changing the shape of the evidence store, precisely because a source filter answers the wrong half of that question.
 
+### Added
+
+- **`batch` is declared in `.supertool.json`, so the op that collapses N calls into one is discoverable here** ([#337](https://github.com/Digital-Process-Tools/claude-remember/issues/337)) — the op existed and worked in this repo; nothing advertised it, so every agent working here paid one round-trip per file read. An undeclared op is indistinguishable from an absent one to whoever is deciding how to make the next call.
+
 ### Fixed
+
+- **A save could report work as done while silently dropping "blocked on you"** ([#323](https://github.com/Digital-Process-Tools/claude-remember/pull/323), reported and fixed by [@turbomotioncat](https://github.com/turbomotioncat)) — `prompts/save-session.prompt.txt` compresses each session into one sentence and lists what counts as droppable filler, but nothing protected blocked / pending / not-yet-live status from being compressed away alongside "successfully" and "in order to". A session that deployed application code but was explicitly waiting on a human to run a credentialed data upload was saved as "...deployed". The caveat had been stated twice in the conversation and appeared nowhere in `now.md`; the user read the entry later, believed the feature was live, and found out otherwise from the application.
+
+  **Blocking status is a fact, not filler.** The format bracket now calls for appending blocked / incomplete / waiting-on-a-manual-step status as a clause in the same sentence, and a new rule states plainly that it must survive compression even if the sentence gets longer — "done, but blocked on X" never compresses to "done". Non-destructive compression was always the intent of the rule next to it; this names the class of fact that was being destroyed. The header contract, the four placeholders and the SKIP logic are untouched.
+
+  A memory entry that is wrong is worse than no memory entry, because it is trusted in place of checking. That makes this the plugin's own failure mode rather than a prompt-wording nit.
 
 - **The README version badge had read 0.8.3 for nine releases** ([#335](https://github.com/Digital-Process-Tools/claude-remember/issues/335)) — the release sweep greps for the *outgoing* version when cutting a new one, which finds every site mid-bump and none that stopped being bumped at all. Bumped to match `.claude-plugin/plugin.json` (0.18.0), and `tests/test_version_manifest.py::test_readme_version_badge_matches_code` now pins the badge to the manifest and fails loud if its own pattern stops matching, rather than passing on a badge it never found.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Python](https://img.shields.io/badge/python-3.9%2B-blue)](https://www.python.org/)
 [![OS](https://img.shields.io/badge/tested%20on-Linux%20%7C%20macOS%20%7C%20Windows-blue)](https://github.com/Digital-Process-Tools/claude-remember/actions/workflows/tests.yml)
 [![License](https://img.shields.io/badge/license-Community-brightgreen)](LICENSE)
-[![Version](https://img.shields.io/badge/version-0.18.0-orange)](.claude-plugin/plugin.json)
+[![Version](https://img.shields.io/badge/version-0.19.0-orange)](.claude-plugin/plugin.json)
 
 Claude Code starts every session blank. It doesn't know what you worked on yesterday, what conventions your team follows, or what mistakes it already made. You re-explain everything, every time.
 


### PR DESCRIPTION
Release 0.19.0 — five PRs since v0.18.0 (2026-08-08).

## What ships

| | |
| --- | --- |
| #340 | A compaction no longer re-injects the whole memory recap (#339, reported by @derekwitucki) |
| #323 | A save can no longer drop "blocked on you" while keeping "deployed" (fixed by @turbomotioncat) |
| #338 | Stale `docs/validators.md` citations (#333); README badge pinned to the manifest (#335) |
| #337 | `batch` declared in `.supertool.json` |
| #336 | A cooldown marker ahead of *now* no longer sticks the throttle on permanently (#326, #332) |

Two of the five came from outside the org, which is a first for this tracker.

## The headline change

`SessionStart` fires at every auto-compaction, and the hook read `session_id` out of that payload while discarding `source` — so every memory file was re-`cat`'d into a context that had just been replaced by a summary. The reporter measured `compact` firing about as often as `startup` across 40 days.

At `source=compact` the bodies are no longer repeated, with one exception: `identity.md` works by *presence*, and no other line of the hook's output even names the file. Everything else is named with its byte size rather than dropped — #124's vocabulary for "kept but not injected", because a recap that shrinks in silence is indistinguishable from a store that emptied.

**Unrecognised input runs the old way.** No `source`, an empty value, a spelling from a future release, or no stdin at all all fall through to today's full output. An absence read as `compact` would silently stop injecting memory for anyone whose payload shape differs from the one the heuristic was written against — the failure this plugin exists to prevent.

## Two CHANGELOG entries added here, not in their own PRs

#323 and #337 merged without one, so they would have shipped unrecorded. #323 is an external contributor's fix, and the CHANGELOG is where that shows up. Both entries are written in this release commit rather than backfilled into merged PRs.

## Release mechanics

Three version sites, all at `0.19.0`: `.claude-plugin/plugin.json`, the README badge, and the CHANGELOG heading. `tests/test_version_manifest.py` — 5 passed locally. A residual sweep for `0.18.0` across all tracked files (no extension allowlist, per #335's lesson) returns nothing outside `CHANGELOG.md`.

The `plugin.json` bump **silently no-matched on the first attempt** and was caught by reading the file back rather than by trusting the edit's exit. That is the half-bumped release the version guards exist to prevent, and the read-back is what found it.

## Gates

- `main` green at leg level on `e506937` — 12/12, one workflow declared (`tests`), one dispatched, none unaccounted for.
- Gate zero: board triaged, every open issue carries a priority. Nothing blocking.
- Security audit of `v0.18.0..e506937`: **round 1 in flight — this does not merge until it reports.** An audit that did not run must never read as an audit that found nothing.
- No cohort freeze: this repo has no `cohort-*` mechanism, verified rather than assumed.
