### PR TITLE
Never publish 120/50 as configured, and never lose a listener, on a store logs/ cannot write

### DIFF
--- a/changelog.d/358.fixed.md
+++ b/changelog.d/358.fixed.md
@@ -1,0 +1,8 @@
+- Fixed: a memory store whose `logs/` directory could not be created (a
+  read-only mount, a permission error) was silently publishing a cooldown of
+  120 seconds and a delta threshold of 50 lines to the env-resolution cache
+  as though `config.json` had asked for exactly that, overriding whatever a
+  user had actually configured until they next edited their config. The
+  publish is now skipped entirely on a store that could not resolve those two
+  values, in `scripts/user-prompt-hook.sh` and `scripts/post-tool-hook.sh`.
+  (#358)

--- a/changelog.d/361.fixed.md
+++ b/changelog.d/361.fixed.md
@@ -1,0 +1,9 @@
+- Fixed: the very first tool call of a session (and the first after any
+  config edit) could print 22 lines of Apple's `/usr/bin/log` usage text to
+  stderr and `dispatch: command not found`, from a `PostToolUse` hook
+  documented to always exit 0 -- and an installed `after_post_tool` listener
+  silently did not run on that call. `scripts/post-tool-hook.sh`'s slow path
+  now guards `log` and `dispatch` the same way its fast path already did
+  (`declare -F`, not `type`, because macOS's own `log` binary makes `type
+  log` true either way); the same unguarded `dispatch` call in
+  `scripts/user-prompt-hook.sh`'s slow path is fixed alongside it. (#361)

--- a/scripts/lib-env-cache.sh
+++ b/scripts/lib-env-cache.sh
@@ -175,6 +175,21 @@ _remember_env_cache_publish() {
     [ -n "${REMEMBER_DIR:-}" ] || return 0
     [ -n "${PROJECT_DIR:-}" ] || return 0
     [ -n "${PIPELINE_DIR:-}" ] || return 0
+    # log.sh returns early — before it ever sets these two — on a store whose
+    # logs/ dir it cannot create (#358). Two of this function's three callers
+    # (user-prompt-hook.sh, post-tool-hook.sh's slow path) source log.sh with
+    # stderr suppressed and call this unconditionally, so an early return left
+    # both variables unset here, not merely absent from config. Defaulting them
+    # below in that case would publish 120/50 as though config had said so, and
+    # the load side cannot tell that apart from a real answer — both are
+    # digits. Required here, not defaulted, same rule _remember_env_cache_load
+    # already applies to the same two keys and for the same reason (#301):
+    # skip the whole publish rather than write a cache the load side would
+    # accept but is really a stand-in for a chain that never ran. A cache one
+    # write cycle stale is the ordinary case anywhere in this file; a cache
+    # that lies about config is the thing #358 exists to refuse.
+    [ -n "${REMEMBER_SAVE_COOLDOWN:-}" ] || return 0
+    [ -n "${REMEMBER_DELTA_THRESHOLD:-}" ] || return 0
     _remember_env_cache_path || return 0
 
     local _f="$_REMEMBER_ENV_CACHE_FILE" _t="${_REMEMBER_ENV_CACHE_FILE}.$$"
@@ -191,8 +206,12 @@ _remember_env_cache_publish() {
         printf 'REMEMBER_DIR=%s\n' "$REMEMBER_DIR"
         printf 'REMEMBER_TZ=%s\n' "${REMEMBER_TZ:-}"
         printf 'REMEMBER_PROMPT_STAMP=%s\n' "${REMEMBER_PROMPT_STAMP:-full}"
-        printf 'REMEMBER_SAVE_COOLDOWN=%s\n' "${REMEMBER_SAVE_COOLDOWN:-120}"
-        printf 'REMEMBER_DELTA_THRESHOLD=%s\n' "${REMEMBER_DELTA_THRESHOLD:-50}"
+        # No `:-120`/`:-50` fallback here — the guard above already refused to
+        # reach this line unless both were actually set by log.sh, and a
+        # default at the point of writing is exactly the silent stand-in
+        # #358 was filed about.
+        printf 'REMEMBER_SAVE_COOLDOWN=%s\n' "$REMEMBER_SAVE_COOLDOWN"
+        printf 'REMEMBER_DELTA_THRESHOLD=%s\n' "$REMEMBER_DELTA_THRESHOLD"
         printf 'MEMORY_PROJECT_DIR=%s\n' "${MEMORY_PROJECT_DIR:-$PROJECT_DIR}"
         printf 'CACHE_CONFIG=%s\n' "${PIPELINE_DIR}/config.json"
         printf 'CACHE_CONFIG=%s\n' "${HOME:-}/.remember/config.json"

--- a/scripts/post-tool-hook.sh
+++ b/scripts/post-tool-hook.sh
@@ -215,6 +215,14 @@ else
     # run since the last config edit, which on a long agentic turn is a hundred
     # tool calls away.
     _remember_env_cache_publish
+    # log.sh returns early on a store it cannot create a logs/ dir in — before
+    # it defines log() — so the source succeeding above is not the same
+    # question as `log` existing (#361). The fast path already carries this
+    # exact guard, for the exact reason given there: `declare -F`, not `type`,
+    # because `type log` is true on macOS whether or not a function was
+    # defined — /usr/bin/log is Apple's unified logging CLI, and a hook
+    # documented "EXIT CODES: 0 Always" must not shell out to it.
+    declare -F log >/dev/null 2>&1 || log() { :; }
     log "hook" "post-tool: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR PYTHON=$PYTHON REMEMBER_DIR=$REMEMBER_DIR"
 fi
 
@@ -631,6 +639,13 @@ if [ -n "$HOOK_STDIN" ] && _after_post_tool_listener; then
     fi
 fi
 
+# Same hazard as the `log` guard above: log.sh may have returned early,
+# before it defined dispatch() (#361). A hook documented "EXIT CODES: 0
+# Always" must not shell out to a "command not found" here either. This one
+# guard covers both branches above it — the fast path already stubs
+# dispatch() unconditionally, so `declare -F` is already true there, and this
+# is a no-op on that path.
+declare -F dispatch >/dev/null 2>&1 || dispatch() { :; }
 dispatch "after_post_tool"
 
 [ -n "$_hook_stdin_file" ] && rm -f "$_hook_stdin_file" 2>/dev/null

--- a/scripts/user-prompt-hook.sh
+++ b/scripts/user-prompt-hook.sh
@@ -87,6 +87,14 @@ if [ "$_REMEMBER_FAST" = "0" ]; then
     _remember_env_cache_publish
 fi
 
+# log.sh returns early — before it defines dispatch() — on a store whose
+# logs/ dir it cannot create. That leaves dispatch() undefined on this branch
+# only (the fast path above already stubs it unconditionally), and this hook
+# is documented "EXIT CODES: 0 Always": it must not shell out to a
+# "command not found" for a listener nobody has to install (adjacent to
+# #361, same mechanism, this file's own unguarded call).
+declare -F dispatch >/dev/null 2>&1 || dispatch() { :; }
+
 # --- Notices for the human (#200, #253) ───────────────────────────────────
 # Other hooks leave a file here when they find something the HUMAN has to know
 # and the model cannot act on. They are delivered from this hook rather than

--- a/tests/test_env_cache_publish_unwritable_logs_358.py
+++ b/tests/test_env_cache_publish_unwritable_logs_358.py
@@ -1,0 +1,126 @@
+"""#358: a cache publish on a store whose logs/ dir cannot be created bakes in
+120/50 as though config had said so.
+
+log.sh (scripts/log.sh) returns early — before it ever sets
+REMEMBER_SAVE_COOLDOWN or REMEMBER_DELTA_THRESHOLD — on a store whose logs/
+directory it cannot create. `_remember_env_cache_publish`
+(scripts/lib-env-cache.sh) used to default both keys at the point of writing
+(`${REMEMBER_SAVE_COOLDOWN:-120}`), so an unwritable store published exactly
+the same digits a real 120-second / 50-line config would, and the load side's
+validation (scripts/lib-env-cache.sh's digit check) cannot tell a default from
+an answer — both are just digits.
+
+user-prompt-hook.sh's slow path (the one every session's first prompt takes,
+before anything is cached) sources log.sh with stderr suppressed and calls
+`_remember_env_cache_publish` unconditionally, which is why this is
+reproduced through that hook rather than by calling the shell function
+directly — the settling experiment the issue itself proposes.
+
+Every "must not publish a lie" assertion below is paired with a "must publish
+the real answer" control in the same fixture: a store that CAN write its logs
+and has a NON-default cooldown configured must have that cooldown reach the
+cache, or "no cache was written" would be indistinguishable from "the hook
+never ran".
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.test_post_tool_fast_path_350 import PROMPT_HOOK, _env, _project
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="chmod-based unwritability and bash hook subprocess are not "
+    "portable to Windows runners; POSIX permission bits do not model an "
+    "ACL-unwritable directory there the way they do here.",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _cache_files(tmpdir: Path):
+    return sorted(Path(tmpdir).glob("remember-env-*"))
+
+
+def _run_prompt_hook(env: dict):
+    return subprocess.run(
+        ["bash", str(PROMPT_HOOK)], capture_output=True, env=env, timeout=60,
+        check=False,
+    )
+
+
+def test_an_unwritable_logs_dir_does_not_publish_a_default_cooldown_as_config(tmp_path):
+    """The issue's own settling experiment: chmod the store so log.sh's
+    `mkdir -p logs` fails, configure a cooldown that is NOT 120, fire
+    user-prompt-hook.sh (the first-prompt / slow-path caller), and check what
+    reached the published cache.
+
+    Note the directory has to be ABSENT for chmod to matter here: log.sh's own
+    `[ ! -d "$REMEMBER_LOG_DIR" ] &&` guard (added for #230) skips the `mkdir`
+    call entirely when logs/ already exists, so chmod 000 on an
+    already-created logs/ directory changes nothing (measured directly against
+    this fixture before writing this test — the cache came back with the
+    configured 999, not a default, because log.sh never even tried to
+    mkdir). What #358 is about is the directory not existing yet and being
+    impossible to create — the CI-relevant, first-run case — so this makes
+    the PARENT unwritable and leaves logs/ absent, which is what actually
+    fails `mkdir -p`.
+
+    Root only: `chmod` on a directory you own does not stop root from
+    creating entries inside it, so this assertion cannot hold under a root
+    test runner. Skipped rather than silently passing there.
+    """
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("root ignores directory write permission bits — chmod-based "
+                    "unwritability does not reproduce as this user")
+
+    home, project, remember = _project(
+        tmp_path, cooldown_ts=int(time.time()),
+        config={"cooldowns": {"save_seconds": 999}},
+    )
+    env = _env(tmp_path, home, project)
+
+    logs = remember / "logs"
+    assert not logs.exists(), "fixture invariant: logs/ must not exist yet"
+    remember.chmod(0o555)  # readable + traversable, NOT writable: mkdir fails
+    try:
+        result = _run_prompt_hook(env)
+    finally:
+        remember.chmod(0o755)
+
+    assert result.returncode == 0, (
+        "documented EXIT CODES: 0 Always — got " + str(result.returncode)
+        + ": " + repr(result.stderr[:600])
+    )
+
+    cache_files = _cache_files(Path(env["TMPDIR"]))
+    assert not cache_files, (
+        "a store that could not create logs/ still published an env cache: "
+        + repr([f.read_text(encoding="utf-8") for f in cache_files])
+        + " — REMEMBER_SAVE_COOLDOWN/REMEMBER_DELTA_THRESHOLD were never set "
+        "by log.sh on this run, so any value written for them is a silent "
+        "default masquerading as a configured answer"
+    )
+
+    # POSITIVE CONTROL, same fixture: once logs/ CAN be created, the same
+    # project — same non-default 999 in config.json — publishes for real.
+    result2 = _run_prompt_hook(env)
+    assert result2.returncode == 0, repr(result2.stderr[:600])
+    cache_files2 = _cache_files(Path(env["TMPDIR"]))
+    assert cache_files2, (
+        "no cache was published even once the store could write its logs — "
+        "this fixture cannot tell a real fix from a hook that stopped "
+        "publishing altogether"
+    )
+    body = cache_files2[0].read_text(encoding="utf-8")
+    assert "REMEMBER_SAVE_COOLDOWN=999" in body, (
+        "the healthy run did not publish the configured cooldown (999) — "
+        "got: " + repr(body)
+    )

--- a/tests/test_post_tool_fast_path_350.py
+++ b/tests/test_post_tool_fast_path_350.py
@@ -540,3 +540,73 @@ def test_an_executable_listener_takes_the_slow_path_and_is_dispatched(tmp_path):
         "the after_post_tool listener was never dispatched — the fast path "
         "stubbed out dispatch() for a user who had installed one"
     )
+
+
+def test_the_slow_path_does_not_exec_system_log_or_call_undefined_dispatch(tmp_path):
+    """#361: the fast path above already guards `log` (`declare -F log`) and
+    stubs `dispatch()` outright. The SLOW path — taken by every session's
+    FIRST tool call, because there is no cache yet to replay — guarded
+    neither: it sourced log.sh with stderr suppressed and then called `log`
+    and `dispatch` unconditionally.
+
+    Reproduced exactly as
+    ``test_a_store_that_cannot_hold_a_log_does_not_exec_the_system_log_binary``
+    does — logs/ as a FILE, the cheapest cross-platform way to make log.sh's
+    `mkdir -p` fail — but deliberately WITHOUT ``_prime(env)`` first, so this
+    run actually takes the slow path instead of the fast one that test (and
+    the one it's modeled on, at line ~448) restricts itself to. The issue's
+    own claim was that dropping ``_prime`` from that fixture makes it fail
+    today; verified directly against this branch's pre-fix tree before the
+    guard below was added — it did.
+
+    Paired with a positive control in the same fixture, on the same project
+    and the same installed listener: a HEALTHY store still dispatches to it.
+    That is the difference between a fallback for a chain that failed and a
+    stub that would silently swallow every real listener too.
+    """
+    home, project, remember = _project(tmp_path, cooldown_ts=int(time.time()))
+    plugin = tmp_path / "plugin"
+    subprocess.run(["cp", "-R", str(REPO_ROOT), str(plugin)], check=True,
+                   capture_output=True)
+    listener_dir = plugin / "hooks.d" / "after_post_tool"
+    listener_dir.mkdir(parents=True, exist_ok=True)
+    witness = tmp_path / "listener-ran"
+    listener = listener_dir / "50-witness.sh"
+    listener.write_text("#!/bin/bash\ntouch " + str(witness) + "\n", encoding="utf-8")
+    listener.chmod(0o755)
+
+    env = _env(tmp_path, home, project, {"CLAUDE_PLUGIN_ROOT": str(plugin)})
+    # No _prime(): this IS the first tool call of a session — the case #361
+    # measured — and there is nothing yet to make it take the fast path.
+
+    logs = remember / "logs"
+    if logs.exists():
+        shutil.rmtree(logs)
+    logs.write_text("not a directory", encoding="utf-8")
+
+    result = _run(env)
+    _reap(remember)
+
+    assert result.returncode == 0, (
+        "documented EXIT CODES: 0 Always — got " + str(result.returncode)
+        + ": " + repr(result.stderr[:600])
+    )
+    assert b"Unknown subcommand" not in result.stderr, (
+        "the slow path shelled out to the system `log` binary instead of "
+        "its own no-op — stderr: " + repr(result.stderr[:600])
+    )
+    assert b"dispatch: command not found" not in result.stderr, (
+        "the slow path called an undefined dispatch() — stderr: "
+        + repr(result.stderr[:600])
+    )
+
+    # POSITIVE CONTROL: a HEALTHY store, same listener, still dispatches —
+    # the guard above is a fallback for a broken chain, not a permanent stub.
+    logs.unlink()
+    result2 = _run(env)
+    _reap(remember)
+    assert result2.returncode == 0, repr(result2.stderr[:400])
+    assert witness.exists(), (
+        "the #361 guard disabled dispatch on the healthy path too — an "
+        "installed after_post_tool listener no longer runs at all"
+    )

--- a/tests/test_prompt_hook_spawns.py
+++ b/tests/test_prompt_hook_spawns.py
@@ -210,6 +210,73 @@ def test_editing_the_config_is_not_ignored_by_a_warmed_hook(tmp_path):
     assert "JST" in after.stdout, f"expected Tokyo time. Got: {after.stdout!r}"
 
 
+# ── The slow path must not lose a listener, or crash trying (#358/#361 adjacent) ──
+
+def test_an_unwritable_logs_dir_does_not_break_after_user_prompt_dispatch(tmp_path):
+    """log.sh returns early -- before it defines dispatch() -- on a store
+    whose logs/ dir it cannot create. The fast path above stubs dispatch()
+    unconditionally and never reaches log.sh at all, but installing an
+    after_user_prompt listener forces the SLOW path here (see the `[ ! -d ]`
+    gate in scripts/user-prompt-hook.sh), and that path used to call
+    `dispatch "after_user_prompt"` with no guard -- the same mechanism #361
+    fixed for post-tool-hook.sh's own slow path, found adjacent to it while
+    fixing #358 in this same file.
+
+    Reproduced by making the PARENT of logs/ unwritable rather than logs/
+    itself: log.sh's own `[ ! -d ]` check (#230) skips the `mkdir` entirely
+    once logs/ already exists, so an existing-but-chmod-000 directory changes
+    nothing -- what actually fails `mkdir -p` is the directory being ABSENT
+    with an unwritable parent.
+
+    Paired with a positive control in the same fixture: once the store CAN
+    write its logs, the same installed listener still fires. Root only:
+    chmod does not stop root from creating entries in its own directory, so
+    this cannot reproduce as that user.
+    """
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("root ignores directory write permission bits — chmod-based "
+                    "unwritability does not reproduce as this user")
+
+    home, project = _project(tmp_path)
+    remember = project / ".remember"
+    plugin = tmp_path / "plugin"
+    subprocess.run(["cp", "-R", str(REPO_ROOT), str(plugin)], check=True,
+                   capture_output=True)
+    listener_dir = plugin / "hooks.d" / "after_user_prompt"
+    listener_dir.mkdir(parents=True, exist_ok=True)
+    witness = tmp_path / "listener-ran"
+    listener = listener_dir / "50-witness.sh"
+    listener.write_text("#!/bin/bash\ntouch " + str(witness) + "\n", encoding="utf-8")
+    listener.chmod(0o755)
+
+    env = _env(home, project, {"CLAUDE_PLUGIN_ROOT": str(plugin)})
+
+    logs = remember / "logs"
+    assert not logs.exists(), "fixture invariant: logs/ must not exist yet"
+    remember.chmod(0o555)
+    try:
+        result = _run(env)
+    finally:
+        remember.chmod(0o755)
+
+    assert result.returncode == 0, (
+        "documented EXIT CODES: 0 Always — got " + str(result.returncode)
+        + ": " + repr(result.stderr[:600])
+    )
+    assert "dispatch: command not found" not in result.stderr, (
+        "the slow path called an undefined dispatch() — stderr: "
+        + repr(result.stderr[:600])
+    )
+
+    # POSITIVE CONTROL, same fixture: a healthy store still dispatches.
+    result2 = _run(env)
+    assert result2.returncode == 0, repr(result2.stderr[:600])
+    assert witness.exists(), (
+        "the guard disabled dispatch on the healthy path too — an installed "
+        "after_user_prompt listener no longer runs at all"
+    )
+
+
 # ── Portability: two implementations, one output ──────────────────────────────
 
 def _stamp_via(env_extra: dict, fmt: str = "+%H:%M %Z") -> subprocess.CompletedProcess:


### PR DESCRIPTION
Both issues were filed by the release audit of v0.20.0..HEAD as `misreports`. Both are the same shape: `scripts/log.sh` returns early, before it sets anything, on a store whose `logs/` directory it cannot create -- and two call sites downstream trusted that it had.

## #358 -- a fabricated cooldown/threshold

`_remember_env_cache_publish()` in `scripts/lib-env-cache.sh` used to write `REMEMBER_SAVE_COOLDOWN`/`REMEMBER_DELTA_THRESHOLD` with shell defaults (`${VAR:-120}`, `${VAR:-50}`) even when log.sh never set them. So an unwritable store silently published 120/50 into the env-resolution cache as though `config.json` had asked for exactly that -- and the load side cannot tell a default from a real answer, because both are just digits. Fixed by refusing the whole publish (`return 0`, no file written) unless both variables are genuinely non-empty, and removing the now-redundant `:-120`/`:-50` defaults from the printf lines, so a default at the point of writing can never happen again.

## #361 -- log/dispatch called on an undefined function

`scripts/post-tool-hook.sh`'s fast path already guarded a `log` call with `declare -F log >/dev/null 2>&1 || log() { :; }` -- not `type log`, because on macOS `/usr/bin/log` (Apple's unified logging CLI) makes `type log` true whether or not a shell function exists -- and stubbed `dispatch()` outright. Its SLOW path, taken by every session's first tool call because there is nothing yet to replay, called both unconditionally. On a store whose `logs/` cannot be created that shells out to the real `log` binary (22 lines of usage text on stderr) and then hits `dispatch: command not found`, from a hook documented "EXIT CODES: 0 Always" -- and an installed `after_post_tool` listener silently never runs. Fixed with the identical guard on the slow path's `log` call and a single `declare -F dispatch` guard placed right before the one `dispatch "after_post_tool"` call site (which correctly covers both branches -- a no-op on the fast path, where dispatch is already stubbed).

## Adjacent, fixed in the same commit

While reproducing #361, the identical unguarded `dispatch "after_user_prompt"` call turned up in `scripts/user-prompt-hook.sh`'s own slow path (reached only when a user has installed an `after_user_prompt` listener AND the store cannot write `logs/` -- a narrower window than post-tool-hook.sh's, but the same file already open for #358's guard, the same mechanism, and a one-line fix). Given its own test (`tests/test_prompt_hook_spawns.py::test_an_unwritable_logs_dir_does_not_break_after_user_prompt_dispatch`), verified red before the fix and green after. Flagging it explicitly here rather than letting it ride silently: this is outside both issues' own text, in scope only because it is the same subsystem and the same file.

## The judgment calls the brief asked me to make and state

**Shared helper or not:** I did not add one shared guard function used by both #358 and #361's fixes. #358 guards a *publish* (a value that outlives the process and must never lie); #361 guards a *call* (a function invocation that must never crash or shell out to a system binary). They are checked with the same primitive (`declare -F` / `[ -n ]` non-empty checks) but at different call sites with different consequences on failure, and a shared helper risked collapsing that distinction -- guarding the cheap half (the call) with the same weight as the expensive half (the durable file), or vice versa. Each fix is local to its own call site.

**What the guard does when it fires:** #358 skips the publish entirely rather than publishing without the two keys -- the load side (`_remember_env_cache_load`) already requires both keys non-empty and all-digits, so a cache missing them would be refused on load anyway; skipping the write outright is strictly cheaper for the identical outcome. #361 stubs `log`/`dispatch` as no-ops rather than exiting non-zero (unlike session-start-hook.sh's own `exit 127` guard for the same underlying hazard) -- both post-tool-hook.sh and user-prompt-hook.sh are documented "EXIT CODES: 0 Always", and post-tool-hook.sh in particular must never block a tool call. An installed listener silently does not run on this one degraded call, which is the same tradeoff #358 makes (a stale-but-honest cache beats a live-but-fabricated one; a call that is silently skipped once beats a hook that crashes the agent's tool call).

## Below-bar finding, in this same body

While reading `scripts/post-tool-hook.sh` around the fix, I noticed the FATAL echo in `scripts/log.sh` at the point of the early return (`echo "FATAL: cannot create $REMEMBER_LOG_DIR" >&2`) reaches the terminal unredirected on exactly the slow-path first-call case this PR fixes noise for -- it is not wrong, and it is the one honest signal a user gets that their store is broken, but it is one more line of stderr on an already-noisy failure mode nobody asked me to quiet further. I judged this below the bar to file or fix: it is a single honest diagnostic line, not a defect, and touching it would be a scope decision (should a hook this degraded print anything at all?) the two issues did not ask for. No class-level reachable bug here -- just a true statement worth having on record.

Closes #358
Closes #361


## Verified by the maintainer

Independent red re-run, because the lane's own red is a claim I did not watch. Built a detached worktree at `main` (`df3e35c`), checked out **only** the three test files from `fix/358` onto it so every source fix was absent, and ran them:

```
FAILED tests/test_env_cache_publish_unwritable_logs_358.py::test_an_unwritable_logs_dir_does_not_publish_a_default_cooldown_as_config
FAILED tests/test_post_tool_fast_path_350.py::test_the_slow_path_does_not_exec_system_log_or_call_undefined_dispatch
FAILED tests/test_prompt_hook_spawns.py::test_an_unwritable_logs_dir_does_not_break_after_user_prompt_dispatch
3 failed, 26 passed, 1 skipped
```

Three failures, one per fix — including the adjacent `user-prompt-hook.sh` one, which is the fix nobody filed an issue for and therefore the one with the weakest external check. The 26 pre-existing tests in those same files still passed with the fixes absent, which is the positive control: the harness was working, so the three failures are the tests biting rather than a broken run.

Observed on darwin / Python 3.13.15. The `logs/`-unwritable premise is built with POSIX permission semantics; whether it reproduces on Windows is **reasoned, not observed**.

Pre-flight premise checked before dispatch and both issues were still open against the code: `declare -F log` matched at `post-tool-hook.sh:201` (the fast-path guard the issue says exists), and did not match at the slow path or at either publish site.
