### PR TITLE
chore: refresh oss-owned files and 01-oss rule layer

### DIFF
--- a/.claude/jit-context/paths/01-oss/00-index.tsv
+++ b/.claude/jit-context/paths/01-oss/00-index.tsv
@@ -1,2 +1,2 @@
 (changelog.d/|(^|/)CHANGELOG\.md$)	changelog-fragments.md
-\.oss\.json	oss-config.md
+(^|/)\.oss\.json$	oss-config.md

--- a/.claude/jit-context/paths/01-oss/changelog-fragments.md
+++ b/.claude/jit-context/paths/01-oss/changelog-fragments.md
@@ -27,15 +27,27 @@ where nothing can read it. The reason is part of the field: a bare verdict is th
 answer one field further along. Other sections may carry the bullet and are read as compatible when
 they do not.
 
+The fragment check reads this line too, so a declaration that will not parse -- a word that is
+neither verdict, a verdict with no reason, both at once, or a `removed` fragment carrying none --
+is a finding on the pull request that introduced it rather than a stopped release days later.
+
 **Do not hand-edit `CHANGELOG.md`** while this directory exists. The fold overwrites it and deletes
 the fragments; an entry written directly into the file is lost at the next release, silently,
 because the fold has no way to know it was meant to stay.
 
-Check before pushing:
+Check before pushing. **Two commands, not one:** the checker refuses both audits in a
+single call, and says so. They used to be combinable, and the combination quietly ran the
+link audit alone while printing one confident `ok` for it -- so each flag now gets its own
+invocation, and each audits its own thing completely.
 
 ```bash
-python3 .oss/assemble_changelog.py --check --check-links --dir 'changelog.d' --changelog CHANGELOG.md
+python3 .oss/assemble_changelog.py --check --dir 'changelog.d' --changelog CHANGELOG.md
+python3 .oss/assemble_changelog.py --check-links --dir 'changelog.d' --changelog CHANGELOG.md
 ```
+
+Those are the same two commands the scaffolded changelog workflow runs as its own two
+steps, so the pair you run before pushing and the pair that gates the pull request cannot
+disagree.
 
 `--check-links` refuses when a `## [x.y.z]` section has no link reference definition. If the
 version it names was never tagged, the missing link is the correct state: there is no release

--- a/.claude/jit-context/paths/01-oss/oss-config.md
+++ b/.claude/jit-context/paths/01-oss/oss-config.md
@@ -1,7 +1,7 @@
 ---
 title: ".oss.json is config, not truth"
 description: "Per-repo settings for the maintainer loop. Re-derive labels before acting; the CI leg count is not in here; null is an answer, not a gap."
-match: \.oss\.json
+match: (^|/)\.oss\.json$
 ---
 
 Per-repo settings for the maintainer loop: `repo`, `default_branch`, `clone`, `worktree_root`,

--- a/.claude/jit-context/tools/01-oss/00-index.tsv
+++ b/.claude/jit-context/tools/01-oss/00-index.tsv
@@ -1,1 +1,1 @@
-Read|Edit|Write|Glob|Grep	~.*	supertool-required.md	block		
+Read|Edit|Write|Glob|Grep	~.*	supertool-required.md	block			supertool

--- a/.claude/jit-context/vocabulary/01-oss/00-index.tsv
+++ b/.claude/jit-context/vocabulary/01-oss/00-index.tsv
@@ -3,3 +3,10 @@ oss-watch	oss-state.md
 tick state	oss-state.md
 handoff	oss-state.md
 oss state	oss-state.md
+reload-plugins	plugin-currency.md
+plugin version	plugin-currency.md
+plugin copy	plugin-currency.md
+plugin currency	plugin-currency.md
+statusline	plugin-currency.md
+oss-workspace	plugin-currency.md
+plugin cache	plugin-currency.md

--- a/.claude/jit-context/vocabulary/01-oss/plugin-currency.md
+++ b/.claude/jit-context/vocabulary/01-oss/plugin-currency.md
@@ -1,0 +1,66 @@
+---
+title: "Which copy of the plugin answered, and which version is current"
+description: "Three different things are called 'the version' and they routinely disagree. Reading the wrong one, or reading the statusline marker backwards, has cost this repo whole sessions."
+keywords: reload-plugins, plugin version, plugin copy, plugin currency, statusline, oss-workspace, plugin cache
+---
+
+Three readings, three different questions. They disagree normally, not exceptionally.
+
+| reading | where | answers |
+| --- | --- | --- |
+| **clone / tree** | `.claude-plugin/plugin.json` in the checkout | what the source says today |
+| **registry / session** | the path inside an injected slash-command's own text | which copy this command resolved from |
+| **installed cache** | `~/.claude/plugins/cache/dpt-plugins/oss/<version>/` | every version ever unpacked |
+
+**Old directories in the cache mean nothing.** `claude plugin update` unpacks a new one and leaves
+the rest. Ten directories is normal; it is not evidence about what resolves.
+
+**`doctor`'s `plugin copy` line compares content, not version numbers.** The manifest version does
+not move between releases, so an installed copy at the tag and a clone a cycle past it declare the
+same number. A `SKEW` is a report, not a fault -- it is the normal state between a merge and a
+release. What it costs you: plugin prose quoted from the running session may be text the clone no
+longer contains.
+
+## `/reload-plugins` vs restart -- not interchangeable
+
+| | moves the registry (which agents/skills/commands resolve) | moves command text already injected in this turn |
+| --- | --- | --- |
+| `/reload-plugins` | yes | **no** |
+| restart | yes | yes |
+
+So a session can hold a registry at one version and instructions from another, and that is not a bug.
+
+- `Agent type not found` -> `/reload-plugins`, then retry. This is the whole fix.
+- Never conclude "the agent files do not register" from inside an unreloaded session. #81 spent ten
+  cohorts and four retracting comments on exactly that: a description-length hypothesis with a
+  measured character boundary, a false regression report, all retracted, cause was a stale registry.
+
+## Statusline markers -- they print different fields
+
+| state | unicode | ascii | colour | the number shown is |
+| --- | --- | --- | --- | --- |
+| `behind` | `↥` | `>` | yellow | **latest** published |
+| `ahead` | `↑` | `+` | green | **installed** |
+| `current` | counted in `N✓` | | green | -- |
+| `unknown` | `N?` | | dim | nothing was comparable |
+
+`ahead` is the normal state in a clone of the plugin itself (unreleased work), and normal for any session
+in the window after a release before the cache refreshes. It is not a problem.
+
+`version_status` folds a stale comparison into `unknown` rather than inventing vocabulary -- so a
+`?` means either half was missing **or** the reading was too old to trust.
+
+## The cached `latest`
+
+- Lives at `cache_dir()/<slug>.json` -- outside the repo. Never re-derive that path; call
+  `statusline.cache_path`.
+- Source is the newest **published GitHub Release**, via `_latest_release` -- *not* the manifest.
+  A tag with no Release does not move it.
+- `LATEST_REFRESH_AFTER` is the long clock; the board half refreshes far more often. Two clocks.
+- `/oss:release` calls `invalidate_latest_cache` the moment a Release is created, because the
+  publish is what falsifies the reading.
+- **A reading fresh by its own rule can still be wrong.** The falsifying event can land one minute
+  after a poll. Do not diagnose this by shortening the interval.
+
+Force a re-read: delete the cache file. `doctor` never does this -- it reports the skew and leaves
+the evidence.

