### PR TITLE
fix: guard session-end-hook.sh log/report_error calls the same way #365 fixed the other two hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ All four are registered together, from `hooks/hooks.json`, when the session star
 
 A flush failure (missing `python3`, a Haiku call that errors) is reported via the same channel `/remember:doctor` already reads (`hook-errors.log`) rather than swallowed silently, unlike the plugin's other hooks — this one is the last chance a session gets, so a failure here has nowhere left to retry from. Because the flush is backgrounded, that report lands once the background process finishes, not synchronously with the hook itself — the same trade the git-backup hook's own detached push already makes.
 
+A store that could never be created at all (a read-only or otherwise unwritable project root) is a narrower case than a flush failure — there is no `hook-errors.log` to write to, because the directory that would hold it is the one that failed. That one warning goes to this hook's own stderr instead ([#372](https://github.com/Digital-Process-Tools/claude-remember/issues/372)); it will not show up in `/remember:doctor`.
+
 ## Diagnostics (`/remember:doctor`)
 
 Prints resolved paths, detected tools, storage mode, whether the session directory Claude Code actually created matches the slug the plugin computes, when the last successful save happened, and whether `PostToolUse` has ever fired for this project. Each line is prefixed `OK` / `WARN` / `FAIL`, ending in a one-line verdict.

