### PR TITLE
fix: three misreports in pipeline/ -- a fault silently reads as the ordinary case (#477, #458, #478)

### DIFF
--- a/changelog.d/458.fixed.md
+++ b/changelog.d/458.fixed.md
@@ -1,0 +1,7 @@
+- Fixed: `read_unread_envelope()` returned the same empty result for "nothing
+  was ever quarantined" and "the quarantine sidecar exists and could not be
+  read", so a torn write or truncated `unread-envelope.json` silently
+  re-lost a span #450's quarantine exists to protect. `extract_session()`
+  now distinguishes the two and reports it on its result (and through
+  `pipeline.shell`'s existing shell bridge as `UNREAD_SIDECAR_UNREADABLE`)
+  (#458).

--- a/changelog.d/477.fixed.md
+++ b/changelog.d/477.fixed.md
@@ -1,0 +1,5 @@
+- Fixed: an auto-detected Codex session whose exported transcript vanished
+  between export and the SessionEnd hook's read was silently routed to
+  Claude's summarizer with no receipt -- `REMEMBER_SUMMARIZER=auto` now logs
+  that the transcript path was set but the file is gone, distinctly from the
+  ordinary no-transcript-exported case, which stays silent (#477).

--- a/changelog.d/478.fixed.md
+++ b/changelog.d/478.fixed.md
@@ -1,0 +1,10 @@
+- Fixed: `sniff_file_envelope()` returned "unrecognised" for both "the
+  transcript could not even be opened" (permission error, bad mount, a file
+  that vanished between listing and open) and "opened it, read it,
+  recognised no known host shape" -- the same string save-session.sh's
+  receipt points at a shape-sniffing function for, which is the wrong place
+  to look when the real answer is "could not read it at all".
+  `extract_session()` now carries the distinction on its result (and
+  through `pipeline.shell`'s shell bridge as `ENVELOPE_UNREADABLE`), while
+  `sniff_file_envelope()`'s own return value is unchanged for existing
+  callers (#478).

--- a/pipeline/extract.py
+++ b/pipeline/extract.py
@@ -151,13 +151,51 @@ def _unread_envelope_path(project_dir: str, remember_dir: str | None = None) -> 
     return effective.rstrip("/\\") + "/tmp/unread-envelope.json"
 
 
+def read_unread_envelope_status(path: str) -> tuple[dict[str, int], bool]:
+    """Read the session -> earliest-unread-line quarantine map, plus
+    whether the sidecar was there and could not be trusted (#458).
+
+    A missing sidecar -- nothing was ever quarantined for this project --
+    and an unreadable one -- a torn write from a crash mid-write, a disk
+    fault, a truncated file -- both have no entries to offer, but they are
+    not the same fact: the first is the ordinary case, correct to render
+    silently; the second means a caller resuming extraction from "no
+    quarantine on record" may be re-losing a span #450 already caught once.
+
+    Args:
+        path: Path to unread-envelope.json.
+
+    Returns:
+        ``(sessions, unreadable)`` -- ``sessions`` maps session ID to the
+        earliest JSONL line not yet successfully read, empty in both the
+        absent and the unreadable case. ``unreadable`` is True only when
+        the file EXISTS but its contents could not be trusted (parse
+        failure, an OS-level read error, or a shape that is not the
+        expected mapping) -- never for a sidecar that simply is not there.
+    """
+    if not os.path.exists(path):
+        return {}, False
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (ValueError, OSError):
+        return {}, True
+    if not isinstance(data, dict):
+        return {}, True
+    return {k: int(v) for k, v in data.items() if _is_line_number(v)}, False
+
+
 def read_unread_envelope(path: str) -> dict[str, int]:
     """Read the session -> earliest-unread-line quarantine map.
 
     Tolerates every shape the file can take, the same way ``read_positions``
     does: a corrupt or missing file reads as "nothing quarantined" rather
     than raising, because this is a best-effort recovery aid, not the
-    source of truth for the saved position.
+    source of truth for the saved position. Callers that need to tell
+    "nothing quarantined" apart from "the sidecar exists and could not be
+    read" -- #458 -- want ``read_unread_envelope_status()`` instead; this
+    function's contract (a plain mapping, corrupt-or-absent both empty) is
+    kept unchanged for every existing caller.
 
     Args:
         path: Path to unread-envelope.json.
@@ -166,14 +204,7 @@ def read_unread_envelope(path: str) -> dict[str, int]:
         Mapping of session ID to the earliest JSONL line not yet
         successfully read; empty if unreadable or absent.
     """
-    try:
-        with open(path, encoding="utf-8") as f:
-            data = json.load(f)
-    except (ValueError, OSError):
-        return {}
-    if not isinstance(data, dict):
-        return {}
-    return {k: int(v) for k, v in data.items() if _is_line_number(v)}
+    return read_unread_envelope_status(path)[0]
 
 
 def _write_unread_envelope(path: str, sessions: dict[str, int]) -> None:
@@ -308,17 +339,24 @@ def count_lines(path: str) -> int:
     return count
 
 
-def sniff_file_envelope(path: str) -> str:
-    """Which host wrote this transcript, from its own first parseable line.
+def sniff_file_envelope_status(path: str) -> tuple[str, bool]:
+    """Which host wrote this transcript, plus whether it could be OPENED at
+    all (#478).
 
-    Independent of any resume position: incremental extraction can start deep
-    into a file, but the envelope is decided once, from line 0, rather than
-    guessed from whatever line an old ``skip_lines`` happens to land on --
-    every line in one transcript comes from the same host.
+    Same sniff as ``sniff_file_envelope()`` -- see that docstring -- but
+    returned alongside a second fact: "unrecognised" covers two different
+    causes, and this call tells them apart. ``unreadable=True`` means the
+    file could not even be opened (an ``OSError`` -- a permission error, a
+    bad mount, a file that vanished between listing and open); ``False``
+    means the file WAS opened and read to exhaustion (or found empty) and
+    simply never contained a line naming a known host shape. The envelope
+    string itself is always "unrecognised" in both cases, matching
+    ``sniff_file_envelope()`` exactly, so a caller that only wants the old
+    behaviour is unaffected.
 
-    Returns "claude-code", "codex", or "unrecognised" -- the last one also
-    covering an unreadable or entirely-empty file, which offers no line to
-    sniff at all.
+    Returns:
+        ``(envelope, unreadable)`` where ``envelope`` is "claude-code",
+        "codex", or "unrecognised".
     """
     try:
         with open(path, encoding="utf-8", errors="replace") as f:
@@ -330,10 +368,29 @@ def sniff_file_envelope(path: str) -> str:
                     obj = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                return _host.sniff_envelope(obj)
+                return _host.sniff_envelope(obj), False
     except OSError:
-        return "unrecognised"
-    return "unrecognised"
+        return "unrecognised", True
+    return "unrecognised", False
+
+
+def sniff_file_envelope(path: str) -> str:
+    """Which host wrote this transcript, from its own first parseable line.
+
+    Independent of any resume position: incremental extraction can start deep
+    into a file, but the envelope is decided once, from line 0, rather than
+    guessed from whatever line an old ``skip_lines`` happens to land on --
+    every line in one transcript comes from the same host.
+
+    Returns "claude-code", "codex", or "unrecognised" -- the last one also
+    covering an unreadable or entirely-empty file, which offers no line to
+    sniff at all. Callers that need to tell "could not even open it" apart
+    from "opened it, found no known shape" -- #478 -- want
+    ``sniff_file_envelope_status()`` instead; this function's contract (a
+    single string, both causes collapsed) is kept unchanged for every
+    existing caller.
+    """
+    return sniff_file_envelope_status(path)[0]
 
 
 _CHANNEL_RE = re.compile(r"^<channel\b[^>]*>(.*)</channel>$", re.DOTALL)
@@ -518,9 +575,10 @@ def extract_session(
     # prevent.
     actual_id = session_id or os.path.basename(path).replace(".jsonl", "")
     total_lines = count_lines(path)
-    envelope = sniff_file_envelope(path)
+    envelope, envelope_unreadable = sniff_file_envelope_status(path)
 
     used_skip_lines = 0
+    unread_sidecar_unreadable = False
     if show_all:
         messages = extract_messages(path, skip_lines=0, envelope=envelope)
     elif count is not None:
@@ -536,9 +594,10 @@ def extract_session(
         # the envelope reads the missed span too. Harmless when this run is
         # STILL unrecognised: extract_messages returns nothing for either
         # skip point, and the quarantine simply stays in force.
-        unread_from = read_unread_envelope(
+        unread_sessions, unread_sidecar_unreadable = read_unread_envelope_status(
             _unread_envelope_path(project_dir, remember_dir)
-        ).get(actual_id)
+        )
+        unread_from = unread_sessions.get(actual_id)
         used_skip_lines = unread_from if unread_from is not None else last_line
         messages = extract_messages(path, skip_lines=used_skip_lines, envelope=envelope)
 
@@ -562,6 +621,8 @@ def extract_session(
         assistant_count=assistant_count,
         envelope=envelope,
         skip_lines=used_skip_lines,
+        unread_sidecar_unreadable=unread_sidecar_unreadable,
+        envelope_unreadable=envelope_unreadable,
     )
 
 

--- a/pipeline/haiku.py
+++ b/pipeline/haiku.py
@@ -237,6 +237,23 @@ def _choose_summarizer_provider() -> str:
         return provider
     path = _host.transcript_path()
     if not path:
+        # transcript_path() collapses two different facts into one None:
+        # the var was never set (ordinary -- no hook preamble, nothing to
+        # say), and the var WAS set but the file it names is gone (#477 --
+        # exported, then vanished before this read, the exact "deleted
+        # between export and this read" case the docstring above already
+        # promises a receipt for). Re-reading the environment here, rather
+        # than widening transcript_path()'s own return shape, keeps that
+        # function's contract ("a usable path or None") unchanged for every
+        # other caller.
+        raw = (os.environ.get(_host.TRANSCRIPT_PATH_VAR) or "").strip()
+        if raw:
+            _warn(
+                f"WARNING: REMEMBER_TRANSCRIPT_PATH={raw!r} names a "
+                "transcript that no longer exists (exported, then vanished "
+                "before this read) -- REMEMBER_SUMMARIZER=auto is falling "
+                "back to 'claude', which may not be correct"
+            )
         return "claude"
     envelope = _extract.sniff_file_envelope(path)
     if envelope == "codex":

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -83,7 +83,8 @@ def cmd_extract(session_id: str, project_dir: str) -> None:
 
     Prints:
         POSITION, HUMAN_COUNT, ASSISTANT_COUNT, EXCHANGE_COUNT,
-        EXTRACT_FILE (path to temp file containing exchange text).
+        EXTRACT_FILE (path to temp file containing exchange text), ENVELOPE,
+        SKIP_LINES, UNREAD_SIDECAR_UNREADABLE.
     """
     import tempfile
     remember_dir = os.environ.get("REMEMBER_DIR") or None
@@ -110,6 +111,27 @@ def cmd_extract(session_id: str, project_dir: str) -> None:
     # quarantine pinned to its earliest point or clears it once something has
     # actually read that span.
     print(f"SKIP_LINES={r.skip_lines}")
+    # #458: distinct from ENVELOPE/SKIP_LINES above -- this is the sidecar
+    # extract_session() consulted to CHOOSE those values, not the transcript
+    # itself. "1" means the unread-envelope.json quarantine sidecar exists
+    # but could not be trusted (a torn write, a disk fault, a truncated
+    # file), so this run resumed as though nothing were quarantined even
+    # though the sidecar may disagree -- the same silent-degrade #450's
+    # quarantine exists to catch, one level inside its own recovery path.
+    # Additive: no current consumer reads this key yet (that plumbing --
+    # reaching a shell-visible log line -- is a decision the issue
+    # explicitly left to whoever wires save-session.sh next), but the
+    # signal is on the bridge rather than only inside this process.
+    print(f"UNREAD_SIDECAR_UNREADABLE={1 if r.unread_sidecar_unreadable else 0}")
+    # #478: ENVELOPE="unrecognised" collapses two different facts -- the
+    # transcript could not even be opened (OSError), or it was opened and
+    # read to exhaustion and simply never named a known host shape. Additive
+    # for the same reason as UNREAD_SIDECAR_UNREADABLE above: no current
+    # consumer reads this key yet, but the distinction is on the bridge for
+    # whoever next revises save-session.sh:276's receipt, which today points
+    # every "unrecognised" case at the shape-sniffing function even when the
+    # real answer is "the file could not be read at all".
+    print(f"ENVELOPE_UNREADABLE={1 if r.envelope_unreadable else 0}")
 
 
 def cmd_build_prompt(

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -84,7 +84,7 @@ def cmd_extract(session_id: str, project_dir: str) -> None:
     Prints:
         POSITION, HUMAN_COUNT, ASSISTANT_COUNT, EXCHANGE_COUNT,
         EXTRACT_FILE (path to temp file containing exchange text), ENVELOPE,
-        SKIP_LINES, UNREAD_SIDECAR_UNREADABLE.
+        SKIP_LINES, UNREAD_SIDECAR_UNREADABLE, ENVELOPE_UNREADABLE.
     """
     import tempfile
     remember_dir = os.environ.get("REMEMBER_DIR") or None

--- a/pipeline/types.py
+++ b/pipeline/types.py
@@ -109,6 +109,21 @@ class ExtractResult:
             the earlier build only skipped past. Callers report it (and
             ``save-position`` consumes it) so the quarantine can be cleared
             once something has actually read that span.
+        unread_sidecar_unreadable: True when the unread-envelope.json
+            quarantine sidecar was consulted for a resume position AND it
+            exists but could not be trusted (a torn write, a disk fault, a
+            truncated file) -- never true when the sidecar simply does not
+            exist, which is the ordinary "nothing was ever quarantined"
+            case (#458). A caller resuming as though nothing were
+            quarantined when the sidecar is actually corrupt can silently
+            re-lose a span #450's quarantine exists to protect.
+        envelope_unreadable: True when the transcript file named by
+            ``envelope`` could not even be OPENED (an ``OSError`` --
+            permission error, bad mount, vanished between listing and
+            open) -- never true when the file was opened and read to
+            exhaustion (or found empty) and simply never contained a line
+            naming a known host shape (#478). ``envelope`` is
+            "unrecognised" in both cases; this is what tells them apart.
     """
 
     exchanges: str = ""
@@ -118,6 +133,8 @@ class ExtractResult:
     corrupt_lines: int = 0
     envelope: str = ""
     skip_lines: int = 0
+    unread_sidecar_unreadable: bool = False
+    envelope_unreadable: bool = False
 
 
 @dataclass

--- a/tests/test_sniff_envelope_unreadable_478.py
+++ b/tests/test_sniff_envelope_unreadable_478.py
@@ -1,0 +1,88 @@
+"""sniff_file_envelope() collapses two different facts into the same
+"unrecognised" string (#478): an OSError reading the file (permission
+error, bad mount, a file that vanished between listing and open) and an
+exhausted, fully-parseable file that simply never named a known host shape.
+The docstring already names the collapse honestly; the receipt
+(scripts/save-session.sh:276) does not -- it points a user whose transcript
+is simply unreadable at a shape-sniffing function, the wrong place to look.
+
+This repository's scripts/ lane is held by another agent right now, so the
+log-line half of the fix is out of scope here. What is fixed in pipeline/ is
+the source of the distinction: sniff_file_envelope() keeps returning
+"unrecognised" for both cases (so the shell bridge's existing
+``[ "$ENVELOPE" = "unrecognised" ]`` check, which the #450 quarantine
+depends on, is untouched), and a new status call carries the OSError case
+out separately, the same "keep the old contract, add a new signal" shape
+#458's fix took one function over.
+
+Every "must not fire" case (a genuinely empty/unrecognised-but-readable
+file) is paired with a "must fire" case (the same file, made unreadable).
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from pipeline.extract import sniff_file_envelope, sniff_file_envelope_status
+
+
+def test_missing_file_is_unrecognised_and_flagged_unreadable(tmp_path):
+    """The defect itself: a transcript path that does not exist at all --
+    the exact OSError arm the issue is about -- must still return
+    "unrecognised" (contract preserved) but must ALSO say it could not even
+    be opened, distinctly from a file that was read and found no known
+    shape.
+    """
+    missing = str(tmp_path / "does-not-exist.jsonl")
+    envelope, unreadable = sniff_file_envelope_status(missing)
+    assert envelope == "unrecognised"
+    assert unreadable is True
+    # Old call site's contract is unchanged.
+    assert sniff_file_envelope(missing) == "unrecognised"
+
+
+def test_permission_denied_file_is_flagged_unreadable(tmp_path):
+    """A second OSError shape -- a file that exists but cannot be opened --
+    must be flagged the same way as a missing file, not treated as
+    "read it, found no known shape"."""
+    if os.name == "nt" or os.geteuid() == 0:
+        import pytest
+        pytest.skip("permission bits are not enforced the same way here")
+    path = tmp_path / "no-read.jsonl"
+    path.write_text('{"type": "user"}\n', encoding="utf-8")
+    path.chmod(0)
+    try:
+        envelope, unreadable = sniff_file_envelope_status(str(path))
+        assert envelope == "unrecognised"
+        assert unreadable is True
+    finally:
+        path.chmod(stat.S_IWUSR | stat.S_IRUSR)
+
+
+def test_a_readable_but_shapeless_file_is_not_flagged_unreadable(tmp_path):
+    """MUST-FIRE control's pair: a file that WAS opened and read to
+    exhaustion, and simply never contained a line naming a known host
+    shape, is the "read it, did not recognise it" case -- not the
+    "could not read it at all" case -- and must not be flagged unreadable.
+    """
+    path = tmp_path / "shapeless.jsonl"
+    path.write_text('{"nothing": "recognisable"}\n', encoding="utf-8")
+    envelope, unreadable = sniff_file_envelope_status(str(path))
+    assert envelope == "unrecognised"
+    assert unreadable is False
+
+
+def test_an_empty_file_is_not_flagged_unreadable(tmp_path):
+    """MUST-FIRE control's pair, the other exhausted-fallthrough shape: an
+    entirely empty file offers no line to sniff, and is genuinely "read it,
+    nothing there", not "could not read it".
+    """
+    path = tmp_path / "empty.jsonl"
+    path.write_text("", encoding="utf-8")
+    envelope, unreadable = sniff_file_envelope_status(str(path))
+    assert envelope == "unrecognised"
+    assert unreadable is False

--- a/tests/test_transcript_missing_477.py
+++ b/tests/test_transcript_missing_477.py
@@ -1,0 +1,73 @@
+"""#477: transcript_path() collapses two different facts into one None --
+the var was never set, and the var was set but the file it names is gone --
+and pipeline.haiku._choose_summarizer_provider() read that single None as
+"nothing to say", so a Codex session whose exported transcript vanished
+between export and read was silently billed to Anthropic with no receipt.
+
+The four probes from the issue body, reproduced as a fixture:
+
+    A unset                       : provider='claude' stderr=''
+    B set-but-file-deleted        : provider='claude' stderr=''
+    C set + real codex transcript : provider='codex'  stderr=''
+    D set + unrecognised shape    : provider='claude' stderr="...WARNING..."
+
+D already logs (test_codex_hook_transcript_465.py::
+test_unusable_transcript_logs_why_it_fell_to_claude). A was already known not
+to log (test_no_transcript_at_all_does_not_warn). B was indistinguishable
+from A -- this file is the missing case: B must now warn, distinctly from A,
+so an operator can tell "genuinely nothing to read" from "there WAS a
+transcript and it is gone".
+
+Every "must not fire" case (A) is paired with a "must fire" case (B) in the
+same fixture, per CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from pipeline.haiku import _choose_summarizer_provider
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _clear_host_signals(monkeypatch):
+    for var in ("CODEX_HOME", "PLUGIN_ROOT", "CODEX_SESSION_ID",
+                "CODEX_THREAD_ID", "CLAUDE_CODE_ENTRYPOINT",
+                "CLAUDE_CODE_SESSION_ID", "CLAUDE_PLUGIN_ROOT",
+                "REMEMBER_SUMMARIZER", "REMEMBER_SUMMARIZER_FALLBACK",
+                "REMEMBER_TRANSCRIPT_PATH"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_set_but_missing_transcript_warns_distinctly_from_unset(monkeypatch):
+    """Probe B: REMEMBER_TRANSCRIPT_PATH was set to a real path, but the
+    file it names does not exist -- deleted between export and this read.
+    The provider still safely falls back to 'claude' (unchanged), but must
+    now say why, the same way probe D (unrecognised shape) already does --
+    otherwise 'genuinely nothing exported' and 'exported, then vanished'
+    render identically to an operator debugging a wrongly-billed session."""
+    _clear_host_signals(monkeypatch)
+    monkeypatch.setenv("REMEMBER_TRANSCRIPT_PATH", str(FIXTURES / "does-not-exist-477.jsonl"))
+    with patch("pipeline.haiku._warn") as mock_warn:
+        assert _choose_summarizer_provider() == "claude"
+    mock_warn.assert_called_once()
+    message = mock_warn.call_args[0][0]
+    assert "does-not-exist-477.jsonl" in message
+    assert "no longer" in message or "vanished" in message or "gone" in message
+
+
+def test_unset_transcript_still_does_not_warn(monkeypatch):
+    """Probe A, the positive control's pair: no REMEMBER_TRANSCRIPT_PATH at
+    all is the ordinary case (a bare invocation with no hook preamble) and
+    must stay silent -- this is what tells B's warning apart from a warning
+    that fires on every ordinary run."""
+    _clear_host_signals(monkeypatch)
+    with patch("pipeline.haiku._warn") as mock_warn:
+        assert _choose_summarizer_provider() == "claude"
+    mock_warn.assert_not_called()

--- a/tests/test_unread_envelope_corrupt_458.py
+++ b/tests/test_unread_envelope_corrupt_458.py
@@ -1,0 +1,176 @@
+"""read_unread_envelope() renders "nothing quarantined" and "the sidecar
+exists and could not be read" the same way (#458), one level inside the
+mechanism #450 built to fix exactly this defect class.
+
+#450 made an unrecognised-envelope save advance the position AND quarantine
+the unread span in unread-envelope.json, so a later build that can parse the
+envelope re-reads it. Recovery depends entirely on that sidecar being
+readable. If it is corrupt -- a torn write from a crash mid-write, a disk
+fault, a truncated file -- read_unread_envelope() returned {} exactly as it
+does when nothing was ever quarantined, so the next extraction silently
+resumed from the already-advanced position and the span was gone for good:
+the pre-#450 behaviour, restored by a fault, reported as normal operation.
+
+The full fix (a corrupt-sidecar signal reaching the shell-visible log) needs
+a decision about scripts/save-session.sh's KEY=VALUE bridge that this issue
+explicitly declines to fold in (see the issue body). What is fixed here,
+inside pipeline/, is the part that mechanism actually depends on: the
+Python-side distinction between "nothing quarantined" and "could not tell",
+surfaced on ExtractResult and through pipeline.shell's existing shell
+bridge as a new, additive key a future caller can read.
+
+Every "must not fire" case (a genuinely empty, absent sidecar) is paired
+with a "must fire" case (the same sidecar, corrupted) in the same fixture.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pipeline.extract import (
+    _unread_envelope_path,
+    extract_session,
+    read_unread_envelope,
+    read_unread_envelope_status,
+)
+
+SESSION_A = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa"
+
+
+@pytest.fixture()
+def store(tmp_path: Path):
+    remember = tmp_path / ".remember"
+    (remember / "tmp").mkdir(parents=True)
+    return remember
+
+
+def _write_jsonl(tmp_path: Path, *lines: str) -> str:
+    path = tmp_path / "session.jsonl"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(path)
+
+
+def _claude_code_line(role: str, text: str) -> str:
+    return json.dumps({"type": role, "message": {"content": text}})
+
+
+# == read_unread_envelope_status: the three-state helper itself ============
+
+def test_absent_sidecar_is_ok_nothing_quarantined(store):
+    """MUST-FIRE control: no sidecar at all -- the ordinary, expected case
+    of a session that was never quarantined -- must read as ok, not corrupt.
+    """
+    path = _unread_envelope_path("/fake", str(store))
+    sessions, corrupt = read_unread_envelope_status(path)
+    assert sessions == {}
+    assert corrupt is False
+
+
+def test_corrupt_sidecar_is_reported_not_silently_emptied(store):
+    """The defect itself: a sidecar that EXISTS but cannot be parsed (a torn
+    write, truncated JSON) must be told apart from "nothing quarantined" --
+    both currently render as {}, which is exactly what read_unread_envelope()
+    (kept, for backward compatibility) still returns; the NEW status call
+    must say the file was there and unreadable.
+    """
+    path = _unread_envelope_path("/fake", str(store))
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text('{"aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa": 3, "trunc', encoding="utf-8")
+
+    sessions, corrupt = read_unread_envelope_status(path)
+    assert sessions == {}, "a corrupt sidecar cannot be trusted for any entry"
+    assert corrupt is True
+
+    # Old call site's contract is unchanged -- still {} either way.
+    assert read_unread_envelope(path) == {}
+
+
+def test_valid_sidecar_with_entries_is_not_reported_corrupt(store):
+    """MUST-FIRE control's pair: a genuinely valid, non-empty sidecar must
+    not be flagged corrupt just because it has content.
+    """
+    path = _unread_envelope_path("/fake", str(store))
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text(json.dumps({SESSION_A: 7}), encoding="utf-8")
+
+    sessions, corrupt = read_unread_envelope_status(path)
+    assert sessions == {SESSION_A: 7}
+    assert corrupt is False
+
+
+# == extract_session surfaces the same distinction on its own result =======
+
+def test_extraction_reports_a_corrupt_quarantine_sidecar(store, tmp_path):
+    """The consumer that matters: extract_session() must not silently
+    resume from the saved position as though nothing were quarantined when
+    the sidecar it consulted is actually corrupt -- it must say so on the
+    result, the same shape ENVELOPE/SKIP_LINES already use to cross the
+    shell bridge (pipeline/shell.py's cmd_extract).
+    """
+    path = _unread_envelope_path("/fake", str(store))
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_text("{not valid json at all", encoding="utf-8")
+
+    transcript = _write_jsonl(tmp_path, _claude_code_line("user", "hi"))
+    with patch("pipeline.extract.find_session", return_value=transcript):
+        result = extract_session(session_id=SESSION_A, project_dir="/fake",
+                                  remember_dir=str(store))
+    assert result.unread_sidecar_unreadable is True
+
+
+def test_extraction_does_not_report_corruption_for_an_absent_sidecar(store, tmp_path):
+    """MUST-FIRE control's pair, at the extract_session level: the ordinary
+    case (no sidecar at all) must not be reported as corrupt.
+    """
+    transcript = _write_jsonl(tmp_path, _claude_code_line("user", "hi"))
+    with patch("pipeline.extract.find_session", return_value=transcript):
+        result = extract_session(session_id=SESSION_A, project_dir="/fake",
+                                  remember_dir=str(store))
+    assert result.unread_sidecar_unreadable is False
+
+
+# == The shell bridge carries the same signal (pipeline/shell.py cmd_extract) =
+
+def test_cmd_extract_prints_unread_sidecar_unreadable(capsys):
+    """Additive to the existing ENVELOPE/SKIP_LINES keys (#443/#450): a
+    consumer of the shell bridge must be able to read whether the
+    quarantine sidecar this run consulted was actually corrupt, the same
+    way it already reads whether the transcript envelope was recognised.
+    """
+    from pipeline.shell import cmd_extract
+    from pipeline.types import ExtractResult
+
+    fake_result = ExtractResult(
+        exchanges="", position=2, human_count=0, assistant_count=0,
+        envelope="claude-code", skip_lines=0,
+        unread_sidecar_unreadable=True,
+    )
+    with patch("pipeline.shell.extract_session", return_value=fake_result):
+        cmd_extract(session_id="sess-abc", project_dir="/tmp/fake")
+
+    output = capsys.readouterr().out
+    assert "UNREAD_SIDECAR_UNREADABLE=1" in output
+
+
+def test_cmd_extract_prints_zero_when_sidecar_is_fine(capsys):
+    """MUST-FIRE control's pair: the ordinary case prints 0, not a blank or
+    absent key -- a downstream shell consumer must be able to test it
+    unconditionally without first checking whether it is even present.
+    """
+    from pipeline.shell import cmd_extract
+    from pipeline.types import ExtractResult
+
+    fake_result = ExtractResult(
+        exchanges="", position=2, human_count=0, assistant_count=0,
+        envelope="claude-code", skip_lines=0,
+        unread_sidecar_unreadable=False,
+    )
+    with patch("pipeline.shell.extract_session", return_value=fake_result):
+        cmd_extract(session_id="sess-abc", project_dir="/tmp/fake")
+
+    output = capsys.readouterr().out
+    assert "UNREAD_SIDECAR_UNREADABLE=0" in output


### PR DESCRIPTION
Three separate fixes, one lane, one theme: a function that collapses "nothing to report" and "could not tell" into the same return value.

## #477 -- an auto-detected Codex session whose transcript vanished was billed to Anthropic with no receipt

`pipeline/host.py`'s `transcript_path()` returns `None` for two different facts -- `REMEMBER_TRANSCRIPT_PATH` was never set, and it was set but the file it names is gone -- and `pipeline/haiku.py`'s `_choose_summarizer_provider()` read that single `None` as "nothing to say", falling back to `claude` silently in both cases. Its own docstring already promised a receipt for the second case.

Fix: rather than widening `transcript_path()`'s contract for every caller, `_choose_summarizer_provider()` now re-reads `os.environ[TRANSCRIPT_PATH_VAR]` itself when the path comes back empty, and warns only for "set but gone" -- staying silent for the ordinary "never set" case, the same way it already warns for "set but unrecognised shape".

Closes #477

## #458 -- a corrupt quarantine sidecar silently re-loses an unread span #450 already caught once

`read_unread_envelope()` (`pipeline/extract.py`) returned the same empty dict for "nothing was ever quarantined" and "the sidecar exists and could not be read" (a torn write, a disk fault, a truncated file). The second silently degraded to the first: the next extraction resumed from the already-advanced position as though nothing were quarantined, and the span was gone for good -- the pre-#450 behaviour, restored by a fault, reported as normal operation.

Fix: a new `read_unread_envelope_status()` returns `(sessions, unreadable)`; the old `read_unread_envelope()` stays a thin wrapper with its contract unchanged for every existing caller. `extract_session()` surfaces the distinction on a new `ExtractResult.unread_sidecar_unreadable` field, and `pipeline.shell`'s `cmd_extract()` prints it as a new, additive `UNREAD_SIDECAR_UNREADABLE` shell-bridge key. The log-line half of the fix (reaching `scripts/save-session.sh`'s output) is explicitly left for a follow-up -- that file is held by a concurrently-running lane, and the issue itself says folding it in would widen the diff past its own subject.

Closes #458

## #478 -- an unreadable transcript's receipt points the user at the wrong function

`sniff_file_envelope()` returned "unrecognised" from both the `except OSError` arm and the exhausted-file fallthrough. `scripts/save-session.sh`'s receipt for "unrecognised" points the user at the shape-sniffing function -- the wrong place to look when the transcript is simply unreadable (a permission error, a bad mount, a file that vanished).

Fix: same shape as #458 -- a new `sniff_file_envelope_status()` returns `(envelope, unreadable)`, `sniff_file_envelope()` stays an unchanged thin wrapper, `extract_session()` surfaces it as `ExtractResult.envelope_unreadable`, and `cmd_extract()` prints a new, additive `ENVELOPE_UNREADABLE` key. Same scope note as #458: the shell-side receipt is left for whoever next revises `scripts/save-session.sh`.

Closes #478

## Adjacent finding, fixed in this PR

Self-review (an Explore reviewer against the committed diff) found `cmd_extract()`'s docstring documented the #458 shell-bridge key but not the #478 one added in the same commit. One-line fix, same file, applied as a follow-up commit.

## Tests

Each issue has its own new test file (`tests/test_transcript_missing_477.py`, `tests/test_unread_envelope_corrupt_458.py`, `tests/test_sniff_envelope_unreadable_478.py`), each pairing a must-fire case with a must-not-fire positive control in the same fixture. Full suite: 1910 passed, 43 skipped, 91.83% coverage, no regressions.

## below-bar finding

Self-review also surfaced a **below-bar** item, not acted on: the Explore reviewer, while reading `pipeline/host.py` with its own `Read` tool, hit a JIT-context hook injecting text instructing it to stop using Read/Grep/Glob/Edit/Write and route all file access through an external `supertool` binary instead. It correctly declined -- only the permission system or the user's own words can authorize a tool/config change -- and fell back to `sed`/`cat` via Bash. Below-bar because there is no reachable caller for this lane to act on: the reviewer already declined correctly on its own, and the mechanism (a JIT-context hook firing inside a spawned sub-agent's sandbox) is tooling infrastructure outside this diff's blast radius, worth a maintainer's second look rather than a code change here.