--- a/.oss/README.md
+++ b/.oss/README.md
@@ -23,9 +23,28 @@ subdirectories are not supported and a symlink there fails outright. So it keeps
 
 ## What is here
 
+Every file this directory holds, and nothing else — `/oss:scaffold` writes these and
+replaces them wholesale on every run.
+
+- `README.md` — this file. It ships beside the others because a directory of generated
+  files with no note is a directory somebody edits.
 - `assemble_changelog.py` — validates changelog fragments and folds them into
   `CHANGELOG.md` at release time. It lives in your repository rather than in the plugin
   because CI checks out your repository and nothing else.
+- `statusline.py` — renders one status line for this repository: the tracker board, when
+  the next tick is due, and whether the plugin copies you are running are current. It is
+  **opt-in, and nothing here calls it**: it stays inert until a `statusLine` entry in
+  `.claude/settings.json` points at it, so removing that entry stops it and breaks nothing else.
+  The command that entry runs is
+
+  ```bash
+  python3 "$CLAUDE_PROJECT_DIR"/.oss/statusline.py
+  ```
+
+  `/oss:scaffold` writes that entry only when the file has no `statusLine` at all; one you
+  already set is never touched, whatever it points at. Every field it prints has three
+  states and the third is `?` — a count nobody took, or a version comparison nobody could
+  make. `?` is never rounded up to `0` or to a tick.
 
 ## Running the fragment check yourself
 

--- a/.oss/assemble_changelog.py
+++ b/.oss/assemble_changelog.py
@@ -26,26 +26,33 @@ a user installs imports this — it is a repo-internal release tool.
     python3 scripts/assemble_changelog.py --check     # CI: names *and* bodies
     python3 scripts/assemble_changelog.py --count     # exact fragment count
 
