### PR TITLE
docs: README's Diagnostics section now mentions the SessionEnd liveness check

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ A store that could never be created at all (a read-only or otherwise unwritable 
 
 ## Diagnostics (`/remember:doctor`)
 
-Prints resolved paths, detected tools, storage mode, whether the session directory Claude Code actually created matches the slug the plugin computes, when the last successful save happened, and whether `PostToolUse` has ever fired for this project. Each line is prefixed `OK` / `WARN` / `FAIL`, ending in a one-line verdict.
+Prints resolved paths, detected tools, storage mode, whether the session directory Claude Code actually created matches the slug the plugin computes, when the last successful save happened, whether `PostToolUse` has ever fired for this project, and whether `SessionEnd` -- the last-chance flush -- has ever fired ([#370](https://github.com/Digital-Process-Tools/claude-remember/issues/370)). Each line is prefixed `OK` / `WARN` / `FAIL`, ending in a one-line verdict.
 
 Available on plugin installs, which auto-discover `commands/`. If you set the plugin up manually into `<project>/.claude/remember/`, that discovery does not apply — copy `commands/doctor.md` into `.claude/commands/`, or just run the script directly: `bash .claude/remember/scripts/doctor.sh`.
 

--- a/changelog.d/390.fixed.md
+++ b/changelog.d/390.fixed.md
@@ -1,0 +1,6 @@
+- Fixed: `README.md`'s `## Diagnostics` section still described `/remember:doctor` as
+  reporting only whether `PostToolUse` has ever fired, though PR #387 (closing #370) gave the
+  script a second, `SessionEnd` liveness check. A reader relying on the docs to know what
+  `/remember:doctor` covers had no description of the new line. The paragraph now also says
+  `/remember:doctor` reports whether `SessionEnd` -- the last-chance flush -- has ever fired for
+  the project. (#390)


### PR DESCRIPTION
Closes #390.

`/remember:doctor` has reported two liveness checks since PR #387 merged (closing #370): the existing `PostToolUse` one, and a new `SessionEnd` one -- three states, not two (fired / never fired despite a prior session demonstrably ending / no session has had the chance to end yet). `README.md`'s `## Diagnostics` section still described only the `PostToolUse` check, because the #370 lane drafted the replacement text before #387 landed and while `README.md` was held by open PR #382; both have since merged.

Applied the drafted replacement text from #390 to `README.md`'s Diagnostics paragraph, after checking it against `scripts/doctor.sh` as merged: `SessionEnd`'s check does read `logs/autonomous/session-end-*.log` presence (a persistent log file, not a transcript count) with a 15-minute staleness threshold, so "has ever fired" is accurate, and the one-clause phrasing matches the paragraph's existing convention for `PostToolUse` (which also has more than two internal states in `doctor.sh` but is summarized the same way). Cross-checked against the four other places README.md already discusses `SessionEnd` (~lines 214, 241, 243, 267-273): no contradiction -- line 273's "only partially documented" is about undocumented firing conditions (crash, killed terminal, usage cap), a different claim from what the doctor check can detect after the fact.

Also added `changelog.d/390.fixed.md`, verified with `python3 .oss/assemble_changelog.py --check`.

Below-bar item noted during self-review, not filed: the new sentence uses a literal `--` where README's dominant style elsewhere is an em dash (`—`, used ~209 times vs `--` ~7 times pre-existing). This is a pre-existing minor inconsistency in the file rather than something this diff introduces, and it has no reachable caller beyond taste -- not filed.

Lane: README.md only, plus the changelog fragment. Did not touch `scripts/doctor.sh`, `scripts/post-tool-hook.sh` or `pipeline/shell.py` (held by open PR #389).