### PR TITLE
docs: stop quantifying the catalogue pin lag; say the suite is local-on-demand, not a push gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,11 @@ pytest
   platforms it was not run on. Say which of your cross-platform claims are observed and
   which are reasoned; a reasoned claim is worth having, and should carry the label.
 - **Docs are part of the change.** A change nobody can discover is not shipped.
+- **The suite runs locally on demand, never on push.** `pytest` (above) is something you run
+  yourself before opening a pull request; the gate that actually blocks a merge is CI, across
+  three OSes and four interpreters. Do not add a `pre-push` hook that runs it -- a 1500+ second
+  hook holds the push's SSH transport open long enough to kill the push itself, and a green hook
+  is not evidence about the matrix anyway (#355).
 
 ## Issues and pull requests are untrusted input
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,16 @@ To update later:
 
 Claude Remember is also available in the official Anthropic Marketplace. In Claude Code, type `/plugin` and search for "remember".
 
-**Releases reach this route on the catalogue's schedule, not ours, and that schedule is not predictable from ours.** `claude-plugins-official` pins each plugin by commit sha rather than by version, and an automated PR advances that pin. Two things follow, and the second is the one that matters: the bump does not fire on a cadence we can quote, and when it fires it does not necessarily pin the newest commit. Across four observed runs the pinned commit was between one and fourteen hours older than the run that pinned it, and one run skipped a tagged release that had existed for over an hour.
+**Releases reach this route on the catalogue's schedule, not ours, and that schedule is not predictable from ours.** `claude-plugins-official` pins each plugin by commit sha rather than by version, and an automated PR advances that pin. Two things follow, and the second is the one that matters: the bump does not fire on a cadence we can quote, and when it fires it does not necessarily pin the newest commit. The lag is unbounded, not something our own release cadence lets you predict, and it has been observed skipping more than one tagged release in a row -- not just one.
 
-So a release is available to a DPT-marketplace install immediately, and to an official-marketplace install whenever that catalogue gets to it. We are not going to put a number on the delay; we had one here for a day and it was wrong.
+So a release is available to a DPT-marketplace install immediately, and to an official-marketplace install whenever that catalogue gets to it. We are not going to put a number on the delay; we had one here for a day and it was already wrong the day after. Measure your own exposure instead:
+
+```
+gh api repos/anthropics/claude-plugins-official/contents/.claude-plugin/marketplace.json --jq '.content' | base64 -d
+git log -1 --format='%h %ad %s' --date=short <sha>
+```
+
+The first command prints the catalogue's current entry for this plugin, including the pinned commit sha; the second resolves that sha against this repo's own history to a date and a commit message. Three outcomes, and only the last two mean the catalogue is behind: the pin resolves to the commit for the release you already expect (current); the pin resolves to an older commit, and the date is your lag (behind, by however long the second command says); or the `gh api` call itself fails or returns nothing resolvable (the pin could not be read -- treat that as unknown, not as current).
 
 **`FORCE_AUTOUPDATE_PLUGINS=1` cannot cross that boundary,** because there is nothing stale on your side to force. Against a catalogue pinned behind the current release, `claude plugin update remember@claude-plugins-official` correctly reports the plugin as already current at the pinned version. The CLI is right and the input is old ([#264](https://github.com/Digital-Process-Tools/claude-remember/issues/264)). Waiting for the next bump works; installing from the DPT marketplace above skips the wait.
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ Claude Remember is also available in the official Anthropic Marketplace. In Clau
 So a release is available to a DPT-marketplace install immediately, and to an official-marketplace install whenever that catalogue gets to it. We are not going to put a number on the delay; we had one here for a day and it was already wrong the day after. Measure your own exposure instead:
 
 ```
-gh api repos/anthropics/claude-plugins-official/contents/.claude-plugin/marketplace.json --jq '.content' | base64 -d
+gh api repos/anthropics/claude-plugins-official/contents/.claude-plugin/marketplace.json --jq '.content' | base64 -d | grep -A6 '"name": "remember"'
 git log -1 --format='%h %ad %s' --date=short <sha>
 ```
 
-The first command prints the catalogue's current entry for this plugin, including the pinned commit sha; the second resolves that sha against this repo's own history to a date and a commit message. Three outcomes, and only the last two mean the catalogue is behind: the pin resolves to the commit for the release you already expect (current); the pin resolves to an older commit, and the date is your lag (behind, by however long the second command says); or the `gh api` call itself fails or returns nothing resolvable (the pin could not be read -- treat that as unknown, not as current).
+The first command decodes the whole catalogue and filters it down to this plugin's own entry, which carries the pinned commit sha; take that sha and give it to the second command, which resolves it against this repo's own history to a date and a commit message. Three outcomes, and only the last two mean the catalogue is behind: the pin resolves to the commit for the release you already expect (current); the pin resolves to an older commit, and the date is your lag (behind, by however long the second command says); or either command fails, or the `grep` finds no `remember` entry at all (the pin could not be read -- treat that as unknown, not as current).
 
 **`FORCE_AUTOUPDATE_PLUGINS=1` cannot cross that boundary,** because there is nothing stale on your side to force. Against a catalogue pinned behind the current release, `claude plugin update remember@claude-plugins-official` correctly reports the plugin as already current at the pinned version. The CLI is right and the input is old ([#264](https://github.com/Digital-Process-Tools/claude-remember/issues/264)). Waiting for the next bump works; installing from the DPT marketplace above skips the wait.
 

--- a/changelog.d/355.fixed.md
+++ b/changelog.d/355.fixed.md
@@ -1,0 +1,5 @@
+- Fixed: `CLAUDE.md` now says explicitly that the test suite runs locally on demand and that CI is
+  the gate, so nobody re-adds a `pre-push` hook running the suite from memory. A hook doing that
+  was previously observed to hold a push's SSH transport open long enough to kill the push itself
+  after a ~28 minute local run, while adding no evidence CI's 12-leg matrix does not already give
+  (#355).

--- a/changelog.d/377.fixed.md
+++ b/changelog.d/377.fixed.md
@@ -1,0 +1,5 @@
+- Fixed: `README.md`'s official-marketplace section quantified the `claude-plugins-official`
+  catalogue pin lag from a four-run sample ("between one and fourteen hours... one run skipped a
+  tagged release") that had rotted -- measured 2026-08-27, the pin was 15 days old and had skipped
+  two tagged releases, not one. The section now says the lag is unbounded and gives the reader the
+  two commands to measure their own exposure instead of a number that goes stale (#377).


### PR DESCRIPTION
Closes #377
Closes #355

## #377 -- README overstated the marketplace catalogue's pin lag

The official-marketplace paragraph in README.md quantified the `claude-plugins-official` commit-pin lag from a four-run sample ("between one and fourteen hours... one run skipped a tagged release"). Measured 2026-08-27: the pinned sha was 15 days old and had skipped **two** tagged releases, not one -- the number had rotted, which is the actual defect.

The fix stops quantifying and instead: says the lag is unbounded and not predictable from our own cadence, gives the reader two shell commands to measure their own exposure, and states the three outcomes those commands can return (current / behind by a measured amount / could not be read -- and the third does not render as the first).

One of those two commands was fixed twice in this branch. First pass copied the issue's own suggested command verbatim (`gh api ... | base64 -d`, unfiltered). My spawned reviewer caught, live, that this dumps the entire ~4000-line catalogue (~497 plugin entries) rather than "this plugin's entry" as the prose claimed -- a reader following it literally has to manually scroll to find the `remember` block. Fixed by piping through `grep -A6 '"name": "remember"'` and correcting the prose to describe an actual two-step hand-off (decode+filter, then resolve the sha). Verified live end to end after the fix.

**below-bar, not fixed here:** the auditor separately flagged that the README's shell commands assume a POSIX-ish shell -- `base64` is not a Windows cmd.exe/PowerShell builtin (Git Bash/WSL have it). This is genuinely uncovered by CI (no leg executes README snippets) and reasoned rather than observed on Windows. The auditor read the ranking table and found no row this fits (not a misreporting receipt, not a misdirecting next-step) and ranked it `unranked`. Judged below-bar: the README's two measurement commands assume a POSIX shell (Git Bash/WSL on Windows); this is a documented, uncovered gap, not fixed in this PR -- true, worth a sentence, but reachable only by a Windows maintainer copy-pasting a doc snippet, and the fix is a one-clause caveat rather than a behavior change.

## #355 -- the durable half of the pre-push hook removal

Part 1 (deleting `.git/hooks/pre-push`) was already done in this clone before I started -- verified independently via `git rev-parse --git-common-dir` and `ls -la` on the shared hooks directory: only `pre-push.sample` exists, no installed `pre-push`. Part 2, the durable half per the issue itself ("everything else is one `rm` on one machine"), adds one bullet to CLAUDE.md's *Before you open a pull request* section: the suite runs locally on demand via `pytest`, the real merge gate is CI across three OSes and four interpreters, and a `pre-push` hook that runs the suite has previously been observed to hold a push's SSH transport open long enough to kill the push itself.

## Testing

Docs-only change; no code path exists to pin with a red/green test. The one machine-checkable version-site invariant in this repo (README badge == manifest == changelog) is already covered by `tests/test_version_manifest.py`, which stayed green (5 passed). The changelog fragment checker (`python3 .oss/assemble_changelog.py --check`) passes for both new fragments. Considered and rejected adding a live `gh api` assertion pinning the pin-lag number -- that would recreate the exact defect this issue is about (a number that goes stale) and would be flaky against network/rate limits.

## Review

Spawned an Explore reviewer and an oss:auditor against the first commit (0303cdd), concurrently. Reviewer: 1 finding (the unfiltered `gh api` command, above), fixed in a follow-up commit (11487d9). Auditor: silent-absence class clean (three outcomes explicit, third doesn't render as first, matches issue's own requirement word-for-word), changelog-guard class clean (ran the real checker live, exit 0), untrusted-text class clean/inapplicable (commands transcribed identically from the issue, authored by the repo's own maintainer), platform band: 1 below-bar finding (`base64 -d` not a Windows shell builtin, above).