-**The fold names its own target; the read-only modes derive one.** `REPO` is
-found by walking up from *this file* for a `.git`, which answers "which
-repository am I stored in" -- not "which repository is being released". Those
-coincide for the copy vendored into a managed repo at
-`.oss/assemble_changelog.py` and they do not coincide for the copy shipped
-inside the plugin, whose own checkout is always a clone: the walk there always
-succeeds, and always on the wrong repository, so the `None` arm that refuses
-cleanly is unreachable in precisely the deployment where the guess is wrong.
+**The fold names its own target; the read-only modes derive one from the
+caller's cwd.** `REPO` is found by walking up from `Path.cwd()` for a
+`.git`, which answers "which repository is the caller standing in" -- not
+"which repository is being released", and the two can still differ (a caller
+`cd`'d into a submodule, say). It used to walk up from *this file* instead,
+which answered a different question -- "which repository am I stored in" --
+and that coincided with the caller's intent for the copy vendored into a
+managed repo at `.oss/assemble_changelog.py` (stored inside the repo it
+serves) and never coincided for the copy shipped inside a plugin, whose own
+checkout is a clone unrelated to whatever the caller meant: that walk always
+succeeded, always on the plugin's own tree, so a bare `--check` reported a
+clean verdict about fragments nobody asked about, from any cwd. Deriving from
+the caller's cwd instead closes that: the two copies now agree, because both
+answer about wherever the caller is standing rather than about wherever the
+script is installed.
 
-The requirement is **unconditional** rather than applied to one copy, and that
-is a decision, not an oversight. Nothing observable distinguishes the two: both
-copies sit at some depth inside a real clone, and the difference between them
-is what the caller meant, which is not on disk. A detector would be guessing,
-and the two directions of a wrong guess are not comparable -- a false negative
-rewrites `CHANGELOG.md` and deletes every fragment in a repository nobody
-named, while a false positive costs one line of typing that the refusal itself
-prints. So the vendored copy pays the same two flags, and every invocation this
-plugin generates passes them. The read-only modes keep the derived default:
-they only read, and requiring the flags there would break the `--check` gate in
-every managed repo at once.
+The fold's own requirement is **unconditional** rather than derived at all,
+in either direction. Nothing observable distinguishes "the caller's cwd is
+the repository being released" from "it merely happens to be a repository" --
+a detector would be guessing, and the two directions of a wrong guess are not
+comparable -- a false negative rewrites `CHANGELOG.md` and deletes every
+fragment in a repository nobody named, while a false positive costs one line
+of typing that the refusal itself prints. So the vendored copy pays the same
+two flags, and every invocation this plugin generates passes them. The
+read-only modes keep the cwd-derived default: they only read, so a wrong
+guess there costs a wasted read rather than a lossy write, and requiring the
+flags there would break the `--check` gate in every managed repo at once.
 
 Exit codes: 0 ok, 1 skipped (nothing to do, or nothing *provable* — stated
 either way), 2 refused (a finding).
@@ -97,7 +104,37 @@ def _find_repo_root(start: Path) -> Optional[Path]:
     return None
 
 
-REPO = _find_repo_root(Path(__file__).resolve().parent)
+def _safe_cwd() -> Optional[Path]:
+    """`Path.cwd()`, without letting a vanished working directory take the
+    whole module down. `os.getcwd()` (which `Path.cwd()` wraps) raises
+    `FileNotFoundError` when the process's own current directory has been
+    removed out from under it -- a live race in this loop's own worktree
+    lifecycle, not a hypothetical one, and unlike the derivation this
+    replaced, a bare module-scope `Path.cwd()` runs on *every* invocation,
+    fold included, before `argparse` has even parsed `--dir`/`--changelog`.
+    `None` here reads exactly like "no `.git` above cwd" to every caller of
+    `REPO` below -- a refusal with a stated reason, never an import crash
+    with none."""
+    try:
+        return Path.cwd()
+    except OSError:
+        return None
+
+
+#: Derived from the *caller's* current working directory, not from
+#: this file's own install location. Walking up from `__file__` used to
+#: answer "which repository is this script stored in" -- correct for the
+#: copy vendored beside the repo it serves at `.oss/assemble_changelog.py`,
+#: and wrong for the copy shipped inside a plugin, whose own checkout is a
+#: clone unrelated to whatever repository the caller means. That walk always
+#: succeeded, always on the plugin's own tree, so a bare `--check` run from
+#: anywhere reported a clean verdict about fragments nobody asked about.
+#: Walking from `Path.cwd()` instead can still miss -- a caller `cd`'d
+#: somewhere with no `.git` above it, or standing nowhere at all -- and the
+#: read-only modes report that rather than falling back to the script's own
+#: tree; see `_resolve` below.
+_CWD = _safe_cwd()
+REPO = _find_repo_root(_CWD) if _CWD is not None else None
 
 #: Keep a Changelog 1.1.0, in the order the spec lists them. The order is data,
 #: not a sort: "Added" before "Fixed" is a convention readers rely on, and
@@ -116,6 +153,39 @@ _VERSION_RE = re.compile(r"^\d+\.\d+\.\d+\Z")  # \Z, not $ (a POSIX filename may
 #: Not fragments, and not mistakes either — refusing these would make the
 #: directory unable to document itself.
 _IGNORED = {"README.md", ".gitkeep", ".gitignore"}
+
+#: The compatibility grammar. **Transcribed from `scripts/release_version.py`**,
+#: which is where it was designed and where the release number is decided from it
+#: — not invented here. This file used to contain no reference to the
+#: compatibility line at all, so a fragment declaring a value neither half
+#: recognises passed every pull-request leg and stopped the release days later,
+#: at the one moment the remedy is most expensive.
+#:
+#: Transcribed rather than imported, for the reason the transcription runs the
+#: other way for fragment *names*: this file is vendored standalone into
+#: `.oss/assemble_changelog.py` in every managed repository, with no
+#: `release_version.py` beside it. Having the release gate import this module
+#: instead would put 2,500 lines and a guarded optional parser import underneath
+#: the one script whose refusal must never be a traceback.
+#:
+#: A transcription is a claim about something outside this file, so the two are
+#: measured against each other over a corpus of bodies in the plugin's own test
+#: suite rather than asserted to agree in this comment. That suite does not ship
+#: with this file, which is the point of saying where the authority is: a reader
+#: of the vendored copy can see that the grammar has one owner, and that it is
+#: not this line.
+BREAKING = "breaking"
+COMPATIBLE = "compatible"
+VERDICTS = (BREAKING, COMPATIBLE)
+
+#: Sections whose fragments can plausibly break a consumer, and which therefore
+#: have to say. `deprecated` is deliberately absent: a deprecation that still
+#: works is the definition of a compatible change, and requiring a field whose
+#: answer is fixed buys a chance to get it wrong and nothing else.
+MUST_DECLARE = ("removed",)
+
+_COMPAT_LINE = re.compile(  # anchored-ok: matched per line of a fragment body; the newline is the delimiter
+    r"^\s*-\s+compatibility\s*:\s*(.*)$", re.IGNORECASE)
 
 _UNRELEASED_LINK_RE = re.compile(  # anchored-ok: matched per line of CHANGELOG.md; the newline is the delimiter
     r"^\[Unreleased\]:\s*(?P<base>\S+?)/compare/v(?P<prev>[0-9][^.\s]*(?:\.[^.\s]+)*)\.\.\.HEAD\s*$"
@@ -630,6 +700,93 @@ def self_reference_finding(name: str, text: str) -> Optional[str]:
         .format(name, at, number, lines[at - 1] if at <= len(lines) else ""))
 
 
+def _has_reason(text: str) -> bool:
+    """Is there a sentence after the verdict, once the separator is dropped?
+
+    Transcribed from `release_version._has_reason`, and the reasoning travels with
+    it: the separator is a hyphen in the documented spelling, a colon in somebody
+    else's, and an en or em dash in prose pasted out of a document. So it is
+    recognised by category — leading non-alphanumerics go, and whatever is left is
+    the reason — rather than by a table of dashes, which has to guess at the one
+    the next author reaches for and puts a non-ASCII literal in a file whose every
+    other byte is ASCII.
+    """
+    return any(char.isalnum() for char in text)
+
+
+def _echo(text: str, limit: int = 60) -> str:
+    """A word out of somebody's fragment, reduced to one printable ASCII line.
+
+    Naming the value is the whole point of this finding — a receipt that says a
+    line "does not read" without saying which line sends the author back to guess.
+    But the body is written by whoever opened the pull request, and `_receipt`
+    prints findings as indented rows, so a newline or a control character in one
+    forges a row of the receipt it appears in.
+    """
+    flat = " ".join(str(text).split())
+    safe = "".join(ch if 32 <= ord(ch) < 127 else "?" for ch in flat)
+    return safe[:limit]
+
+
+def compatibility_finding(name: str, section: str, text: str) -> Optional[str]:
+    """One finding if this fragment's compatibility declaration will not read.
+
+    Three states, and the third is why this is not a one-line regex:
+
+    * **present and it reads** — `breaking` or `compatible`, with a reason after
+      it. `None`.
+    * **present and it does not read** — an unrecognised word, a verdict with no
+      reason, or both verdicts at once. A finding naming the file and the value.
+    * **absent** — `None` on every section but `removed`, where a fragment that
+      declares nothing is a finding: whether a removal breaks anything is the
+      question the release number turns on, and an author who knows the answer and
+      writes it as prose puts it where nothing can read it.
+
+    Collapsing the last two would either block every fragment that omits an
+    optional line, or wave through the one that got it wrong.
+
+    Nothing here needs a Markdown parser, which is why `collect` runs it ahead of
+    the body scan: a definite refusal must not be lost behind a `CannotValidate`
+    raised by a check that could not look.
+    """
+    verdicts = set()
+    for line in text.splitlines():
+        found = _COMPAT_LINE.match(line)
+        if not found:
+            continue
+        rest = found.group(1).strip()
+        head = rest.split()[0] if rest else ""
+        word = head.strip(".,:;-").lower()
+        if word not in VERDICTS:
+            return (
+                "{0}: `Compatibility: {1}` — {2} is neither `{3}` nor `{4}`, and a "
+                "value nothing recognises never grades as compatible. The release "
+                "number is proposed from these fragments, so this stops the "
+                "proposal rather than defaulting quietly.".format(
+                    name, _echo(rest), _echo(head) or "an empty verdict",
+                    BREAKING, COMPATIBLE))
+        if not _has_reason(rest[len(head):]):
+            return (
+                "{0}: `Compatibility: {1}` carries no reason — a bare verdict is "
+                "the same unsourced answer one field further along, and the "
+                "sentence is the part worth having. Write "
+                "`- Compatibility: {1} - <reason>`.".format(name, _echo(head)))
+        verdicts.add(word)
+    if len(verdicts) > 1:
+        return (
+            "{0}: the fragment declares both `{1}` and `{2}` — nothing downstream "
+            "can pick one, and reading the first would make the fragment's meaning "
+            "depend on the order of its bullets.".format(name, BREAKING, COMPATIBLE))
+    if not verdicts and section in MUST_DECLARE:
+        return (
+            "{0}: a `{1}` fragment must declare compatibility, as one more bullet "
+            "in the body: `- Compatibility: {2}|{3} - <reason>`. Whether the "
+            "removal breaks anything is the question the version number turns on, "
+            "and a removal that declares nothing is read here rather than defaulted "
+            "to a quiet minor.".format(name, section, BREAKING, COMPATIBLE))
+    return None
+
+
 # How far up the tree `_absence_confirmed` will walk. Sibling constant to
 # `doctor._ANCESTOR_LIMIT` / `lane_setup._ANCESTOR_LIMIT`: a belt on a walk
 # that already stops at the anchor.
@@ -791,16 +948,22 @@ def collect(directory: Path) -> List[Fragment]:
         self_ref = self_reference_finding(path.name, text)
         if self_ref is not None:
             findings.append(self_ref)
+        # Beside the self-reference finding and for the identical reason: the
+        # compatibility line is read with a line regex and needs no parser, so it
+        # has a definite answer on a run where the body scan has none.
+        compat = compatibility_finding(path.name, frag.section, text)
+        if compat is not None:
+            findings.append(compat)
         try:
             body_findings = scan_fragment_body(path.name, text)
         except CannotValidate:
             # A refusal that needed no parser outranks "could not look". The
             # alternative loses the definite answer to report the absent one,
             # which is the shape `validators/changelog-fragment` already names.
-            if self_ref is None:
+            if self_ref is None and compat is None:
                 raise
             continue
-        if self_ref is not None or body_findings:
+        if self_ref is not None or compat is not None or body_findings:
             findings.extend(body_findings)
             continue
         fragments.append(Fragment(frag.issue, frag.section, frag.slug, path))
@@ -2175,9 +2338,15 @@ def check(directory: Path) -> int:
         _receipt("refused", "{0} fragment(s) will not assemble".format(len(findings)),
                  ["{0}/{1}".format(directory.name, line) for line in findings])
         return REFUSED
+    # Named on every branch below, including `ok`: a verdict that does
+    # not say what it read cannot be checked by the person reading it, and
+    # `directory.name` alone (a bare basename like `changelog.d`) does not
+    # say which repository that directory sits under -- resolved is the only
+    # spelling that answers the question this fragment's own bug was about.
+    resolved = directory.resolve()
     if not fragments:
         _receipt("skipped", "{0}/ holds 0 fragments — nothing to validate"
-                 .format(directory.name))
+                 .format(resolved))
         return OK
     # The receipt states what was established and names what established it,
     # which the last three did not. "no body writes at column 0" stayed
