### PR TITLE
fix: the #373 delivery-record sweep can no longer prune a live session's record

### DIFF
--- a/changelog.d/393.fixed.md
+++ b/changelog.d/393.fixed.md
@@ -1,0 +1,14 @@
+- Fixed: the #373 delivery-record sweep could delete a *live* session's
+  `remember.delivered.<session_id>` record, resetting its delivery counter so
+  an already-shown handoff read as news again. The sweep's only signal --
+  whether that session's transcript still exists under Claude Code's own
+  session directory -- cannot tell a dead session from one still inside its
+  own startup: at `source=startup`, Claude Code creates a session's
+  transcript only *after* this hook has already run and already written that
+  session's own delivery record, so a concurrent session start could prune a
+  record still in active use. The sweep now also checks the record's own
+  mtime, adding a third state: a record younger than a short grace window is
+  left untouched even when the transcript is absent, since that is exactly
+  what a session still starting up looks like. A record old enough to be
+  outside the window is still pruned exactly as before -- nothing is lost,
+  pruning is only deferred past the window (#393).

--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -1035,13 +1035,31 @@ fi
 # is gone in every way this hook can observe.
 #
 # Three states, not two, matching the record left behind:
-#   - transcript confirmed ABSENT  -> record is pruned
+#   - transcript confirmed ABSENT, record older than GRACE_MIN -> pruned
 #   - transcript confirmed PRESENT -> record is kept (not a bug: correct
 #     under the coupling above)
-#   - $SESSIONS_DIR cannot be listed at all -> nothing is touched.
-#     Could-not-tell must never render as either of the other two, so on
-#     doubt the safe direction is the one #221 already chose for the
-#     handoff itself: keep, never guess-delete.
+#   - transcript ABSENT but record younger than GRACE_MIN, or $SESSIONS_DIR
+#     cannot be listed at all -> nothing is touched. Could-not-tell must
+#     never render as either of the other two, so on doubt the safe
+#     direction is the one #221 already chose for the handoff itself: keep,
+#     never guess-delete.
+#
+# #393: "transcript absent" alone does not mean "session gone". At
+# source=startup (see the #270 comment above, lines 100-108) Claude Code
+# creates a session's own transcript AFTER this hook has already run and
+# already written that session's delivery record (line ~1012 above). For
+# that window a live session's record is indistinguishable from a dead
+# one's on the transcript check alone -- any concurrent session start
+# would prune a record that is still in active use. GRACE_MIN arbitrates:
+# a record newer than the window is not evidence the session is over,
+# whatever the transcript says; the mtime check below is what makes this a
+# third state instead of a coin flip. GRACE_MIN is REASONED, not measured
+# against real Claude Code startup timing -- there is no instrumented
+# figure for how long that gap runs, so this picks a duration wide enough
+# that no plausible hook-to-transcript-creation delay approaches it, while
+# staying bounded: a genuinely dead session's record is still pruned, just
+# on the next session start after it ages past this window, never lost.
+GRACE_MIN=5
 #
 # Runs regardless of THIS session's own handoff_mode -- not gated on
 # $PER_SESSION_HANDOFF. Gating it there was considered and rejected: a
@@ -1062,10 +1080,18 @@ if [ -d "$SESSIONS_DIR" ] && [ -d "$REMEMBER_DIR/tmp" ]; then
         # Never sweep the record this very invocation just wrote.
         [ "$_remember_stale_id" = "$CURRENT_SESSION_ID" ] && continue
         if [ ! -e "$SESSIONS_DIR/$_remember_stale_id.jsonl" ]; then
+            # #393: an absent transcript is not proof the session is over --
+            # it is also what a session still inside its own startup window
+            # looks like. `find -mmin +N` answers "strictly older than N
+            # minutes"; a record inside the window (find finds nothing) is
+            # left untouched rather than treated as confirmed-dead.
+            if [ -z "$(find "$_remember_stale_record" -mmin "+$GRACE_MIN" 2>/dev/null)" ]; then
+                continue
+            fi
             rm -f "$_remember_stale_record" 2>/dev/null
         fi
     done
-    unset _remember_stale_record _remember_stale_id
+    unset _remember_stale_record _remember_stale_id GRACE_MIN
 fi
 
 # ── History hint ───────────────────────────────────────────────────────────

--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -1082,16 +1082,44 @@ if [ -d "$SESSIONS_DIR" ] && [ -d "$REMEMBER_DIR/tmp" ]; then
         if [ ! -e "$SESSIONS_DIR/$_remember_stale_id.jsonl" ]; then
             # #393: an absent transcript is not proof the session is over --
             # it is also what a session still inside its own startup window
-            # looks like. `find -mmin +N` answers "strictly older than N
-            # minutes"; a record inside the window (find finds nothing) is
-            # left untouched rather than treated as confirmed-dead.
-            if [ -z "$(find "$_remember_stale_record" -mmin "+$GRACE_MIN" 2>/dev/null)" ]; then
+            # looks like. Read the record's own mtime rather than shelling
+            # out to `find -mmin`: `find` is the one command on this path
+            # with a real PATH-shadowing risk on Windows Git Bash
+            # (System32's find.exe can resolve ahead of MinGW's find on
+            # some setups and silently answers a different question), so it
+            # would degrade "prune" into a silent always-keep with nothing
+            # surfaced. `stat` uses the same GNU-first-then-BSD-fallback
+            # order already used by doctor.sh:257 and lib-lock.sh:183 for
+            # exactly this portability split -- GNU first, because GNU
+            # `stat -f` on Linux pollutes stdout with a filesystem block
+            # before failing (the #327/#1072 class), so trying it second,
+            # only after `-c` has already failed cleanly, is load-bearing
+            # order and not a stylistic choice.
+            _remember_stale_mtime=$(stat -c %Y "$_remember_stale_record" 2>/dev/null) \
+                || _remember_stale_mtime=$(stat -f %m "$_remember_stale_record" 2>/dev/null) \
+                || _remember_stale_mtime=""
+            if [ -z "$_remember_stale_mtime" ]; then
+                # Could not read the record's own age -> could-not-tell,
+                # same safe direction as an unreadable $SESSIONS_DIR above.
+                continue
+            fi
+            case "$_remember_stale_mtime" in (''|*[!0-9]*) _remember_stale_mtime=0 ;; esac
+            # _remember_date +%s -- same call site convention as
+            # post-tool-hook.sh:377/605. lib-clock.sh routes %s to `date`
+            # unconditionally (never the printf builtin), and `_remember_date`
+            # itself already falls back to plain `date` with no TZ set, so
+            # this always yields digits; the guard below is what #332 asks
+            # for at every arithmetic sink regardless.
+            _remember_now=$(_remember_date +%s)
+            case "$_remember_now" in (''|*[!0-9]*) _remember_now=0 ;; esac
+            if [ "$_remember_now" -gt 0 ] && [ "$_remember_stale_mtime" -gt 0 ] \
+                && [ $((10#$_remember_now - 10#$_remember_stale_mtime)) -lt $((GRACE_MIN * 60)) ]; then
                 continue
             fi
             rm -f "$_remember_stale_record" 2>/dev/null
         fi
     done
-    unset _remember_stale_record _remember_stale_id GRACE_MIN
+    unset _remember_stale_record _remember_stale_id _remember_stale_mtime _remember_now GRACE_MIN
 fi
 
 # ── History hint ───────────────────────────────────────────────────────────

--- a/tests/test_delivery_record_pruning_373.py
+++ b/tests/test_delivery_record_pruning_373.py
@@ -42,6 +42,20 @@ SESSION_START_SCRIPT = REPO_ROOT / "scripts" / "session-start-hook.sh"
 
 from pipeline.slug import session_dir_slug as _slug
 
+# Mirrors the grace window scripts/session-start-hook.sh's #393 fix uses to
+# arbitrate the sweep -- see the comment beside GRACE_MIN there for why this
+# duration (reasoned, not measured against real Claude Code timing).
+_GRACE_MIN = 5
+
+
+def _age_record(record: Path, minutes: float) -> None:
+    """Backdate a record's mtime so the #393 grace-window check reads it as
+    old enough that "no transcript yet" can only mean "session is over" --
+    never a session still inside its own startup window."""
+    import time
+    old = time.time() - (minutes * 60)
+    os.utime(record, (old, old))
+
 
 def _sandbox(tmp_path: Path):
     project = tmp_path / "proj"
@@ -111,8 +125,9 @@ class TestStaleDeliveryRecordsArePruned:
 
     def test_record_for_a_session_with_no_transcript_is_pruned(self, tmp_path):
         """MUST FIRE: session AAA delivered once and left a record behind;
-        its transcript is gone (never existed, or was cleaned up elsewhere).
-        The next session start must remove AAA's stale record."""
+        its transcript is gone (never existed, or was cleaned up elsewhere),
+        and the record is old enough that #393's grace window no longer
+        applies. The next session start must remove AAA's stale record."""
         project, home, remember_dir, _sessions_dir = _sandbox(tmp_path)
 
         out_a = _session_start(project, home, "sess-aaa")
@@ -123,6 +138,9 @@ class TestStaleDeliveryRecordsArePruned:
         # genuine artifact the hook itself writes, not a hand-built stand-in.
         _session_start(project, home, "sess-aaa")
         assert record_a.exists(), "setup did not produce a delivery record"
+        # Past the #393 grace window -- old enough that "no transcript" can
+        # only mean the session is over, never that it is still starting up.
+        _age_record(record_a, _GRACE_MIN + 1)
 
         # sess-aaa's transcript never existed under sessions_dir -- simulates
         # a session that is over and gone. A different, unrelated session
@@ -130,8 +148,38 @@ class TestStaleDeliveryRecordsArePruned:
         _session_start(project, home, "sess-bbb")
 
         assert not record_a.exists(), (
-            "a delivery record for a session with no transcript on disk "
-            "survived a later session start -- this is the #373 leak"
+            "a delivery record for a session with no transcript on disk, "
+            "old enough to be outside the startup grace window, survived "
+            "a later session start -- this is the #373 leak"
+        )
+
+    def test_fresh_record_with_no_transcript_yet_survives(self, tmp_path):
+        """MUST NOT FIRE (#393 positive control): session AAA's record was
+        JUST written and its transcript does not exist yet -- indistinguish-
+        able, on the sweep's only signal, from a session that is over. A
+        different session (BBB) starts inside that same window. AAA's
+        record must survive: at source=startup Claude Code creates a
+        session's own transcript only AFTER this hook has already run, so a
+        record this young is not evidence the session is gone."""
+        project, home, remember_dir, _sessions_dir = _sandbox(tmp_path)
+
+        _session_start(project, home, "sess-aaa")
+        record_a = _seed_delivery_record(remember_dir, "sess-aaa")
+        _session_start(project, home, "sess-aaa")
+        assert record_a.exists(), "setup did not produce a delivery record"
+        # record_a's mtime is left exactly as the hook just wrote it --
+        # inside the grace window, deliberately not backdated.
+
+        # sess-aaa's transcript still does not exist -- the exact #393 shape:
+        # absent transcript, freshly-written record. A different session
+        # (BBB) starts inside the window.
+        _session_start(project, home, "sess-bbb")
+
+        assert record_a.exists(), (
+            "a delivery record younger than the #393 startup grace window "
+            "was pruned on the strength of an absent transcript alone -- "
+            "a live session starting up is indistinguishable from a dead "
+            "one on that signal, so this is the #393 race"
         )
 
     def test_record_for_a_session_whose_transcript_still_exists_survives(self, tmp_path):
@@ -207,6 +255,9 @@ class TestStaleDeliveryRecordsArePruned:
         record_a = _seed_delivery_record(remember_dir, "sess-aaa")
         _session_start(project, home, "sess-aaa")
         assert record_a.exists(), "setup did not produce a delivery record"
+        # Past the #393 grace window -- an old per_session-era leftover, not
+        # a session still inside its own startup.
+        _age_record(record_a, _GRACE_MIN + 1)
 
         # sess-aaa's transcript is gone, and the user has switched back to
         # single mode before the next session starts.

--- a/tests/test_delivery_record_pruning_373.py
+++ b/tests/test_delivery_record_pruning_373.py
@@ -11,9 +11,15 @@ over": whether Claude Code's own transcript for that session id still
 exists under $SESSIONS_DIR (the same directory session-start-hook.sh already
 reads via `previous_transcript`).
 
-Three states, tested here as three cases over one fixture shape:
-  - the session's transcript is gone -> its delivery record is pruned
+Four states, tested here as four cases over one fixture shape (a fourth,
+#393, joined the original three below):
+  - the session's transcript is gone AND its record is old enough to be
+    outside the #393 startup grace window -> its delivery record is pruned
     (the "must fire" case)
+  - the session's transcript is gone but its record is still inside that
+    grace window -> its delivery record survives (#393's own "must not
+    fire" case -- a session still starting up is indistinguishable from a
+    dead one on the transcript check alone)
   - the session's transcript still exists -> its delivery record survives
     (the paired "must not fire" case -- the positive control that a broken
     or over-eager sweep would fail)


### PR DESCRIPTION
Closes #393.

With `handoff_mode: "per_session"`, the #373 sweep in `scripts/session-start-hook.sh` treated "transcript absent under `$SESSIONS_DIR`" as proof a session was over, and pruned its `remember.delivered.<session_id>` record on that signal alone. But at `source=startup`, Claude Code creates a session's own transcript only *after* this hook has already run and already written that session's delivery record (the #270 comment at lines 100-108 of the same file states this independently). For that window a live session's record is indistinguishable from a dead one's on the transcript check alone -- a concurrent session starting inside the window would delete a record still in active use, resetting the delivery counter so an already-shown handoff read as news again.

## Fix

The sweep now also checks the record's own mtime when the transcript is absent, adding a third state: a record younger than a 5-minute grace window (`GRACE_MIN`) is left untouched even with no transcript, since that is exactly what a session still starting up looks like. A record old enough to be outside the window is pruned exactly as before -- nothing is lost, pruning is only deferred past the window. `GRACE_MIN` is reasoned, not measured against real Claude Code startup timing: there is no instrumented figure for how long that gap runs, so the value is chosen wide enough that no plausible delay approaches it while staying bounded.

The age check reads the mtime directly via `stat -c ... || stat -f ...` (GNU-first, BSD-fallback -- the same order already used at `doctor.sh:257` and `lib-lock.sh:183` for the identical portability split), not `find -mmin`. That swap was made after review (see below).

## Tests

`tests/test_delivery_record_pruning_373.py` gained a fourth case pairing with the original three: `test_fresh_record_with_no_transcript_yet_survives` is the #393 positive control -- a freshly-written record with no transcript yet must survive a concurrent session start. `test_record_for_a_session_with_no_transcript_is_pruned` and `test_records_left_over_after_switching_back_to_single_mode_are_still_pruned` were updated to backdate their records past the grace window, since a fresh record with no transcript is now the ambiguous case rather than an automatic prune.

## Review

Two spawned reviews ran against the first commit. Both returned `states-findings` under `scripts/review_return.py`.

**Reviewer (Explore):** stale docstring in the test module -- it still described "three states" after this change added a fourth. Fixed: the docstring now names all four.

**Auditor (oss:auditor):** the original `find -mmin` arbiter carries a genuine Windows Git-Bash risk -- `System32`'s `find.exe` can resolve ahead of MinGW's `find` on PATH depending on invocation, which would silently degrade the grace check to an unconditional keep with nothing surfaced (reasoned, not observed -- no Windows box was available). CI would not have caught it either way, since the whole test file is already skipped on win32 from #373/#79. Fixed anyway rather than filed, since it was cheap and in-scope: replaced `find -mmin` entirely with the `stat`-based mtime read described above, which has no such PATH-shadowing surface and matches this repo's own established fallback order.

No item in this pull request is `below-bar` -- both findings were fixed before this commit was opened.

## Docs

No `README.md` change: the #373 PR that introduced this sweep did not touch `README.md` either (the sweep is bookkeeping, not user-facing behavior), and the delivery-record section of `README.md` (around line 303) does not describe internal pruning timing.

## Test plan

- [x] `pytest tests/test_delivery_record_pruning_373.py -v` -- 6 passed
- [x] `pytest tests/test_arith_base_lint_332.py -q` -- 10 passed (the new arithmetic is `10#`-guarded)
- [x] Full suite: `pytest -q` -- 1700 passed, 43 skipped
- [x] `python3 .oss/assemble_changelog.py --check` -- ok
