### PR TITLE
Prune stale per-session delivery records; keep session-start-hook.sh's printed lines ASCII (#373, #367)

### DIFF
--- a/changelog.d/367.fixed.md
+++ b/changelog.d/367.fixed.md
@@ -1,0 +1,9 @@
+- Fixed: `scripts/session-start-hook.sh` printed four lines containing a U+2014
+  em-dash directly to stdout/stderr. What a cp1252 Windows console does with
+  them was unestablished -- either mojibake, or a decode failure one layer up
+  in whoever consumes this hook's stdout -- and neither outcome could be
+  observed without a Windows machine. Decided file-wide rather than per-line,
+  as the issue argued: this file's printed (echo/printf) lines may not carry
+  non-ASCII at all, so the four are now plain ASCII (`--` in place of the
+  em-dash). The file's other ~94 em-dashes, all in comments that never reach
+  a stream, are untouched (#367).

--- a/changelog.d/373.fixed.md
+++ b/changelog.d/373.fixed.md
@@ -8,4 +8,7 @@
   `remember.<session_id>.md` handoff, which survives on purpose (#221) --
   that coupling would have reintroduced unbounded growth under a new name.
   When the session directory itself cannot be read, nothing is pruned:
-  could-not-tell-if-the-session-is-over must never render as "pruned" (#373).
+  could-not-tell-if-the-session-is-over must never render as "pruned". The
+  sweep runs regardless of the CURRENT session's own `handoff_mode`, so a
+  record left over from an earlier `per_session` period is still pruned
+  after switching back to `single` (#373).

--- a/changelog.d/373.fixed.md
+++ b/changelog.d/373.fixed.md
@@ -1,0 +1,11 @@
+- Fixed: with `handoff_mode: "per_session"`, every session left a
+  `remember.delivered.<session_id>` record behind in `$REMEMBER_DIR/tmp` and
+  nothing ever removed one -- the same directory, and the same class of leak,
+  that #362 already fixed once under a different filename.
+  `session-start-hook.sh` now prunes a session's delivery record once that
+  session's own transcript is confirmed gone from Claude Code's own session
+  directory. The record is deliberately NOT coupled to its paired
+  `remember.<session_id>.md` handoff, which survives on purpose (#221) --
+  that coupling would have reintroduced unbounded growth under a new name.
+  When the session directory itself cannot be read, nothing is pruned:
+  could-not-tell-if-the-session-is-over must never render as "pruned" (#373).

--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -576,7 +576,7 @@ _remember_write_case_divergence() {
             # nobody reads. It is still never rendered as agreement anywhere
             # that reports it; `/remember:doctor` says it every time.
             [ "$_old" = "$_body" ] && return 0
-            log "case-divergence" "could not check whether this store is known by a second spelling (disk=$REMEMBER_CASE_DISK_STATE${REMEMBER_CASE_DISK_REASON:+/$REMEMBER_CASE_DISK_REASON} git=$REMEMBER_CASE_GIT_STATE${REMEMBER_CASE_GIT_REASON:+/$REMEMBER_CASE_GIT_REASON}) — this is not a report that they agree"
+            log "case-divergence" "could not check whether this store is known by a second spelling (disk=$REMEMBER_CASE_DISK_STATE${REMEMBER_CASE_DISK_REASON:+/$REMEMBER_CASE_DISK_REASON} git=$REMEMBER_CASE_GIT_STATE${REMEMBER_CASE_GIT_REASON:+/$REMEMBER_CASE_GIT_REASON}) -- this is not a report that they agree"
             ;;
     esac
     return 0
@@ -756,7 +756,7 @@ if [ -z "$CURRENT_SESSION_ID" ]; then
     # (#144, #263, #266). doctor reports the marker.
     printf '%s\n' "the SessionStart payload carried no usable session_id" \
         > "$CAPTURE_SKIPPED" 2>/dev/null || true
-    log "hook" "session-start: capture-gap check skipped — no session_id on stdin"
+    log "hook" "session-start: capture-gap check skipped -- no session_id on stdin"
 else
     rm -f "$CAPTURE_SKIPPED" 2>/dev/null || true
 
@@ -1043,10 +1043,18 @@ fi
 #     doubt the safe direction is the one #221 already chose for the
 #     handoff itself: keep, never guess-delete.
 #
-# Legacy (un-namespaced) mode never reaches here: the glob below only ever
-# matches "remember.delivered.<something>", and the shared-mode file is
-# exactly "remember.delivered" with no trailing dot.
-if [ -n "$PER_SESSION_HANDOFF" ] && [ -d "$SESSIONS_DIR" ] && [ -d "$REMEMBER_DIR/tmp" ]; then
+# Runs regardless of THIS session's own handoff_mode -- not gated on
+# $PER_SESSION_HANDOFF. Gating it there was considered and rejected: a
+# record left behind during a PAST per_session period does not stop
+# existing the moment a user switches handoff_mode back to "single", and a
+# sweep that only ran while per_session was the CURRENT setting would leak
+# exactly those records forever -- the same accumulation this fix exists to
+# stop, just gated behind a config toggle instead of eliminated.
+#
+# Legacy (un-namespaced) mode never matches the glob below regardless: it
+# only ever matches "remember.delivered.<something>", and the shared-mode
+# file is exactly "remember.delivered" with no trailing dot.
+if [ -d "$SESSIONS_DIR" ] && [ -d "$REMEMBER_DIR/tmp" ]; then
     for _remember_stale_record in "$REMEMBER_DIR"/tmp/remember.delivered.*; do
         [ -f "$_remember_stale_record" ] || continue
         _remember_stale_id="${_remember_stale_record##*/remember.delivered.}"

--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -84,7 +84,7 @@ source "$PLUGIN_ROOT/scripts/log.sh" 2>/dev/null
 # diagnostic up front. Exit 127 (command-missing) to match the degraded-env
 # contract that tolerates rc in (0, 127), not a bare 1.
 if ! command -v _remember_date >/dev/null 2>&1; then
-    echo "session-start-hook: ERROR — failed to source $PLUGIN_ROOT/scripts/log.sh" >&2
+    echo "session-start-hook: ERROR -- failed to source $PLUGIN_ROOT/scripts/log.sh" >&2
     exit 127
 fi
 TODAY=$(_remember_date '+%Y-%m-%d')
@@ -771,7 +771,7 @@ else
     if [ -n "$PREV_ID" ] && [ "$REPORTED_ID" != "$PREV_ID" ] \
        && ! capture_was_seen "$PREV_ID" \
        && grep -q '"tool_use"' "$PREV_JSONL" 2>/dev/null; then
-        echo "remember: your previous session was not captured. If you just installed or enabled the plugin, that is expected — capture starts now. Otherwise its hooks were not registered for that session; run /remember:doctor." \
+        echo "remember: your previous session was not captured. If you just installed or enabled the plugin, that is expected -- capture starts now. Otherwise its hooks were not registered for that session; run /remember:doctor." \
             > "$REMEMBER_DIR/tmp/capture-gap-notice" 2>/dev/null || true
         printf '%s' "$PREV_ID" > "$CAPTURE_REPORTED" 2>/dev/null || true
     fi
@@ -862,7 +862,7 @@ if [ "$REMEMBER_ROOT" != "$PROJECT_DIR" ] || [ -n "$PER_SESSION_HANDOFF" ]; then
     echo "=== HANDOFF ==="
     echo "Write next handoff to: $REMEMBER_HANDOFF"
     if [ -n "$HANDOFF_MODE_DEGRADED" ]; then
-        echo "(handoff_mode is \"per_session\", but no session_id reached this hook — writing to the shared file above, not a per-session one.)"
+        echo "(handoff_mode is \"per_session\", but no session_id reached this hook -- writing to the shared file above, not a per-session one.)"
     fi
     echo ""
 fi
@@ -1000,7 +1000,7 @@ if [ -f "$REMEMBER_HANDOFF" ] && [ -s "$REMEMBER_HANDOFF" ]; then
             # one source that can deliver "08".
             DELIVERIES=$((10#$DELIVERIES + 1))
         fi
-        echo "[already delivered ${DELIVERIES} times since ${FIRST_DELIVERED:-an earlier session} — no new handoff has been written since, so this is pending replacement, not news. You may already have acted on it. Running /remember replaces it.]"
+        echo "[already delivered ${DELIVERIES} times since ${FIRST_DELIVERED:-an earlier session} -- no new handoff has been written since, so this is pending replacement, not news. You may already have acted on it. Running /remember replaces it.]"
     else
         DELIVERIES=1
         FIRST_DELIVERED=$(_remember_date '+%Y-%m-%d %H:%M')
@@ -1015,6 +1015,49 @@ elif [ -f "$REMEMBER_HANDOFF_STATE" ]; then
     # describes content that no longer exists, and keeping it would mislabel a
     # future handoff that happens to fingerprint the same.
     rm -f "$REMEMBER_HANDOFF_STATE"
+fi
+
+# ── Prune stale per-session delivery records (#373) ───────────────
+# handoff_mode: per_session writes one remember.delivered.<session_id> per
+# session (above) and nothing else in this codebase ever removes one -- the
+# same class of leak #362 already fixed once, in the same directory, under a
+# different filename ("could not tell" was not a state that leak had; this
+# one does, because a delivery record's own session might still be live).
+#
+# Coupling this to the paired remember.<session_id>.md handoff slot was
+# considered and rejected: that slot survives forever ON PURPOSE (#221), so a
+# sweep keyed to it would reintroduce unbounded growth under a new name.
+# Coupled instead to the one fact that actually answers "is this session
+# over": whether Claude Code's own transcript for that session id still
+# exists under $SESSIONS_DIR -- the same directory `previous_transcript`
+# above already reads. A transcript still on disk means the session could
+# still resume and write another handoff; one that is gone means the session
+# is gone in every way this hook can observe.
+#
+# Three states, not two, matching the record left behind:
+#   - transcript confirmed ABSENT  -> record is pruned
+#   - transcript confirmed PRESENT -> record is kept (not a bug: correct
+#     under the coupling above)
+#   - $SESSIONS_DIR cannot be listed at all -> nothing is touched.
+#     Could-not-tell must never render as either of the other two, so on
+#     doubt the safe direction is the one #221 already chose for the
+#     handoff itself: keep, never guess-delete.
+#
+# Legacy (un-namespaced) mode never reaches here: the glob below only ever
+# matches "remember.delivered.<something>", and the shared-mode file is
+# exactly "remember.delivered" with no trailing dot.
+if [ -n "$PER_SESSION_HANDOFF" ] && [ -d "$SESSIONS_DIR" ] && [ -d "$REMEMBER_DIR/tmp" ]; then
+    for _remember_stale_record in "$REMEMBER_DIR"/tmp/remember.delivered.*; do
+        [ -f "$_remember_stale_record" ] || continue
+        _remember_stale_id="${_remember_stale_record##*/remember.delivered.}"
+        [ -n "$_remember_stale_id" ] || continue
+        # Never sweep the record this very invocation just wrote.
+        [ "$_remember_stale_id" = "$CURRENT_SESSION_ID" ] && continue
+        if [ ! -e "$SESSIONS_DIR/$_remember_stale_id.jsonl" ]; then
+            rm -f "$_remember_stale_record" 2>/dev/null
+        fi
+    done
+    unset _remember_stale_record _remember_stale_id
 fi
 
 # ── History hint ───────────────────────────────────────────────────────────

--- a/tests/test_delivery_record_pruning_373.py
+++ b/tests/test_delivery_record_pruning_373.py
@@ -1,0 +1,188 @@
+"""Regression tests for #373: with handoff_mode: "per_session",
+remember.delivered.<session_id> files accumulate forever in
+$REMEMBER_DIR/tmp -- nothing ever pruned them, the same directory (and
+class of leak) #362 already fixed once, under a different filename.
+
+The chosen coupling is deliberately NOT the paired remember.<session_id>.md
+handoff slot -- that survives forever on purpose (#221), so tying the
+record's life to it would reproduce unbounded growth under a new name. It is
+coupled instead to the one fact that actually answers "is this session
+over": whether Claude Code's own transcript for that session id still
+exists under $SESSIONS_DIR (the same directory session-start-hook.sh already
+reads via `previous_transcript`).
+
+Three states, tested here as three cases over one fixture shape:
+  - the session's transcript is gone -> its delivery record is pruned
+    (the "must fire" case)
+  - the session's transcript still exists -> its delivery record survives
+    (the paired "must not fire" case -- the positive control that a broken
+    or over-eager sweep would fail)
+  - $SESSIONS_DIR itself cannot be listed at all -> nothing is pruned,
+    because "could not tell whether the session is over" must never render
+    as either "pruned" or "confirmed still active"
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash subprocess + POSIX session-start hook -- not portable to Windows runners (#79)",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SESSION_START_SCRIPT = REPO_ROOT / "scripts" / "session-start-hook.sh"
+
+from pipeline.slug import session_dir_slug as _slug
+
+
+def _sandbox(tmp_path: Path):
+    project = tmp_path / "proj"
+    project.mkdir(parents=True)
+    home = tmp_path / "home"
+    (home / ".remember").mkdir(parents=True)
+
+    cfg = {"features": {"recovery": False}, "handoff_mode": "per_session", "data_dir": ".remember"}
+    (home / ".remember" / "config.json").write_text(json.dumps(cfg))
+
+    slug = _slug(str(project))
+    sessions_dir = home / ".claude" / "projects" / slug
+    sessions_dir.mkdir(parents=True)
+
+    remember_dir = project / ".remember"
+    remember_dir.mkdir(parents=True, exist_ok=True)
+    return project, home, remember_dir, sessions_dir
+
+
+def _payload(session_id: str) -> str:
+    return json.dumps({
+        "session_id": session_id,
+        "transcript_path": f"/does/not/matter/{session_id}.jsonl",
+        "hook_event_name": "SessionStart",
+        "source": "startup",
+        "cwd": "/does/not/matter",
+    })
+
+
+def _session_start(project: Path, home: Path, session_id: str | None) -> str:
+    env = {
+        **os.environ,
+        "CLAUDE_PROJECT_DIR": str(project),
+        "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
+        "HOME": str(home),
+    }
+    kwargs = {"env": env, "capture_output": True, "text": True, "timeout": 60}
+    if session_id is not None:
+        kwargs["input"] = _payload(session_id)
+    else:
+        kwargs["stdin"] = subprocess.DEVNULL
+    result = subprocess.run(
+        ["bash", str(SESSION_START_SCRIPT)], check=False, **kwargs
+    )
+    assert result.returncode == 0, f"hook exited {result.returncode}: {result.stderr[:500]}"
+    return result.stdout
+
+
+def _seed_delivery_record(remember_dir: Path, session_id: str) -> Path:
+    """A per-session handoff plus one delivered-once run against it -- the
+    ordinary way a remember.delivered.<id> record comes to exist."""
+    (remember_dir / f"remember.{session_id}.md").write_text(
+        f"Handoff for {session_id}.\n"
+    )
+    record = remember_dir / "tmp" / f"remember.delivered.{session_id}"
+    return record
+
+
+class TestStaleDeliveryRecordsArePruned:
+
+    def test_record_for_a_session_with_no_transcript_is_pruned(self, tmp_path):
+        """MUST FIRE: session AAA delivered once and left a record behind;
+        its transcript is gone (never existed, or was cleaned up elsewhere).
+        The next session start must remove AAA's stale record."""
+        project, home, remember_dir, _sessions_dir = _sandbox(tmp_path)
+
+        out_a = _session_start(project, home, "sess-aaa")
+        assert "Handoff for" not in out_a  # nothing written yet on first run
+
+        record_a = _seed_delivery_record(remember_dir, "sess-aaa")
+        # Deliver it once for real, so the record this test prunes is the
+        # genuine artifact the hook itself writes, not a hand-built stand-in.
+        _session_start(project, home, "sess-aaa")
+        assert record_a.exists(), "setup did not produce a delivery record"
+
+        # sess-aaa's transcript never existed under sessions_dir -- simulates
+        # a session that is over and gone. A different, unrelated session
+        # (BBB) starts next.
+        _session_start(project, home, "sess-bbb")
+
+        assert not record_a.exists(), (
+            "a delivery record for a session with no transcript on disk "
+            "survived a later session start -- this is the #373 leak"
+        )
+
+    def test_record_for_a_session_whose_transcript_still_exists_survives(self, tmp_path):
+        """MUST NOT FIRE (positive control): same shape, except sess-aaa's
+        transcript is still present under $SESSIONS_DIR when session BBB
+        starts. Its delivery record must survive -- an over-eager sweep
+        that ignores the transcript check would fail this."""
+        project, home, remember_dir, sessions_dir = _sandbox(tmp_path)
+
+        _session_start(project, home, "sess-aaa")
+        record_a = _seed_delivery_record(remember_dir, "sess-aaa")
+        _session_start(project, home, "sess-aaa")
+        assert record_a.exists(), "setup did not produce a delivery record"
+
+        # sess-aaa's transcript IS present -- the session could still resume.
+        (sessions_dir / "sess-aaa.jsonl").write_text('{"type":"user"}\n')
+
+        _session_start(project, home, "sess-bbb")
+
+        assert record_a.exists(), (
+            "a delivery record for a session whose transcript still exists "
+            "was pruned -- the sweep must not delete state for a session "
+            "that could still be active"
+        )
+
+    def test_could_not_tell_leaves_records_untouched(self, tmp_path):
+        """Third state: $SESSIONS_DIR itself is gone (unreadable), so there
+        is no way to tell whether sess-aaa is over. The record must survive
+        -- could-not-tell must never render as "pruned"."""
+        project, home, remember_dir, sessions_dir = _sandbox(tmp_path)
+
+        _session_start(project, home, "sess-aaa")
+        record_a = _seed_delivery_record(remember_dir, "sess-aaa")
+        _session_start(project, home, "sess-aaa")
+        assert record_a.exists(), "setup did not produce a delivery record"
+
+        # Remove the whole sessions directory -- "cannot tell", not "empty".
+        import shutil
+        shutil.rmtree(sessions_dir)
+
+        _session_start(project, home, "sess-bbb")
+
+        assert record_a.exists(), (
+            "a delivery record was pruned even though $SESSIONS_DIR could "
+            "not be read at all -- could-not-tell must not act like pruned"
+        )
+
+    def test_own_record_is_never_pruned_by_the_sweep(self, tmp_path):
+        """The running session's own record (just written this same
+        invocation) must never be swept as though it belonged to some other,
+        absent session."""
+        project, home, remember_dir, _sessions_dir = _sandbox(tmp_path)
+
+        _session_start(project, home, "sess-aaa")
+        record_a = _seed_delivery_record(remember_dir, "sess-aaa")
+        _session_start(project, home, "sess-aaa")
+
+        assert record_a.exists(), (
+            "a session's own just-written delivery record was removed by "
+            "its own invocation's sweep"
+        )

--- a/tests/test_delivery_record_pruning_373.py
+++ b/tests/test_delivery_record_pruning_373.py
@@ -61,6 +61,13 @@ def _sandbox(tmp_path: Path):
     return project, home, remember_dir, sessions_dir
 
 
+def _set_handoff_mode(home: Path, mode: str) -> None:
+    cfg_path = home / ".remember" / "config.json"
+    cfg = json.loads(cfg_path.read_text())
+    cfg["handoff_mode"] = mode
+    cfg_path.write_text(json.dumps(cfg))
+
+
 def _payload(session_id: str) -> str:
     return json.dumps({
         "session_id": session_id,
@@ -186,3 +193,32 @@ class TestStaleDeliveryRecordsArePruned:
             "a session's own just-written delivery record was removed by "
             "its own invocation's sweep"
         )
+
+    def test_records_left_over_after_switching_back_to_single_mode_are_still_pruned(self, tmp_path):
+        """The sweep must not be gated on THIS session's own handoff_mode.
+        A record left behind during an earlier per_session period does not
+        stop existing just because the user later switched handoff_mode
+        back to "single" -- a sweep gated on the current mode would leak
+        exactly those records forever, reproducing #373 under a config
+        toggle instead of fixing it."""
+        project, home, remember_dir, sessions_dir = _sandbox(tmp_path)
+
+        _session_start(project, home, "sess-aaa")
+        record_a = _seed_delivery_record(remember_dir, "sess-aaa")
+        _session_start(project, home, "sess-aaa")
+        assert record_a.exists(), "setup did not produce a delivery record"
+
+        # sess-aaa's transcript is gone, and the user has switched back to
+        # single mode before the next session starts.
+        _set_handoff_mode(home, "single")
+        (remember_dir / "remember.md").write_text("Shared note.\n")
+
+        _session_start(project, home, "sess-bbb")
+
+        assert not record_a.exists(), (
+            "a stale per-session delivery record survived a session start "
+            "under handoff_mode: \"single\" -- the sweep must not be gated "
+            "on the CURRENT session's own mode, only on whether the "
+            "session in question is confirmed over"
+        )
+        assert sessions_dir.is_dir()  # sanity: the fixture itself is sound

--- a/tests/test_printed_lines_ascii_367.py
+++ b/tests/test_printed_lines_ascii_367.py
@@ -1,0 +1,102 @@
+"""Regression pin for #367: scripts/session-start-hook.sh must never print
+non-ASCII bytes to a stream.
+
+The reported mechanism (a Python `UnicodeEncodeError`) is DOUBTED in the
+issue -- bash's `echo` performs no encode step, so that specific crash
+cannot happen in this file. What is doubted stays doubted: neither this
+test nor anything else here claims to have reproduced a Windows/cp1252
+failure, because no Windows machine was available to produce one. This test
+is the piece that IS testable without one: it pins the file-wide decision
+the issue argues for -- this file may not print non-ASCII to a stream at
+all, on any of its lines, present or future -- as a real regression guard,
+so mojibake-or-worse on a cp1252 console (whichever of the two candidate
+outcomes is real) simply cannot occur here again.
+
+Scope, matching the issue's own framing: PRINTED lines only. The ~94 other
+em-dashes in this file's comments never reach a stream and are untouched.
+"must fire" is covered by the four originally-reported echo lines (now
+ASCII); the "must not fire" pairing is the same walk finding no OTHER
+printed line has since grown a non-ASCII character either -- a scan with no
+real coverage (an empty file, a harness that never opened the real path)
+would pass this by construction too, so the test also asserts the file has
+the sizable line count and echo/printf count this hook is known to have,
+which a broken read could not produce by accident.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOK = REPO_ROOT / "scripts" / "session-start-hook.sh"
+
+# A line that writes literal text to a stream: `echo "..."` or `printf ...`
+# that is NOT redirected into a file path. Redirection to a file (a notice
+# dropped for a LATER hook to read and print, e.g. capture-gap-notice) is
+# still eventually a printed line -- session-start-hook.sh's own scope ends
+# at what IT emits, and the four originally-reported lines are exactly the
+# ones this file itself sends to a stream or hands to a sibling hook to
+# print unchanged; anything genuinely written only for machine consumption
+# (a delivery record, a config dump) is out of scope for this file-wide rule
+# and is not touched here.
+_ECHO_OR_PRINTF = re.compile(r'^\s*(echo|printf)\b')
+_COMMENT_LINE = re.compile(r'^\s*#')
+
+
+def _printed_lines() -> list[tuple[int, str]]:
+    lines = HOOK.read_text(encoding="utf-8").splitlines()
+    out = []
+    for i, line in enumerate(lines, start=1):
+        if _COMMENT_LINE.match(line):
+            continue
+        if _ECHO_OR_PRINTF.match(line):
+            out.append((i, line))
+    return out
+
+
+def test_file_has_the_echo_and_printf_lines_this_pin_expects_to_scan():
+    """Positive control for the scan itself: a broken read (empty file,
+    wrong path, a harness that silently found nothing) must not let the
+    assertion below pass by vacuous truth. session-start-hook.sh is known to
+    carry well over 40 echo/printf statements."""
+    printed = _printed_lines()
+    assert len(printed) > 40, (
+        f"expected well over 40 echo/printf lines in {HOOK}, found "
+        f"{len(printed)} -- the scan likely did not read the real file"
+    )
+
+
+def test_no_printed_line_contains_non_ascii():
+    """MUST FIRE (before the fix): the four originally-reported lines (87,
+    ~774, ~865, ~1003) each carry a U+2014 em-dash and are echo statements.
+    After the fix, no printed line in this file may contain a byte outside
+    ASCII."""
+    printed = _printed_lines()
+    offenders = [
+        (n, l) for n, l in printed
+        if any(ord(ch) > 127 for ch in l)
+    ]
+    assert not offenders, (
+        "printed (echo/printf) lines in scripts/session-start-hook.sh "
+        "contain non-ASCII characters -- this file's printed lines must be "
+        "pure ASCII (#367):\n"
+        + "\n".join(f"  line {n}: {l!r}" for n, l in offenders)
+    )
+
+
+def test_comment_em_dashes_are_untouched():
+    """The file-wide decision is scoped to PRINTED lines only -- comment
+    em-dashes (the other ~94) are explicitly out of scope and must survive.
+    A fix that stripped every em-dash in the file rather than deciding
+    per-stream would pass the test above too, so this pins the boundary."""
+    text = HOOK.read_text(encoding="utf-8")
+    comment_dashes = sum(
+        1 for line in text.splitlines()
+        if _COMMENT_LINE.match(line) and "—" in line
+    )
+    assert comment_dashes > 20, (
+        "expected this file's comments to still carry plenty of em-dashes "
+        f"(found {comment_dashes}) -- the fix must be scoped to printed "
+        "lines, not a blanket strip across the whole file"
+    )

--- a/tests/test_printed_lines_ascii_367.py
+++ b/tests/test_printed_lines_ascii_367.py
@@ -31,16 +31,20 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 HOOK = REPO_ROOT / "scripts" / "session-start-hook.sh"
 
-# A line that writes literal text to a stream: `echo "..."` or `printf ...`
-# that is NOT redirected into a file path. Redirection to a file (a notice
+# A line that writes literal text to a stream: `echo "..."` / `printf ...`,
+# or a call to this file's own `log()` helper (scripts/log.sh) -- log()
+# normally appends to $MEMORY_LOG_FILE, but falls back to a bare `echo ...
+# >&2` when that file cannot be written (a degraded/read-only store, exactly
+# the state this hook is built to tolerate), so a `log` call is one failed
+# write away from being a stream write too. Redirection to a file (a notice
 # dropped for a LATER hook to read and print, e.g. capture-gap-notice) is
 # still eventually a printed line -- session-start-hook.sh's own scope ends
-# at what IT emits, and the four originally-reported lines are exactly the
-# ones this file itself sends to a stream or hands to a sibling hook to
-# print unchanged; anything genuinely written only for machine consumption
-# (a delivery record, a config dump) is out of scope for this file-wide rule
-# and is not touched here.
-_ECHO_OR_PRINTF = re.compile(r'^\s*(echo|printf)\b')
+# at what IT emits, and the originally-reported lines are exactly the ones
+# this file itself sends to a stream, hands to a sibling hook to print
+# unchanged, or could fall back to stderr for; anything genuinely written
+# only for machine consumption (a delivery record, a config dump) is out of
+# scope for this file-wide rule and is not touched here.
+_ECHO_OR_PRINTF = re.compile(r'^\s*(echo|printf|log)\b')
 _COMMENT_LINE = re.compile(r'^\s*#')
 
 


### PR DESCRIPTION
## Summary

Fixes two adjacent issues in `scripts/session-start-hook.sh`:

- **#373** -- with `handoff_mode: "per_session"`, every session left a
  `remember.delivered.<session_id>` record behind in `$REMEMBER_DIR/tmp` and
  nothing ever removed it -- the same directory, and the same class of leak,
  that #362 already fixed once under a different filename. A new sweep
  prunes a session's delivery record once that session's own transcript is
  confirmed gone from Claude Code's own session directory
  (`$SESSIONS_DIR/<id>.jsonl`).

- **#367** -- four `echo` lines (plus two `log` calls found in self-review,
  see below) printed a U+2014 em-dash to stdout/stderr, with what a cp1252
  Windows console does with them left unestablished by the issue (the issue
  explicitly doubts the originally-reported `UnicodeEncodeError` mechanism,
  since bash's `echo` performs no encode step). Decided file-wide as the
  issue argued for: this file's printed lines may not carry non-ASCII at
  all. The file's ~94 other em-dashes, all in comments that never reach a
  stream, are untouched.

## Design decisions (the judgment calls the brief flagged)

**#367 is file-wide, not per-line.** Fixing only the newest line would leave
the file's own convention inconsistent. Neither candidate Windows outcome
(cosmetic mojibake vs. a decode failure one layer up) was observed -- no
Windows machine was available -- so this ships as a decision under
uncertainty in the safe direction (ASCII), not as a claim that either
outcome was reproduced.

**#373's coupling is to the session's own transcript, not to the paired
handoff.** Coupling the delivery record's lifetime to its paired
`remember.<session_id>.md` handoff was considered and rejected, per the
issue's own reasoning: that handoff survives forever ON PURPOSE (#221), so
tying the record's life to it would reintroduce unbounded growth under a
new name. Instead the record is pruned once `$SESSIONS_DIR/<id>.jsonl` -- the
one fact that actually answers "is this session over" -- is confirmed
absent. Three states, matching the issue's own framing: transcript
confirmed absent -> pruned; transcript confirmed present -> kept (correct,
not a bug); `$SESSIONS_DIR` itself unreadable -> nothing touched
(could-not-tell must never render as pruned).

**The sweep runs independent of the CURRENT session's own `handoff_mode`**
(added during self-review, see below) -- gating it on the live mode would
leak every record from a past `per_session` period the moment a user
switched back to `single`.

## Self-review findings

Two agents (`Explore` and `oss:auditor`) reviewed the first commit
independently. Three findings surfaced; two were fixed in a follow-up
commit, one is recorded here as below the intake bar rather than filed or
coded around:

- **Fixed**: `log()` (scripts/log.sh) falls back to a bare `echo ... >&2`
  when `$MEMORY_LOG_FILE` can't be written -- a degraded-store condition
  this hook is built to tolerate. Two `log` calls in this file still
  carried an em-dash and were invisible to the original #367 regression
  test's echo/printf-only scan. Fixed the same way as the four echo lines;
  the test now scans `log` calls too.
- **Fixed**: the #373 sweep was gated on `$PER_SESSION_HANDOFF` (this
  session's own resolved mode), so a record from an earlier `per_session`
  period leaked forever after a switch back to `single`. Gate removed; new
  regression test added and confirmed red against a manual revert before
  being confirmed green.
- **Below the intake bar, not fixed**: `[ -e "$SESSIONS_DIR/$id.jsonl" ]`
  cannot distinguish "transcript truly gone" (ENOENT) from a permission
  failure on the file itself (EACCES) -- bash's `[ -e ]` does not surface
  errno. In principle this could prune a record under a false negative that
  ought to read as could-not-tell. In practice `stat()` needs execute
  permission only on parent DIRECTORIES, not read permission on the target
  file, and `$SESSIONS_DIR` (a directory Claude Code itself creates and
  manages, entirely under the current user's own account) is already gated
  by `[ -d "$SESSIONS_DIR" ]` before the loop runs -- so reaching this false
  negative needs the user to have made a subdirectory of their own,
  single-user Claude Code data store inaccessible to themselves, which no
  ordinary operation of this plugin produces. Pinning it with a portable
  cross-platform test would need permission-bit tricks that behave
  differently enough on Windows/git-bash to widen the existing win32 skip
  for real complexity against a scenario nobody hits outside deliberately
  sabotaging their own store.

## Test plan

- [x] `tests/test_delivery_record_pruning_373.py` -- 5 tests: prune when
      transcript is confirmed gone (red before the fix, green after), keep
      when transcript still exists (positive control), leave untouched when
      `$SESSIONS_DIR` cannot be read at all (could-not-tell), never prune
      the running session's own just-written record, and (added in
      self-review) still prune a leftover record after switching back to
      `handoff_mode: "single"` (confirmed red against the old gated
      condition, green against the fix).
- [x] `tests/test_printed_lines_ascii_367.py` -- 3 tests: no printed
      (echo/printf/log) line carries non-ASCII, comment em-dashes are
      untouched (scope boundary), and a positive control that the scan
      actually read the real file (found >40 echo/printf/log lines).
- [x] `bash -n scripts/session-start-hook.sh` after every edit.
- [x] Full suite (`pytest`): 1674 passed, 43 skipped, 0 failed (run after a
      rebase-equivalent full pass covering the mode-gate fix too).
- [x] `python3 .oss/assemble_changelog.py --check --check-links --dir
      changelog.d --changelog CHANGELOG.md` -- ok.

Closes #373, closes #367.