@@ -2185,14 +2354,18 @@ def check(directory: Path) -> int:
     # link ref, at any indent or nesting" was true of the scanner's own model
     # of CommonMark and false of CommonMark. This claim is checkable by the
     # person reading it: it is what markdown-it-py saw.
-    _receipt("ok", "{0} fragments, all names parse, each body names the issue "
-                   "in its own filename; each body parsed with "
-                   "markdown-it-py {1}, whose token stream holds no heading, no "
+    _receipt("ok", "{0} fragments in {1}, all names parse, each body names "
+                   "the issue in its own filename, and every compatibility line "
+                   "present reads as `{3}` or `{4}` with a reason (a `{5}` "
+                   "fragment carrying none is a finding, every other section may "
+                   "omit it); each body parsed with "
+                   "markdown-it-py {2}, whose token stream holds no heading, no "
                    "link ref definition and no raw HTML at any depth, whose "
                    "fences all close inside the fragment, whose top level is "
                    "one `- ` bullet list, and every link and image destination "
                    "in which is on the allowlist"
-             .format(len(fragments), _MD_VERSION),
+             .format(len(fragments), resolved, _MD_VERSION,
+                     BREAKING, COMPATIBLE, "`/`".join(MUST_DECLARE) or "no"),
              ["{0}  {1}".format(f.path.name if f.path else "?", f.section) for f in fragments])
     return OK
 
@@ -2208,11 +2381,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     # caller named this" and "we guessed it", which is the whole question.
     parser.add_argument("--changelog", default=None,
                         help="path to CHANGELOG.md; required to fold, derived "
-                             "from this script's own repository for the "
-                             "read-only modes")
+                             "from the caller's own current working "
+                             "directory for the read-only modes")
     parser.add_argument("--dir", dest="directory", default=None,
                         help="path to the fragment directory; required to "
-                             "fold, derived for the read-only modes")
+                             "fold, derived from the caller's cwd for the "
+                             "read-only modes")
     parser.add_argument("--dry-run", action="store_true", help="report, write nothing")
     parser.add_argument("--keep", action="store_true", help="do not delete consumed fragments")
     parser.add_argument("--check", action="store_true",
@@ -2243,11 +2417,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     def _resolve(value: Optional[str], flag: str,
                  derived: Optional[Path]) -> Optional[Path]:
         """Read-only modes only. Take what the caller passed, else the value
-        derived from this script's own location.
+        derived from the caller's own current working directory --
+        not from this script's install location, which may be a plugin
+        cache unrelated to whatever repository the caller means.
 
-        No `--dir`/`--changelog` given, and no `.git` found above this script
-        to derive a default from: say so, rather than composing a path out of
-        a guess and failing on that instead.
+        No `--dir`/`--changelog` given, and no `.git` found above the
+        caller's cwd to derive a default from: say so, rather than composing
+        a path out of a guess and falling back to the script's own tree.
 
         An empty string is treated the same as absent, not as `Path('')` --
         which `pathlib` reads as `.`. `--dir ''` is what a caller gets when
@@ -2263,11 +2439,20 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         if value:
             return Path(value)
         if derived is None:
-            _receipt("skipped",
-                     "could not find the repository root above {0} "
-                     "(no .git there or in any parent) to derive a default "
-                     "for {1}; pass it explicitly"
-                     .format(Path(__file__).resolve(), flag))
+            if _CWD is None:
+                # The rarer of the two `derived is None` causes: the process's
+                # own current directory no longer exists to walk up from at
+                # all (see `_safe_cwd`), not merely "no .git found above it".
+                _receipt("skipped",
+                         "could not read the current working directory to "
+                         "derive a default for {0}; pass it explicitly"
+                         .format(flag))
+            else:
+                _receipt("skipped",
+                         "could not find the repository root above {0} "
+                         "(no .git there or in any parent) to derive a default "
+                         "for {1}; pass it explicitly"
+                         .format(_CWD, flag))
             return None
         if value == "":
             # Distinct from `value is None` -- the caller said *something*,
@@ -2286,11 +2471,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         """The fold's target, or a refusal that names what to pass.
 
         Deliberately does not fall back to `REPO`. See the module docstring:
-        the derivation says which repository this file is *stored* in, the
-        fold needs the one being *released*, and no copy of this script can
-        tell whether those are the same. A refusal that only reported
-        something missing would turn a wrong-target write into a dead end, so
-        this prints the flags and a whole invocation.
+        the derivation says which repository the caller's cwd is *inside*
+        of, the fold needs the one being *released*, and no copy of this
+        script can tell whether those are the same. A refusal that only
+        reported something missing would turn a wrong-target write into a
+        dead end, so this prints the flags and a whole invocation.
 
         An empty string counts as missing, the same as `None`. `Path('')` is
         `Path('.')`, so without this an empty `--dir` or `--changelog` would
@@ -2320,9 +2505,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
                   "CHANGELOG.md".format(args.version),
                   "why       the fold derives no default, in this copy or the "
                   "one vendored into a managed repo. This file finds a "
-                  "repository root by walking up from itself, which names the "
-                  "repository it is stored in and not the one you are "
-                  "releasing; nothing on disk says whether those are the same",
+                  "repository root by walking up from your current working "
+                  "directory, which names wherever you happen to be standing "
+                  "and not necessarily the one you are releasing; nothing on "
+                  "disk says whether those are the same",
                   "untouched CHANGELOG.md was not read or written, and no "
                   "fragment was consumed"])
         return None
@@ -2332,6 +2518,31 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     #: named nothing", which is what the fold gate reads.
     derived_dir = (REPO / "changelog.d") if REPO else None
     derived_changelog = (REPO / "CHANGELOG.md") if REPO else None
+
+    # `--check` and `--check-links` together used to run only the links audit --
+    # the mode dispatch below is a chain of `if`/`return`, and `check_links` was
+    # tested and returned before `check` was ever reached, so a fragment this
+    # run never opened could sit next to a link table that happened to be fine
+    # and the whole thing printed a single confident `ok`. That `ok` names what
+    # it did audit ("N release section(s)"), which reads as thorough rather
+    # than partial, and a combined invocation like this one is exactly what a
+    # "check before pushing" habit reaches for. Refusing the combination is the
+    # same shape as the `--untagged` refusal just below: a caller who asks for
+    # two audits in one call gets two separate ones, never a silent choice
+    # between them.
+    if args.check and args.check_links:
+        _receipt("refused",
+                 "--check and --check-links together only ever ran the links "
+                 "audit -- the fragment audit was silently skipped, and the "
+                 "printed ok named only the half that ran",
+                 ["run       --check --dir <fragment directory> for the "
+                  "fragment audit",
+                  "run       --check-links --changelog <changelog file> "
+                  "[--untagged x.y.z,...] for the link audit",
+                  "why       each flag already audits its own thing "
+                  "completely; combining them silently ran only one, which is "
+                  "the one failure mode a guard must not have"])
+        return REFUSED
 
     # `--untagged` is read by `--check-links` and by nothing else. Accepting it
     # silently on the fold, `--check` or `--count` would make a declaration that

