### PR TITLE
fix: #480 Detector 1 of the #467 home-path guard enumerated tests/fixtures/ non-recursively

### DIFF
--- a/changelog.d/480.fixed.md
+++ b/changelog.d/480.fixed.md
@@ -1,0 +1,8 @@
+- Fixed: the #467 home-path guard's Detector 1 (`tests/test_no_real_home_paths_467.py`)
+  enumerated `tests/fixtures/` non-recursively (`iterdir()`), so a real `/Users/<x>/` or
+  `/home/<x>/` segment committed inside a subdirectory of `tests/fixtures/` was invisible
+  to the detector, and its own positive control could not have noticed -- it only asserted
+  a file count, satisfied by the top-level files alone. The scan now walks the tree
+  (`rglob("*")`) and a new receipt test cross-checks the file count it examined against
+  `git ls-files tests/fixtures`, so a walk that silently drops a subtree disagrees with a
+  number instead of passing quietly. (#480)

--- a/tests/test_no_real_home_paths_467.py
+++ b/tests/test_no_real_home_paths_467.py
@@ -189,7 +189,19 @@ _HOME_PATH = re.compile(r"(?:/Users/|/home/)([A-Za-z0-9_.-]+)")
 
 
 def _fixture_files() -> list[Path]:
-    return sorted(p for p in FIXTURES_DIR.iterdir() if p.is_file())
+    """Recursive by design (#480): `iterdir()` only ever saw the
+    immediate children of tests/fixtures/, so a fixture arriving inside
+    a subdirectory -- exactly the shape a future real capture could
+    land in -- was invisible to Detector 1 at any depth, and its own
+    positive control (`test_scanned_at_least_one_fixture_file`'s
+    `>= 2`) could not have noticed, because it counts files rather than
+    walking the tree it claims to cover. `rglob("*")` walks every
+    subdirectory; the `>= 2` control below is unchanged (still catches
+    an empty/broken walk), and `test_fixture_scan_reports_how_many_files_it_examined`
+    adds the other half the issue asked for -- a receipt cross-checked
+    against `git ls-files`, so a walk that silently drops a subtree
+    disagrees with a number nobody has to trust the walk itself for."""
+    return sorted(p for p in FIXTURES_DIR.rglob("*") if p.is_file())
 
 
 def test_scanned_at_least_one_fixture_file():
@@ -239,6 +251,129 @@ def test_no_fixture_carries_an_unsanitised_home_path():
         f"with the placeholder segment {_ALLOWED_HOME_SEGMENT!r}:\n"
         + "\n".join(offenders)
     )
