### PR TITLE
docs(readme): name the three sibling plugins near the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Claude Remember fixes that. It hooks into Claude Code's lifecycle — saving ses
 
 The result: your Claude Code instance develops continuity. It remembers what it learned, what broke, what worked. Not perfect recall — compressed, practical memory that fits in minimal tokens.
 
+## From the same workshop
+
+Four plugins, one team, each does one thing. This one and three siblings:
+
+- [claude-jit-context](https://github.com/Digital-Process-Tools/claude-jit-context): project knowledge that loads only when the prompt, the file or the tool matches it.
+- [claude-supertool](https://github.com/Digital-Process-Tools/claude-supertool): batched file and tracker ops. One call instead of seven, and a refusal instead of a wrong answer.
+- [claude-oss](https://github.com/Digital-Process-Tools/claude-oss): the maintainer loop that runs these four repos. Triage, build, review, merge, release.
+
+All four install from one marketplace: `/plugin marketplace add Digital-Process-Tools/claude-marketplace`.
+
 ## Install
 
 ### From our marketplace (recommended)

--- a/changelog.d/505.added.workshop.md
+++ b/changelog.d/505.added.workshop.md
@@ -1,0 +1,3 @@
+- **The README names its three sibling plugins near the top** (#505). One block, three
+  links, one marketplace command. Before this each README named the others once or not
+  at all, and the repo strangers reach first (claude-remember) pointed nowhere.


### PR DESCRIPTION
One block under the pitch: the three sibling plugins, one line each, and the one marketplace command that installs all four.

Why: claude-remember has 163 stars and its README named the other three tools once in 934 lines. supertool named remember 5 times. The traffic went the wrong way. Same block on all four repos tonight.

Part of #505 (the README rewrite), which this does not close.

https://claude.ai/code/session_01UqogxB9dfRZaWefk6SkXqL