--- a/.oss/statusline.py
+++ b/.oss/statusline.py
@@ -30,6 +30,7 @@ Python 3.9 compatible.
 
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -49,6 +50,22 @@ REFRESH_AFTER = 60
 #: order of weeks -- so they are carried forward between long intervals rather than making
 #: the board wait on them.
 LATEST_REFRESH_AFTER = 3600
+
+#: A third clock (#613), beside the two above, for the one field that answers a
+#: question neither of them can afford: is the watch channel actually delivering.
+#: `channel:health` is classed `acts` and spawns `claude mcp get` once per
+#: subscription tag -- 1-3s measured in supertool's own presets/watch/channel.py
+#: -- so it cannot share the board's 60s clock, and the consumer it asks about can
+#: die at any moment, which is far too often for LATEST_REFRESH_AFTER's 3600s.
+#:
+#: 300 is a GUESS TO BE MEASURED, not a number this module asserts as correct --
+#: the issue's own words (#613). There is no history of consumer deaths on this
+#: repository to fit an interval to, so any starting value ships unmeasured; what
+#: would settle it is a wall-clock record of how long a real death goes
+#: unreported at this interval, taken the first time one actually happens. State
+#: what it cost when that reading is in hand -- do not silently promote this
+#: constant to "measured" later without adding that record.
+CHANNEL_REFRESH_AFTER = 300
 
 #: How long a refresh may hold its lock before another render is allowed to retry. A
 #: lock that outlives a killed refresher would otherwise freeze the counts forever.
@@ -144,22 +161,167 @@ def version_status(installed, latest, stale=False):
     return {"state": state, "installed": installed, "latest": latest}
 
 
+# -------------------------------------------------------------------------- channel
+
+
+#: The text after "channel: " on `channel:health`'s own first content line,
+#: mapped to this module's five-way state (#613). Both routes to that report --
+#: `channel.py` run directly and `supertool 'channel:health'` -- agree on this
+#: text; only the exit code differs, and the supertool wrapper collapses every
+#: non-zero exit to 1, so text is the only signal both routes share. Anything
+#: not a key here -- an error page for a preset that is not enabled, output this
+#: module has never seen -- is deliberately not in this table, so it falls
+#: through to `cannot_determine` in `parse_channel_report` rather than being
+#: guessed at.
+CHANNEL_STATES = {
+    "FORWARDING": "forwarding",
+    "NOT DELIVERING": "not_delivering",
+    "CANNOT DETERMINE": "cannot_determine",
+    "CONTRADICTED": "contradicted",
+    "BOUND, NOT SUBSCRIBED": "not_subscribed",
+}
+
+#: Same name supertool's own `presets/watch/naming.py` reads (`NAME_ENV`). Not
+#: imported -- this module has no third-party imports and is vendored standalone
+#: -- so the string is duplicated rather than the module.
+WATCH_NAME_ENV = "SUPERTOOL_WATCH_NAME"
+
+#: A copy of `oss_config.WATCH_NAME_UNSAFE_RE`'s substitution, not an import of
+#: it, for the same reason `_one_line` below is a copy of `doctor.py`'s own
+#: function rather than an import: this file is vendored into `.oss/statusline.py`
+#: and must run standalone. `tests/test_statusline_channel_613.py` measures this
+#: constant against `oss_config.watch_channel_name` directly so the two copies
+#: cannot drift silently -- the failure mode #570 named for the supertool rule
+#: body, one file over.
+_WATCH_NAME_UNSAFE_RE = re.compile(r"[^A-Za-z0-9._-]")
+
+#: A copy of `oss_config.REPO_RE`, for the same standalone-vendoring reason as
+#: the pattern above (#653). `oss_config.watch_channel_name` routes a candidate
+#: `repo` through `repo_problem` -- this pattern -- BEFORE folding it, which is
+#: what keeps a refused value like `'..'` from ever reaching the fold. The copy
+#: above used to skip straight to the fold and had no refusal in front of it at
+#: all, so `'..'` and `'../../etc'` -- both refused by `oss_config` -- still
+#: produced a channel name here. `tests/test_statusline_watch_name_refusal_653.py`
+#: is the positive control: slugs `oss_config` REJECTS, not only ones it accepts.
+_REPO_RE = re.compile(r"\A[^/\s]+/[^/\s]+\Z")
+
+
+def _expected_watch_name(repo):
+    """The watch channel name THIS repository would derive from its own `repo`.
+
+    `None` for anything that is not a non-empty string that also matches the
+    same `owner/name` shape `oss_config.repo_problem` requires -- there is no
+    name to expect from a `.oss.json` that states no repo, or one that states
+    something `oss_config` would refuse, and `None` can never equal whatever
+    `SUPERTOOL_WATCH_NAME` happens to hold, which is exactly the "do not
+    attribute" outcome the issue's closing bullet asks for.
+    """
+    if not isinstance(repo, str) or not repo:
+        return None
+    if not _REPO_RE.match(repo):
+        return None
+    return _WATCH_NAME_UNSAFE_RE.sub("-", repo)
+
+
+def parse_channel_report(text):
+    """The state `channel:health` reported, from its own report text, or `None`.
+
+    `None` covers everything that is not one of the five recognised states --
+    most importantly the "op 'channel' is unavailable here" refusal supertool
+    prints when the `watch` preset is not enabled, which also exits 1 and would
+    otherwise be indistinguishable from a genuine `NOT DELIVERING` (#613; this
+    was reproduced live against the installed supertool while filing this fix).
+    A caller maps `None` to `cannot_determine`, never to a guess.
+    """
+    if not text:
+        return None
+    for line in str(text).splitlines():
+        # Anchored at column 0, before any stripping (#654) -- an indented
+        # line that merely LOOKS like a state line (e.g. a padded "channel  :"
+        # detail line, or remote-authored text reproducing the shape) must
+        # never outrank the genuine state line. Stripping first erased that
+        # distinction and let the first STRIPPED match win regardless of
+        # indentation, which relied on the report's own composition order
+        # rather than on this parser's own anchor.
+        if line.startswith("channel: "):
+            return CHANNEL_STATES.get(line[len("channel: "):].strip())
+    return None
+
+
+def channel_status(raw_state, attributable, fetched_at, now, interval=CHANNEL_REFRESH_AFTER):
+    """Fold a raw `channel:health` reading, its own age and its attribution into
+    the state `render` actually shows (#613).
+
+    Three ways this becomes `cannot_determine` before a caller ever sees one of
+    the five real states, and each is a distinct reason a reader might act on
+    differently -- collapsing them into one `?` would be this module's own
+    defect class, the same reason `board_from_cache` keeps its counts separate:
+
+    * ``not-asked``    -- nobody has taken a reading yet (`fetched_at` is None).
+    * ``stale``        -- the reading is older than its own refresh interval
+      (#550/#551's lesson, applied a third time: never let an old reading
+      render as though it were fresh).
+    * ``not-attributable`` -- the channel name this reading came from was not
+      derived from this repository's own `.oss.json`, so the socket and poller
+      slots may be another project's fleet entirely (the issue's closing
+      bullet). Checked first and unconditionally: an unattributed reading must
+      never reach the real-state branch below, however fresh it is.
+
+    Deliberately NOT handled here, and this is #551's own gap restated for a
+    third instrument: a reading that is fresh BY THIS RULE and simply wrong --
+    the consumer died one second after the reading was taken -- renders exactly
+    like a correct one. Nothing performs "the consumer died" the way
+    `/oss:release` performs a publish, so there is no falsifying event to
+    invalidate the cache against; #613's own docstring on `CHANNEL_REFRESH_AFTER`
+    states that gap rather than papering over it.
+
+    `not-asked` is checked BEFORE `attributable`, and that order is deliberate:
+    a cache holding no reading at all also holds no attribution, so
+    `attributable` defaults falsy there too -- checking it first would report
+    every never-asked repository as "not this repo's fleet" instead of "nobody
+    has looked yet", which is a different and more alarming claim about a
+    question that was never even put.
+    """
+    if not isinstance(fetched_at, (int, float)):
+        return {"state": "cannot_determine", "reason": "not-asked"}
+    if not attributable:
+        return {"state": "cannot_determine", "reason": "not-attributable"}
+    if now - fetched_at >= interval:
+        return {"state": "cannot_determine", "reason": "stale"}
+    if raw_state not in CHANNEL_STATES.values():
+        return {"state": "cannot_determine", "reason": "unrecognized"}
+    return {"state": raw_state, "reason": None}
+
+
 # ---------------------------------------------------------------------------- board
 
 
 def board_from_cache(cache, now=None):