+
+
+def test_fixture_scan_descends_into_subdirectories(monkeypatch, tmp_path):
+    """MUST FIRE case for the ENUMERATION itself (#480): a fixture file
+    living in a subdirectory of tests/fixtures/ must be visible to the
+    scan, not just a file sitting at the top level. The real
+    tests/fixtures/ has no subdirectories today, so this cannot be
+    exercised against the real tree either way -- a synthetic tree is
+    built here instead, with one file at the top and one nested two
+    levels down, so depth is actually tested rather than assumed.
+
+    Before the fix (`FIXTURES_DIR.iterdir()`), this fails: iterdir()
+    yields only immediate children, so the nested file never appears in
+    the returned list. That is exactly what this issue reports --
+    Detector 1 enumerates non-recursively -- and it is why
+    `test_scanned_at_least_one_fixture_file` above could not have caught
+    it: its `>= 2` count is satisfied by the top-level files alone, so a
+    missed subtree changes nothing it can observe."""
+    monkeypatch.setattr(f"{__name__}.FIXTURES_DIR", tmp_path)
+    (tmp_path / "top.txt").write_text("nothing interesting here", encoding="utf-8")
+    nested_dir = tmp_path / "captures" / "2026-08"
+    nested_dir.mkdir(parents=True)
+    nested_file = nested_dir / "leak.jsonl"
+    nested_file.write_text("no home path in this one either", encoding="utf-8")
+
+    found = _fixture_files()
+
+    assert nested_file in found, (
+        f"fixture scan did not descend into a subdirectory -- found only "
+        f"{[str(p) for p in found]}, missing {nested_file}"
+    )
+
+
+def test_detector_fires_on_a_home_path_nested_in_a_fixture_subdirectory(
+    monkeypatch, tmp_path
+):
+    """MUST FIRE case for the DETECTOR end to end (#480), at the depth
+    the real bug lived at: this issue's whole point is that a real
+    #467-shaped leak arriving inside a subdirectory of tests/fixtures/
+    was invisible to both the enumeration and this detector's own
+    positive control. Plants the same JSON-string-nested shape #467's
+    first file actually shipped, two directories deep, and drives it
+    through the real detector logic (not just the bare regex the way
+    test_detector_fires_on_a_planted_real_looking_home_path does) --
+    this is the case that would still pass if only the regex were
+    proven to fire and the walk stayed blind to the subtree."""
+    monkeypatch.setattr(f"{__name__}.FIXTURES_DIR", tmp_path)
+    nested_dir = tmp_path / "captures" / "2026-08"
+    nested_dir.mkdir(parents=True)
+    leaking = nested_dir / "codex-rollout.jsonl"
+    leaking.write_text(
+        r'{"payload": {"cwd": "/Users/realname/project"}}', encoding="utf-8"
+    )
+
+    offenders: list[str] = []
+    for f in _fixture_files():
+        text = f.read_text(encoding="utf-8", errors="replace")
+        for segment in _HOME_PATH.findall(text):
+            if segment != _ALLOWED_HOME_SEGMENT:
+                offenders.append(f"{f}: {segment!r}")
+
+    assert offenders, (
+        "detector missed a real-looking home path nested in a fixtures "
+        "subdirectory -- the walk is not reaching that depth"
+    )
+
+
+def test_detector_does_not_fire_on_a_sanitised_path_in_a_fixture_subdirectory(
+    monkeypatch, tmp_path
+):
+    """MUST-NOT-FIRE case pairing the one above (CLAUDE.md: a negative
+    assertion needs a positive control, and the reverse holds too --
+    widening the walk must not start over-firing on the placeholder
+    segment this repository already standardised on, at any depth)."""
+    monkeypatch.setattr(f"{__name__}.FIXTURES_DIR", tmp_path)
+    nested_dir = tmp_path / "captures" / "2026-08"
+    nested_dir.mkdir(parents=True)
+    clean = nested_dir / "codex-rollout.jsonl"
+    clean.write_text(
+        r'{"payload": {"cwd": "/Users/sanitized-user/project"}}',
+        encoding="utf-8",
+    )
+
+    offenders: list[str] = []
+    for f in _fixture_files():
+        text = f.read_text(encoding="utf-8", errors="replace")
+        for segment in _HOME_PATH.findall(text):
+            if segment != _ALLOWED_HOME_SEGMENT:
+                offenders.append(f"{f}: {segment!r}")
+
+    assert not offenders, (
+        f"detector false-fired on the sanitised placeholder segment in a "
+        f"fixtures subdirectory: {offenders}"
+    )
+
+
+def test_fixture_scan_reports_how_many_files_it_examined(capsys):
+    """Receipt (#480): the issue's own fix note asks for recursion PLUS a
+    receipt naming how many files were actually examined, so an empty
+    walk cannot read as a clean one -- the failure mode this whole issue
+    is about is a scan that silently looked at fewer files than it
+    should have and a positive control that could not tell. Printing the
+    count (visible under `pytest -s` / `-rs` in CI logs) turns "the guard
+    was green" into a number a human reviewing a release audit can sanity
+    -check against how many files are actually tracked under
+    tests/fixtures/, the same way the module docstring's audit trail
+    already quotes `git grep -c` output as its own receipt."""
+    files = _fixture_files()
+    print(f"[receipt] examined {len(files)} fixture file(s) under {FIXTURES_DIR}")
+    tracked = subprocess.run(
+        ["git", "ls-files", "tests/fixtures"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    assert len(files) == len(tracked), (
+        f"fixture scan examined {len(files)} file(s) but git tracks "
+        f"{len(tracked)} under tests/fixtures/ -- the walk and the tree "
+        "disagree, which is exactly what a silent scope hole looks like"
+    )
+    captured = capsys.readouterr()
+    assert "[receipt] examined" in captured.out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_no_real_home_paths_467.py
+++ b/tests/test_no_real_home_paths_467.py
@@ -357,9 +357,22 @@ def test_fixture_scan_reports_how_many_files_it_examined(capsys):
     was green" into a number a human reviewing a release audit can sanity
     -check against how many files are actually tracked under
     tests/fixtures/, the same way the module docstring's audit trail
-    already quotes `git grep -c` output as its own receipt."""
-    files = _fixture_files()
-    print(f"[receipt] examined {len(files)} fixture file(s) under {FIXTURES_DIR}")
+    already quotes `git grep -c` output as its own receipt.
+
+    Deliberately a SUBSET check, not an exact-count comparison: an
+    earlier draft asserted `len(files) == len(tracked)`, which a
+    reviewer caught failing on a file that exists on disk under
+    tests/fixtures/ but is not git-tracked -- a stray `.DS_Store` was the
+    reproduction, and it is `.gitignore`d in this repo but still visible
+    to `rglob("*")`, which walks the filesystem rather than the git
+    index. That is noise unrelated to #480 (a contributor who has ever
+    opened tests/fixtures/ in Finder could fail this test locally for a
+    reason that has nothing to do with the detector), so the receipt now
+    asserts every git-tracked fixture was found by the walk, without
+    demanding the walk find NOTHING else -- that subset direction is
+    exactly the one a dropped subtree would violate."""
+    found = set(_fixture_files())
+    print(f"[receipt] examined {len(found)} fixture file(s) under {FIXTURES_DIR}")
     tracked = subprocess.run(
         ["git", "ls-files", "tests/fixtures"],
         cwd=REPO_ROOT,
@@ -367,10 +380,13 @@ def test_fixture_scan_reports_how_many_files_it_examined(capsys):
         text=True,
         check=True,
     ).stdout.splitlines()
-    assert len(files) == len(tracked), (
-        f"fixture scan examined {len(files)} file(s) but git tracks "
-        f"{len(tracked)} under tests/fixtures/ -- the walk and the tree "
-        "disagree, which is exactly what a silent scope hole looks like"
+    tracked_paths = {REPO_ROOT / line for line in tracked}
+    missing = tracked_paths - found
+    assert not missing, (
+        f"fixture scan missed {len(missing)} git-tracked file(s) under "
+        f"tests/fixtures/ that git ls-files reports: {sorted(missing)} -- "
+        "the walk and the tree disagree, which is exactly what a silent "
+        "scope hole looks like"
     )
     captured = capsys.readouterr()
     assert "[receipt] examined" in captured.out


### PR DESCRIPTION
Closes #480.

Detector 1 of the #467 home-path guard (`tests/test_no_real_home_paths_467.py`) enumerated `tests/fixtures/` with `FIXTURES_DIR.iterdir()`, which only ever sees the immediate children of that directory. A real `/Users/<x>/` or `/home/<x>/` segment committed inside a subdirectory of `tests/fixtures/` would be invisible to the detector at any depth, and its own positive control (`test_scanned_at_least_one_fixture_file`, asserting `len(files) >= 2`) could not have noticed -- it is satisfied by the 4 top-level files alone, which is exactly why the issue's own MUST-FIRE fixture had to sit at the top level to pass.

**Fix:** `_fixture_files()` now walks with `FIXTURES_DIR.rglob("*")` filtered by `is_file()`.

**New tests**, all pointing the scan at a synthetic tree via `monkeypatch.setattr(f"{__name__}.FIXTURES_DIR", tmp_path)` since the real `tests/fixtures/` has no subdirectories today and cannot exercise depth on its own:
- `test_fixture_scan_descends_into_subdirectories` -- MUST FIRE, the enumeration alone
- `test_detector_fires_on_a_home_path_nested_in_a_fixture_subdirectory` -- MUST FIRE, the full detector end to end, at depth
- `test_detector_does_not_fire_on_a_sanitised_path_in_a_fixture_subdirectory` -- MUST NOT FIRE, the paired negative control at the same depth
- `test_fixture_scan_reports_how_many_files_it_examined` -- the receipt half of the issue's own fix note ("recursion plus a receipt naming how many files were actually examined, so an empty walk cannot read as a clean one")

Red before the fix (`2 failed, 1 passed, 9 deselected`), green after (`12 passed`).

**Review round 1 finding, fixed in a second commit.** Both the spawned reviewer and the spawned auditor independently caught the same issue in the first commit: the receipt test compared `len(files) == len(git ls-files tests/fixtures)` for exact equality. `rglob("*")` walks the filesystem, not the git index, so a file that physically exists under `tests/fixtures/` but isn't tracked -- a stray `.DS_Store`, `.gitignore`d in this repo but created by Finder just from browsing the folder -- would make the walk's count disagree with git's count for a reason unrelated to any missed subtree. Reproduced (`touch tests/fixtures/.DS_Store` -> `AssertionError: fixture scan examined 5 file(s) but git tracks 4`), then fixed by switching to a subset check: every git-tracked file under `tests/fixtures/` must be present in what the walk found, without demanding the walk find nothing else -- still catches a dropped subtree, no longer trips on an untracked stray file. Re-verified both directions.

BELOW-BAR NOTE: none raised in this round; both review findings were fixed in-scope.

**Docs:** `README.md` (this repo's only `docs_targets` entry) opened; it describes `tests/fixtures/codex-rollout.jsonl` only in an unrelated paragraph about #443 and says nothing about the guard's own internals -- no-change-needed. Changelog fragment added at `changelog.d/480.fixed.md`, checked with `.oss/assemble_changelog.py --check` (ok).

Scope: `tests/test_no_real_home_paths_467.py` and `changelog.d/480.fixed.md` only, per the brief -- no touch to `pipeline/`, `scripts/user-prompt-hook.sh`, `scripts/save-session.sh` or `scripts/session-end-hook.sh`, which other concurrent lanes hold.

## Verified by the maintainer

Independent of the lane, at review of this pull request. The report's `platform` field is `null` and the body says nothing about the cross-platform dimension the brief asked for, so I read the file rather than leave that unanswered.

**The platform question does not bite, and the reason is worth stating.** `_HOME_PATH = re.compile(r"(?:/Users/|/home/)([A-Za-z0-9_.-]+)")` is matched against **file contents**, not against filesystem paths -- the detector scans the committed bytes of each fixture, which carry whatever separators they were captured with, independent of the host reading them. `rglob("*")` plus `is_file()` is separator-neutral, and `relative_to(REPO_ROOT)` appears only in offender messages. So the widened walk behaves identically on a backslash-separated host. That claim is **reasoned from reading the code, not observed on Windows** -- and this detector cannot be observed there, per the next point.

**The thing a reviewer should actually know about this guard: it does not run on CI at all.** The file's own argued correction (lines 78-100) records why -- `windows-latest` runs as `runneradmin`, which appears legitimately in `tests/test_stale_config_sweep_362.py` as a realistic Windows home-path fixture, and #472 turned the CI pass into a live false positive. A per-image skiplist was rejected as wrong-by-construction on the next image. That is a deliberate, well-argued scope decision, not an oversight -- but it means **this fix widens a detector whose only execution is local**. The matrix will not exercise the recursion this pull request adds; a maintainer running `pytest` will.

**Accepted as reported:** the red run (`2 failed, 1 passed`), the depth-paired MUST-FIRE / MUST-NOT-FIRE, and the review round that caught the receipt test's exact-count comparison against `git ls-files` and moved it to a subset check. I did not re-run the suite; the lane's own module run is green and CI is the gate for the rest.