--- a/changelog.d/372.fixed.md
+++ b/changelog.d/372.fixed.md
@@ -1,0 +1,15 @@
+- Fixed: a store whose `.remember/logs/` could never be created (a
+  read-only or otherwise unwritable project root) made `SessionEnd` report
+  nothing at all -- `scripts/session-end-hook.sh` sourced `log.sh` with
+  stderr suppressed and then called `log`/`report_error` unguarded, both of
+  which `log.sh` returns before defining on exactly this path. On macOS the
+  first call also shelled out to Apple's `/usr/bin/log` binary (`type log`
+  is true whether or not a shell function exists), and the second failed
+  outright with `report_error: command not found` -- silently, because the
+  hook is documented `EXIT CODES: 0 Always` and a `command not found` does
+  not change that. `session-end-hook.sh` now carries the same `declare -F`
+  guard `post-tool-hook.sh` and `user-prompt-hook.sh` already do (#361), and
+  on this one path -- the last chance a session gets to report a failed
+  flush -- the fallback still writes a `WARNING` line to stderr rather than
+  going silent, since `hook-errors.log` and the notice channel both live
+  under the same directory that could not be created. (#372)

--- a/scripts/session-end-hook.sh
+++ b/scripts/session-end-hook.sh
@@ -159,7 +159,8 @@ source "$PIPELINE_DIR/scripts/log.sh" 2>/dev/null
 # Unlike the no-op stubs the hot paths install, these two still have to
 # report SOMETHING: this is the one file whose own docstring (EXIT CODES,
 # above) promises a failed flush is "reported loudly ... rather than
-# swallowed silently", and line 158 below is reachable only when this source
+# swallowed silently", and the `report_error` call further down (guarding
+# the `[ ! -d "$REMEMBER_DIR" ]` branch) is reachable only when this source
 # has already failed for that exact reason. log.sh's own log() documents
 # "Falls back to stderr if log file is unwritable" — this reproduces exactly
 # that fallback, because it is the same fallback for the same reason:

--- a/scripts/session-end-hook.sh
+++ b/scripts/session-end-hook.sh
@@ -145,6 +145,35 @@ REMEMBER_PATHS_SOFT_FAIL=1 source "$_HOOK_DIR/resolve-paths.sh" || exit 0
 source "$_HOOK_DIR/detect-tools.sh"
 source "$_HOOK_DIR/bootstrap-dirs.sh"
 source "$PIPELINE_DIR/scripts/log.sh" 2>/dev/null
+# log.sh returns early on a store it cannot create a logs/ dir in — before it
+# defines log(), report_error() or dispatch() — so the source succeeding
+# above is not the same question as those existing (#361, #372). Same guard
+# post-tool-hook.sh and user-prompt-hook.sh already carry, for the same
+# reason: `declare -F`, NOT `type` or `command -v` — on macOS /usr/bin/log is
+# Apple's unified-logging CLI, so `type log` is true whether or not a shell
+# function was ever defined, the guard would pass, and the stub below would
+# never be installed: `log "hook" "..."` two lines down would instead exec
+# that binary, dump its own usage text to stderr, and exit 64 from a hook
+# documented "EXIT CODES: 0 Always". Measured on bash 3.2.57 (macOS).
+#
+# Unlike the no-op stubs the hot paths install, these two still have to
+# report SOMETHING: this is the one file whose own docstring (EXIT CODES,
+# above) promises a failed flush is "reported loudly ... rather than
+# swallowed silently", and line 158 below is reachable only when this source
+# has already failed for that exact reason. log.sh's own log() documents
+# "Falls back to stderr if log file is unwritable" — this reproduces exactly
+# that fallback, because it is the same fallback for the same reason:
+# $REMEMBER_DIR/logs is what could not be created. hook-errors.log and the
+# notices channel user-prompt-hook.sh reads (#200, #253) are both files under
+# that same directory, so neither is reachable here; stderr is the only
+# channel left, and bootstrap-dirs.sh only redirects it into hook-errors.log
+# once that directory exists (bootstrap-dirs.sh:230-231) — on this path it is
+# still going wherever Claude Code sends an unredirected hook's stderr,
+# which is not nowhere.
+declare -F log >/dev/null 2>&1 || log() {
+    printf '%s [%s] %s\n' "$(_remember_date +%H:%M:%S)" "$1" "$2" >&2
+}
+declare -F report_error >/dev/null 2>&1 || report_error() { log "$1" "$2"; }
 log "hook" "session-end: reason=$SESSION_END_REASON session=${STDIN_SESSION_ID:-unresolved}"
 
 # bootstrap-dirs.sh's mkdir is best-effort, and by the time this line runs it

--- a/tests/test_session_end_hook_345.py
+++ b/tests/test_session_end_hook_345.py
@@ -248,6 +248,13 @@ class TestFailSoftContract:
             "nothing failed, so nothing should be reported\n" + result.stderr
         )
 
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root ignores the read-only mode bits this test depends on "
+               "(same guard as tests/test_bootstrap_readonly_root.py and "
+               "friends) -- mkdir would succeed anyway, and the fixture "
+               "assertion below would fail for an unrelated reason",
+    )
     def test_must_fire_unwritable_store_reports_a_warning(self, tmp_path):
         """#372: when the store genuinely cannot be created -- not merely
         missing, but its parent is unwritable so bootstrap-dirs.sh's own

--- a/tests/test_session_end_hook_345.py
+++ b/tests/test_session_end_hook_345.py
@@ -236,3 +236,50 @@ class TestFailSoftContract:
         result = _run_hook(plugin, env, session_id=sid)
 
         assert result.returncode == 0, subprocess_failure_detail(result, project / ".remember")
+        # Positive control for test_must_fire_unwritable_store_reports_a_warning
+        # below (#372): bootstrap-dirs.sh's mkdir succeeds here (the project
+        # dir is fully writable), so REMEMBER_DIR is recreated and nothing
+        # went wrong -- no WARNING belongs on stderr. Without this half, an
+        # assertion that the warning fires elsewhere would be unfalsifiable:
+        # a broken harness that always prints WARNING would pass that test
+        # too.
+        assert "WARNING" not in result.stderr, (
+            "the store was recreated successfully (mkdir is writable here) -- "
+            "nothing failed, so nothing should be reported\n" + result.stderr
+        )
+
+    def test_must_fire_unwritable_store_reports_a_warning(self, tmp_path):
+        """#372: when the store genuinely cannot be created -- not merely
+        missing, but its parent is unwritable so bootstrap-dirs.sh's own
+        mkdir also fails -- log.sh returns before defining log() or
+        report_error() at all. Reaching line 158 requires exactly this: the
+        hook's own docstring (EXIT CODES) promises the failure is "reported
+        loudly ... rather than swallowed silently", and a `command not found`
+        does not change the exit status, so returncode alone cannot tell a
+        real report from total silence.
+        """
+        env, project, plugin, _calls, sid = _make_env(tmp_path, exchanges=1, humans=1)
+        _wire_hook(plugin)
+        shutil.rmtree(project / ".remember")
+        os.chmod(project, 0o555)
+        try:
+            result = _run_hook(plugin, env, session_id=sid)
+        finally:
+            # Restore before any fixture cleanup (tmp_path teardown) tries to
+            # remove a now-read-only directory.
+            os.chmod(project, 0o755)
+
+        assert result.returncode == 0, subprocess_failure_detail(result, project / ".remember")
+        assert not (project / ".remember").exists(), (
+            "the fixture must actually fail to create the store, or this test "
+            "proves nothing about the degraded path"
+        )
+        assert "command not found" not in result.stderr, (
+            "report_error (or log) was called while genuinely undefined -- "
+            "the declare -F guard is missing or bypassed\n" + result.stderr
+        )
+        assert "WARNING" in result.stderr, (
+            "a store that could never be created must be reported, not "
+            "swallowed into the same silent no-op as a session with nothing "
+            "new to flush\n" + result.stderr
+        )


### PR DESCRIPTION
Closes #372.

## What was broken

`scripts/session-end-hook.sh` sources `scripts/log.sh` with stderr suppressed and then calls `log`/`report_error` unguarded (lines 148, 158, 164, 209). `log.sh` returns before it defines `log()`, `report_error()` or `dispatch()` when it cannot create `$REMEMBER_DIR/logs` -- so on a store that can never be created, both calls hit an undefined function. On macOS `log` additionally resolves to Apple's `/usr/bin/log` unified-logging CLI even when undefined as a shell function (`type log` is true either way), so the first call dumps 19 lines of usage text to stderr and exits 64; the second, `report_error`, fails outright with `command not found`. Neither changes the hook's exit status, which stays 0 either way -- so this was fully silent to anything that only checks `returncode`, including `/remember:doctor`, which reads `hook-errors.log` and reports nothing wrong.

Sibling hooks `post-tool-hook.sh` and `user-prompt-hook.sh` already carry a `declare -F` guard for exactly this (#365, added 15 minutes before #368 registered this fourth hook without it) -- `declare -F`, not `type`/`command -v`, is required specifically because of the macOS `/usr/bin/log` collision.

## The judgment call

Unlike the no-op stubs the hot paths in the other two hooks install, the fallback here is not a no-op: `session-end-hook.sh`'s own docstring (EXIT CODES) promises a failed flush is "reported loudly ... rather than swallowed silently", and the guarded `report_error` call is reachable *only* on the path where that promise is being broken. `log.sh`'s own `log()` documents "Falls back to stderr if log file is unwritable" -- the stub reproduces exactly that fallback, for exactly that reason: `hook-errors.log` and the notices channel `user-prompt-hook.sh` reads (#200, #253) both live under `$REMEMBER_DIR`, the same directory that failed to get created, so stderr is the only channel actually available. Confirmed by reading `bootstrap-dirs.sh:225-231`, which only redirects this hook's own stderr into `hook-errors.log` once that directory exists.

## Tests

The existing test at `tests/test_session_end_hook_345.py:227` (`test_missing_remember_dir_on_a_real_project_still_exits_zero`) removes `.remember` but leaves the project directory itself writable -- `bootstrap-dirs.sh`'s `mkdir -p` recreates it successfully, so this test never actually reaches the guarded `report_error` call, contrary to a literal reading of the issue's framing. Verified empirically. It is now the paired must-not-fire positive control (`"WARNING" not in result.stderr`).

A new test, `test_must_fire_unwritable_store_reports_a_warning`, chmods the project directory itself to `0o555` after removing `.remember`, which genuinely forces `bootstrap-dirs.sh`'s `mkdir` to fail. Watched red against the unfixed script (reproducing `log: Unknown subcommand 'hook'` then `report_error: command not found`, exactly the issue's mechanism) and green against the fix.

The sibling at line 200 (`test_no_project_at_all_still_exits_zero`) does **not** have the same defect: with no `CLAUDE_PROJECT_DIR`, `resolve-paths.sh`'s soft-fail mode exits the hook at line 144, before `log.sh` is even sourced -- a different, pre-existing, out-of-scope early-exit path. Left unmodified.

## Review

Both spawned reviewers (Explore + oss:auditor) converged on the same finding: the new must-fire test's `os.chmod(0o555)` technique had no root-uid skip guard, unlike five sibling test files in this repo that use the identical technique. root ignores directory write-permission bits, so under a root CI runner the test would fail for an unrelated reason instead of skipping. Fixed with the matching `@pytest.mark.skipif(hasattr(os, "geteuid") and os.geteuid() == 0, ...)` guard, in a second commit, along with a stale "line 158" reference in the new guard's own comment (drifted after other comment lines were added around it).

Below-bar item (no reachable caller beyond a doc nicety): none.

## Docs

`README.md` (the repo's only `docs_targets` entry) gets two new sentences distinguishing this narrow "store could never be created at all" case from the broader flush-failure case the file already documents -- the warning here goes to stderr, not `hook-errors.log`, and will not show up in `/remember:doctor`. A changelog fragment is at `changelog.d/372.fixed.md`, checked with `.oss/assemble_changelog.py --check`.