-    """Read the two forge counts back out of a cache document.
+    """Read the forge counts back out of a cache document.
 
     Each count is read on its own. A cache written by a refresh where one call answered
-    and the other did not is a real state, and collapsing it to "unknown board" throws
-    away the half that was measured.
+    and another did not is a real state, and collapsing it to "unknown board" throws away
+    the half that was measured -- which is why there is no summary `state` field here.
+    An earlier version computed one (`unknown`/`partial`/`measured`) from exactly these
+    same values, but nothing ever read it: `_board_field` renders `?` per missing value
+    directly off `prs`/`issues`/`issues_external`/`checks`, regardless of what a summary
+    said. #595 added a rule to that summary -- a cache carrying `issues` but no
+    `issues_external` is `partial` -- and the rule could not affect anything a maintainer
+    sees, because the field it was added to had no caller. That is the same shape as a
+    check that never runs (#597): a guard nobody reads. Deleted rather than wired to a
+    reader, because each of the three counts below already carries its own missing/present
+    distinction, and a summary that can disagree with the values it summarizes is a second
+    copy of the same fact -- one that was, in fact, never even complete: it never accounted
+    for `checks` at all.
     """
     if not isinstance(cache, dict):
-        return {"state": "unknown", "prs": None, "issues": None, "age": None}
+        return {"prs": None, "issues": None, "issues_external": None, "age": None}
     prs = cache.get("prs")
     issues = cache.get("issues")
+    issues_external = cache.get("issues_external")
     prs = prs if isinstance(prs, int) else None
     issues = issues if isinstance(issues, int) else None
+    issues_external = issues_external if isinstance(issues_external, int) else None
     checks = cache.get("pr_checks")
     if not (
         isinstance(checks, dict)
@@ -172,13 +334,10 @@ def board_from_cache(cache, now=None):
     age = None
     if isinstance(fetched, (int, float)):
         age = max(0.0, (time.time() if now is None else now) - fetched)
-    if prs is None and issues is None:
-        state = "unknown"
-    elif prs is None or issues is None:
-        state = "partial"
-    else:
-        state = "measured"
-    return {"state": state, "prs": prs, "issues": issues, "checks": checks, "age": age}
+    return {
+        "prs": prs, "issues": issues, "issues_external": issues_external,
+        "checks": checks, "age": age,
+    }
 
 
 # ------------------------------------------------------------------ release progress
@@ -571,6 +730,7 @@ def _symbols(ascii_only):
             "bad": "x",
             "run": "...",
             "unk": "?",
+            "own": "b",
         }
     return {
         "sep": " | ",
@@ -592,6 +752,13 @@ def _symbols(ascii_only):
         "bad": "✗",
         "run": "⋯",
         "unk": "?",
+        # `BOUND, NOT SUBSCRIBED` (#613): a consumer that is bound, verified and
+        # counting, with nobody subscribed -- distinct from both `ok` and `bad`,
+        # because it is neither a pass nor an absence, it is a finding of its own
+        # (supertool's own `presets/watch/channel.py` docstring: "a fourth state
+        # on purpose", "a fifth state for the same reason"). Half-filled shape
+        # reads as "handed off, half-heard" even before the colour is read.
+        "own": "◐",
     }
 
 
@@ -638,7 +805,8 @@ def _last_field(stamp):
 
 
 def _board_field(board, symbols, color=False):
-    """`4pr 2ok 1x 1... 0? . 23is` -- how many are open, and what CI says about each.
+    """`4pr 2ok 1x 1... 0? . 23is / 2eis` -- how many are open, what CI says about each,
+    and how many of the issues arrived from outside repository membership (#595).
 
     Lowercase because the fields either side of it are, and a status line that shouts one
     field trains the eye to read that one first regardless of what it says.
@@ -647,10 +815,14 @@ def _board_field(board, symbols, color=False):
     makes the reader subtract to find what is missing, and `0x` -- nothing red -- and `0...`
     -- nothing on the way -- are two of the more useful things this line can say. The one
     thing that does collapse is a reading that never happened: rollups nobody could fetch
-    render as a single `?`, never as four zeros.
+    render as a single `?`, never as four zeros. `eis` follows the same rule: `0eis` is a
+    real reading -- nobody outside has filed anything -- and it must stay visibly different
+    from `?eis`, a count nobody could take, because zero external issues is both a common
+    true answer and exactly what a failed call looks like.
     """
     prs = board.get("prs")
     issues = board.get("issues")
+    issues_external = board.get("issues_external")
     checks = board.get("checks")
     if isinstance(checks, dict):
         groups = " ".join(
@@ -664,11 +836,12 @@ def _board_field(board, symbols, color=False):
         )
     else:
         groups = symbols["unk"]
-    return "{}pr {}{}{}is".format(
+    return "{}pr {}{}{}is / {}eis".format(
         "?" if not isinstance(prs, int) else prs,
         groups,
         symbols["dot"],
         "?" if not isinstance(issues, int) else issues,
+        "?" if not isinstance(issues_external, int) else issues_external,
     )
 
 
@@ -810,6 +983,49 @@ def _plugins_field(plugins, symbols, color=False):
     return "plug " + " ".join(parts)
 
 
+def _channel_field(channel, symbols, color=False):
+    """`ch` + a one-glyph verdict on the watch channel, or nothing at all (#613).
+
+    Three or four characters -- the same width discipline `_plugins_field` (#512)
+    argues for (that field spent 45 characters saying nothing on almost every
+    render), scaled down for a field with five possible states rather than a
+    per-plugin list.
+    `None` -- never a placeholder `?` -- when `watch_channel` is off in
+    `.oss.json`: an operator's deliberate off switch is not the same absence as
+    a question this line asked and could not answer, and the whole point of the
+    third state this repository is named after is keeping those apart.
+
+    The five upstream states map to distinct markers because they call for
+    distinct actions (the issue's own table): a pass, a definite negative, a
+    finding that is neither, a contradiction, and "nothing was established".
+    `CONTRADICTED` renders uncoloured on purpose, matching the issue's own table,
+    whose shade column is blank for that row alone.
+
+    **What this must never claim, in the render layer too, not only in the
+    docstrings that compute the state:** `forwarding` means the consumer's own
+    counters are moving, never that an event reached a Claude session --
+    `channel:health`'s own module docstring states outright that delivery into a
+    session is not observable from outside it. Nothing here spells `forwarded`
+    as `delivered`.
+    """
+    if channel is None:
+        return None
+    state = channel.get("state")
+    if state == "forwarding":
+        text, shade = "ch" + symbols["ok"], GREEN
+    elif state == "not_delivering":
+        text, shade = "ch" + symbols["bad"], RED
+    elif state == "not_subscribed":
+        text, shade = "ch" + symbols["own"], YELLOW
+    elif state == "contradicted":
+        text, shade = "ch!", None
+    else:
+        text, shade = "ch" + symbols["unk"], DIM
+    if not color or shade is None:
+        return text
+    return shade + text + RESET
+
+
 def render(facts, ascii_only=False, color=False):
     """The whole line, from facts already gathered. No I/O, so it is testable.
 
@@ -864,6 +1080,9 @@ def render(facts, ascii_only=False, color=False):
     blocks.append(_last_field(facts.get("last")))
 
     blocks.append(_plugins_field(facts.get("plugins") or [], symbols, color))
+    channel_block = _channel_field(facts.get("channel"), symbols, color)
+    if channel_block is not None:
+        blocks.append(channel_block)
     return symbols["sep"].join(blocks)
 
 
@@ -1099,6 +1318,90 @@ def _gh_count(repo, kind):
         return None
 
 
+#: GitHub's own membership tiers -- `authorAssociation` values that mean "one of us".
+_INSIDE_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
+
+
+def _gh_external_issue_count(repo, total):
+    """How many of the `total` open issues (`_gh_count`'s own answer) were filed by
+    someone outside repository membership, per GitHub's `authorAssociation` (#595).
+
+    Not `-author:@me`: that resolves to whoever is authenticated on this machine, so
+    the count would be a fact about a laptop rather than about the repository, and a
+    second maintainer running this same loop would see a different number for the
+    same tracker. `authorAssociation` is repo-relative and identical for everyone --
+    and it is already what supertool's own `gh-issues` op uses for its external-filer
+    marker, so the two boards agree instead of answering differently.
+
+    **Not `gh issue list --json authorAssociation` (#620).** That field has never
+    existed on `gh issue list` -- `gh` refuses the whole call, exit 1, empty stdout,
+    every single time, and the six-fixture suite that shipped with #595 could not
+    catch it because every fixture there mocked `_run`'s *return value* and none of
+    them looked at what `_run` was *called with*. `author_association` does exist on
+    the REST `repos/{owner}/{repo}/issues` listing, so this reads that instead, with
+    `--jq` selecting the one field this function needs and dropping pull requests --
+    that endpoint mixes both, and a PR row carries a `pull_request` key an issue never
+    has, so `select(.pull_request == null)` filters server-side before this function
+    ever sees a row. Without it the row count would include PRs and permanently fail
+    the cross-check below, because `_gh_count`'s own `is:issue` search never counts
+    them.
+
+    **`--jq` output, not `--paginate`'s raw concatenation, and the difference is not
+    cosmetic.** `_gh_count`'s own docstring already documents that `gh api --paginate
+    --jq` runs its filter once per page and prints one number per page with no total
+    -- irrelevant here, since this asks for one row per issue rather than a count.
+    What matters for `--paginate` *without* `--jq` is that each page is a raw JSON
+    array, and concatenating two JSON arrays end to end produces text no parser can
+    read (`[...][...]`) -- the exact trap #620's own writeup names for a naive fix.
+    `--jq` sidesteps it by construction: piping `.[] | select(...) | .author_association`
+    through jq's raw-output mode prints one bare `author_association` value per line,
+    and *lines* concatenate safely across pages -- unlike JSON arrays, there is no
+    boundary for two pages' lines to collide on. `--paginate` alone still walks every
+    page regardless of the repository's issue count, so there is no analogue of the
+    old `--limit`-at-100 hazard to reintroduce here.
+
+    The row count is cross-checked against `total` exactly as before: fewer lines
+    than the count `_gh_count` already took means this call did not cover every open
+    issue (a rate limit, a truncated page, the tracker growing between the two
+    calls), and the number is not reliable enough to report. `None`, never a count
+    smaller than the truth -- the same convention `_gh_count`'s own docstring names.
+    A `null` line (jq's raw-mode spelling of a missing/`None` field) is treated the
+    same as a missing row: one unreadable association and the whole count is untaken.
+    """
+    if not isinstance(total, int):
+        return None
+    out = _run(
+        [
+            "gh",
+            "api",
+            "--paginate",
+            "-X",
+            "GET",
+            "repos/{}/issues".format(repo),
+            "-f",
+            "state=open",
+            "-f",
+            "per_page=100",
+            "--jq",
+            ".[] | select(.pull_request == null) | .author_association",
+        ],
+        timeout=25,
+    )
+    if out is None:
+        return None
+    lines = out.split("\n") if out else []
+    if len(lines) != total:
+        return None
+    external = 0
+    for line in lines:
+        assoc = line.strip()
+        if not assoc or assoc.upper() == "NULL":
+            return None
+        if assoc.upper() not in _INSIDE_ASSOCIATIONS:
+            external += 1
+    return external
+
+
 #: How many open pull requests one rollup page carries. Anything past it is counted as
 #: unknown rather than dropped, so the groups still sum to the exact count beside them.
 ROLLUP_PAGE = 100
@@ -1173,14 +1476,98 @@ def _latest_release(repo):
         return None
 
 
+def _watch_preset_declared(root):
+    """Does this repository's tracked `.supertool.json` enable the `watch` preset?
+
+    Three states, not two: `True`/`False` are a real answer, `None` is "could not
+    tell" -- no such file, or one this process could not parse -- and a caller
+    must not spend the `channel:health` subprocess's own cost finding out the
+    hard way. Measured live while filing #613: with the preset disabled,
+    `supertool 'channel:health'` still exits 1 but prints "op 'channel' is
+    unavailable here", never a `channel: ` line at all -- so skipping the call
+    here also avoids relying on `parse_channel_report` to catch that refusal
+    every single time.
+    """
+    try:
+        data = json.loads((Path(root) / ".supertool.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        # Self-review finding on this issue: `.supertool.json` is a file this
+        # module does not own or control the shape of, and `json.loads` accepts
+        # any valid JSON document -- a bare list, a number, `null`. `.get` on
+        # anything but a dict raised `AttributeError` here with no `except`
+        # above it in `refresh()`'s own call chain, so a malformed-but-parseable
+        # file silently killed the WHOLE detached refresh, not only this field:
+        # board counts and plugin versions stopped updating along with it.
+        return None
+    presets = data.get("presets")
+    if not isinstance(presets, list):
+        return False
+    return "watch" in presets
+
+
+def _run_channel_health(timeout=30):
+    """The raw text of `supertool 'channel:health'`, regardless of its exit code.
+
+    NOT `_run`: that helper returns `None` on any non-zero exit, and `NOT
+    DELIVERING`/`CANNOT DETERMINE`/`CONTRADICTED`/`BOUND, NOT SUBSCRIBED` are
+    all real, distinct findings that exit non-zero on purpose (supertool's own
+    `presets/watch/channel.py`: "a single non-zero would put answers this op
+    exists to separate back into one bucket"). Using `_run` here would fold
+    four of the five real states into the same `None` a missing binary
+    produces, which is the exact defect this field exists to stop happening to
+    the loop's own instrumentation.
+
+    30s, not the 1-3s the issue's own measurement names: that number is the
+    ordinary case, and `MCP_LOOKUP_BUDGET` plus `PS_TIMEOUT` (supertool's own
+    constants) put a documented worst case north of 20s when a lookup is slow
+    rather than merely present.
+    """
+    try:
+        result = subprocess.run(
+            ["supertool", "channel:health"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return result.stdout.decode("utf-8", "replace")
+
+
+def _channel_reading(root, config):
+    """One `channel:health` reading for `refresh()`, or why there is none.
+
+    `(raw_state, attributable)`. `raw_state` is `None` when the `watch` preset
+    is not declared, `.supertool.json` could not be read, the `supertool`
+    binary could not be run, or its report carried no recognisable `channel: `
+    line -- every one of those folds to `cannot_determine` in `channel_status`,
+    never to a guess. `attributable` is independent of all of that: it asks
+    whether THIS process's own `SUPERTOOL_WATCH_NAME` -- read here, in the
+    detached refresh's own environment, which is the environment the actual
+    `channel:health` call below ran under -- is the name this repository's own
+    `.oss.json` would derive, per the issue's closing bullet: a reading off an
+    inherited name must never be attributed to this repository's fleet, however
+    real the reading itself is.
+    """
+    expected = _expected_watch_name(config.get("repo"))
+    actual = os.environ.get(WATCH_NAME_ENV) or None
+    attributable = bool(expected) and expected == actual
+    if _watch_preset_declared(root) is not True:
+        return None, attributable
+    return parse_channel_report(_run_channel_health()), attributable
+
+
 def refresh(root, now=None):
     """Fill the cache for one managed repository. Runs detached, never on the render path.
 
-    Two clocks (#515). The board -- open pull requests, open issues, their check rollups --
-    is re-read every time; the version each plugin's source repository publishes is re-read
-    only when its own longer interval has passed, and carried forward from the previous
-    cache in between. Four of the seven forge calls were the second kind, which is why the
-    board's own interval could not be shortened while they shared one.
+    Two clocks (#515), soon three (#613). The board -- open pull requests, open issues,
+    who filed each, their check rollups -- is re-read every time; the version each
+    plugin's source repository publishes is re-read only when its own longer interval
+    has passed, and carried forward from the previous cache in between. Four of the
+    eight forge calls are the second kind (#595 added a fourth board call), which is
+    why the board's own interval could not be shortened while they shared one.
 
     A carried-forward value carries its own stamp with it. Stamping it `now` would make an
     hour-old reading indistinguishable from one just taken, which is the same defect this
@@ -1195,6 +1582,7 @@ def refresh(root, now=None):
     if repo:
         document["prs"] = _gh_count(repo, "pr")
         document["issues"] = _gh_count(repo, "issue")
+        document["issues_external"] = _gh_external_issue_count(repo, document["issues"])
         document["pr_checks"] = check_rollup_counts(_gh_rollups(repo), document["prs"])
     carried = previous.get("latest")
     carried = dict(carried) if isinstance(carried, dict) else {}
@@ -1223,6 +1611,29 @@ def refresh(root, now=None):
             # under its own old stamp, which is what makes it due again immediately.
             document["latest"] = carried
             document["latest_fetched_at"] = carried_stamp
+    if config.get("watch_channel") is False:
+        # A deliberate off switch (#613): no reading, no stamp, and never
+        # carried forward from a previous `on` state -- `channel_status` reads
+        # this back through `gather()` and the field disappears from the line
+        # rather than rendering `?`, which would misstate a decision as a
+        # question nobody could answer.
+        document["channel"] = None
+        document["channel_fetched_at"] = None
+    else:
+        previous_channel_stamp = previous.get("channel_fetched_at")
+        channel_due = not isinstance(previous_channel_stamp, (int, float)) or (
+            now - previous_channel_stamp >= CHANNEL_REFRESH_AFTER
+        )
+        if channel_due:
+            raw_state, attributable = _channel_reading(root, config)
+            document["channel"] = {"raw_state": raw_state, "attributable": attributable}
+            document["channel_fetched_at"] = now
+        else:
+            # Carried forward under its OWN old stamp, same shape as `latest`
+            # above and for the same reason: re-stamping `now` would make an
+            # old reading indistinguishable from a fresh one at the render.
+            document["channel"] = previous.get("channel")
+            document["channel_fetched_at"] = previous_channel_stamp
     path = cache_path(repo)
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(".tmp")
@@ -1412,6 +1823,16 @@ def gather(payload, root, now=None):
     stale_latest = latest_is_due(cache, now)
     loop_name = os.environ.get("OSS_STATUSLINE_PLUGIN", "oss")
 
+    channel = None
+    if config.get("watch_channel") is not False:
+        raw_channel = (cache or {}).get("channel") or {}
+        channel = channel_status(
+            raw_channel.get("raw_state"),
+            raw_channel.get("attributable", False),
+            (cache or {}).get("channel_fetched_at"),
+            now,
+        )
+
     # One tail read shared by both transcript-derived facts (#504) -- a render
     # happens on every message, so a second full scan would be a doubled,
     # unmeasured cost paid every time rather than an occasional one.
@@ -1433,6 +1854,7 @@ def gather(payload, root, now=None):
         "tick": tick,
         "last": _render_stamp(now),
         "plugins": plugin_facts(loop_name, installed_plugins(root), latest, stale=stale_latest),
+        "channel": channel,
     }
 
 


### PR DESCRIPTION
## What

`/oss:scaffold --apply` run against oss 0.17.0, which replaces the four owned files wholesale and rewrites the `01-oss` jit-context rule layer.

- `.oss/README.md`, `.oss/assemble_changelog.py`, `.oss/statusline.py`, `.github/workflows/oss-changelog.yml` (the workflow came back byte-identical, so it is not in the diff)
- the nine files of the `01-oss` layer, including a new `vocabulary/01-oss/plugin-currency.md`

## Why

Owned files are replaced wholesale by the scaffold command, so a fix shipped in the plugin reaches this repo only when the command is re-run here. `/oss:doctor` reported all three `.oss/` files as *would change what it does*, naming the regions, and that is the only signal that the re-run is worth doing.

The layer rewrite also clears the second doctor warning: `tools/01-oss/00-index.tsv` was stale, its rows for `supertool-required.md` no longer matching that entry's frontmatter, so the rule that ran was not the rule as written.

No hand edits were carried in any of these files, so the wholesale replacement discards nothing of ours.

## Result

`/oss:doctor` before: 7 warnings. After: 3. The three that remain are not repo faults and none is fixed here:

- `project dir guessed from cwd` -- no `--root` was passed to the diagnostic; it landed on the right tree.
- `./supertool` points at the local checkout at `~/Documents/claude-supertool/supertool.py`. Deliberate or stale looks the same from a script; leaving it alone.
- `jit rule layer` is *unknown*, not a gap: the only layer list found in claude-jit-context 0.6.0 is in a test fixture the runtime never executes, and one hook line enumerates by glob. That belongs upstream.

## Testing

`pytest` is running locally and had not finished when this was opened -- the result is a comment on this PR, not a claim in this description. CI across three OSes and four interpreters is the gate either way, and a green local run on macOS/arm64 says nothing about the other legs.

Nothing user-visible ships here, so this is labelled `no-changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbgfeEN6BkkpSsW7u8Etcf