### PR TITLE
Fix consolidation retire overwriting a re-opened day's .done.md, and write down the cross-host lock contract (#509, #491)

### DIFF
--- a/changelog.d/491.changed.md
+++ b/changelog.d/491.changed.md
@@ -1,0 +1,13 @@
+- **Cross-host locking contract written down and tested** (#491). Claude Code and Codex
+  sharing one `.remember/` store had no explicit safety contract: `scripts/lib-lock.sh`
+  and `scripts/lib-staging-lock.sh` were written and tested against a single host's
+  process model, and neither file nor its tests mentioned Codex or "host" at all.
+  Established (not assumed): the lock primitive is already safe there, because `mkdir`
+  and `kill -0` are OS-level, process-table operations indifferent to which CLI spawned
+  the contending process, and every lock is keyed by a fixed literal name or by day, never
+  by session id. Both files now carry that contract as a header comment, and
+  `tests/test_cross_host_lock_contract_491.py` proves it under real concurrent writes
+  from two simulated hosts (no lost or interleaved entries), documents the one general,
+  pre-existing `kill -0` PID-reuse limitation this design inherits (not new, not made
+  worse by a second host), and locks in that the lock/staging layer never assumes a
+  session-ID shape.

--- a/changelog.d/509.fixed.md
+++ b/changelog.d/509.fixed.md
@@ -1,0 +1,7 @@
+- **Consolidation's retire no longer overwrites an existing retired day** (#509). When a
+  `today-YYYY-MM-DD.md` staging file is re-created for a day that was already retired -- a
+  long-running session spanning midnight, or NDC re-opening a retired day's staging file --
+  the retire loop used to `mv`/`head -c ... >` straight over the existing `.done.md`,
+  silently destroying the first retired span's hourly-detail content with no log line.
+  `run-consolidation.sh` now appends to an existing `.done.md` instead of truncating it, in
+  both the plain-rename and the concurrent-append (`head -c`/tail-split) retire paths.

--- a/changelog.d/509.fixed.md
+++ b/changelog.d/509.fixed.md
@@ -4,4 +4,8 @@
   the retire loop used to `mv`/`head -c ... >` straight over the existing `.done.md`,
   silently destroying the first retired span's hourly-detail content with no log line.
   `run-consolidation.sh` now appends to an existing `.done.md` instead of truncating it, in
-  both the plain-rename and the concurrent-append (`head -c`/tail-split) retire paths.
+  both the plain-rename and the concurrent-append (`head -c`/tail-split) retire paths. The
+  concurrent-append path also no longer commits the consumed prefix into `.done.md` until
+  the unconsumed tail has been safely extracted too, closing a duplication self-review found
+  in the first version of this fix (a `tail` failure used to leave the prefix committed once
+  by the extraction step and once more by the whole-file fallback).

--- a/scripts/lib-lock.sh
+++ b/scripts/lib-lock.sh
@@ -44,6 +44,28 @@
 # Functions:
 #   lock_acquire <lock_dir> [timeout_seconds]  -> 0 acquired, 1 timed out
 #   lock_release <lock_dir>                    -> 0 released, 1 not ours
+#
+# CROSS-HOST CONTRACT (Claude Code and Codex sharing one .remember/ store on
+# one machine, #491): this primitive is safe there, deliberately, because it
+# never looks at which CLI a process belongs to. `mkdir` and `kill -0` are
+# OS-level, process-table operations -- they see a PID, never a host. Every
+# lock directory used against this file is named by a fixed literal
+# (save.lock, consolidation.lock, staging.lock), never by session id, so a
+# Codex session and a Claude Code session contend for the exact same lock the
+# exact same way two Claude Code sessions would. Proven under real
+# concurrent writes from two simulated hosts in
+# tests/test_cross_host_lock_contract_491.py, not merely asserted.
+#
+# One limitation survives, and it is NOT new here: `kill -0`-based staleness
+# detection (`_lock_try_steal` below) cannot tell a dead holder's PID from an
+# unrelated LIVE process that has since been assigned the same PID by the OS
+# ("PID recycling") -- the lock is then judged live and is not recovered
+# until that unrelated process also exits. This is exactly as likely between
+# two Claude Code processes racing on their own as it is between a Claude
+# Code process and a Codex process; a second host does not make PID reuse
+# more probable, because `kill -0` cannot see which CLI started a PID in
+# either case. See the same test file for a reproduction that documents
+# this as an accepted, general limitation rather than a fix.
 
 [ -n "${_REMEMBER_LIB_LOCK_SOURCED:-}" ] && return 0
 _REMEMBER_LIB_LOCK_SOURCED=1

--- a/scripts/lib-staging-lock.sh
+++ b/scripts/lib-staging-lock.sh
@@ -62,6 +62,13 @@
 #   degrades to "retire it next run", not to data loss. Re-measure before
 #   changing this number — that is the whole point of #226.
 #
+# CROSS-HOST CONTRACT: same as lib-lock.sh's own header (#491). This file
+# never reads any per-session identifier of its own -- staging.lock is one
+# fixed lock directory shared by every writer regardless of host, and
+# staging_append is keyed by *today_file* (a day), never by session, so a
+# Claude Code save and a Codex save contend for it identically. See
+# tests/test_cross_host_lock_contract_491.py.
+#
 
 [ -n "${_REMEMBER_LIB_STAGING_LOCK_SOURCED:-}" ] && return 0
 _REMEMBER_LIB_STAGING_LOCK_SOURCED=1

--- a/scripts/run-consolidation.sh
+++ b/scripts/run-consolidation.sh
@@ -195,27 +195,23 @@ fi
 # NDC re-opening an already-retired day's staging file (#509). Append rather
 # than truncate-overwrite in that case, so the earlier retired span's hourly
 # detail survives; a plain rename/truncate when $2 does not exist yet is
-# unchanged. Same-directory content append + unlink, not a partial-write
-# hazard the way a cross-filesystem mv would be (#246 is about mv atomicity
-# across filesystems; cat+rm here never crosses one).
+# unchanged. Same-directory append + unlink, so it never crosses a
+# filesystem the way a cross-filesystem mv can (#246 is about mv atomicity
+# across filesystems) -- but the `cat >>` itself is NOT atomic: a write that
+# fails partway (ENOSPC, a killed process) can leave a truncated trailing
+# line durably embedded in $2, something a same-directory rename can never
+# do (self-review of #509 caught this understating the earlier draft's own
+# claim here). $1 is a whole, self-contained file in every caller below
+# (either the original staging_path, or a temp file holding exactly the
+# bytes to commit -- see the concurrent-append branch), so that partial
+# write is bounded to at most one truncated line, never a torn boundary
+# between two callers' content.
 retire_whole_into() {
     local src="$1" dst="$2"
     if [ -e "$dst" ]; then
         cat "$src" >> "$dst" && rm -f "$src"
     else
         mv "$src" "$dst"
-    fi
-}
-
-# Same guard as retire_whole_into, for the bounded-prefix write below: write
-# $3 bytes of $1 into $2, appending instead of truncating if $2 already
-# exists.
-retire_prefix_into() {
-    local src="$1" dst="$2" nbytes="$3"
-    if [ -e "$dst" ]; then
-        head -c "$nbytes" "$src" >> "$dst"
-    else
-        head -c "$nbytes" "$src" > "$dst"
     fi
 }
 
@@ -237,44 +233,78 @@ while IFS= read -r -d '' staging_path && IFS= read -r -d '' staging_consumed; do
         # crash between mktemp and mv leaves a stray sibling; sweep it first,
         # same as #245 — inert (name does not end in .md, so nothing globs it)
         # but would accumulate one per failure otherwise.
-        rm -f "${staging_path}".tail-* 2>/dev/null
+        rm -f "${staging_path}".tail-* "${staging_path}".prefix-* 2>/dev/null
         staging_tail=$(mktemp "${staging_path}.tail-XXXXXX")
-        if retire_prefix_into "$staging_path" "$staging_done" "$staging_consumed" 2>/dev/null &&
+        # Extracted into a FRESH temp file, never straight into staging_done
+        # (self-review of #509, Explore finding 1): an earlier draft wrote the
+        # consumed prefix into staging_done directly here, before the tail
+        # extraction below was known to succeed. When `tail` then failed, the
+        # whole-file fallback in the `else` branch re-committed the SAME
+        # prefix on top of the one already sitting in staging_done -- a
+        # duplicate on the very first attempt, unconditionally, not only on a
+        # retry the way the comment further down describes. Landing both
+        # extractions in temps first and touching staging_done only once BOTH
+        # are known good closes that: a `head`/`tail` failure now falls
+        # through to the whole-file fallback with staging_done untouched.
+        staging_prefix=$(mktemp "${staging_path}.prefix-XXXXXX")
+        if head -c "$staging_consumed" "$staging_path" > "$staging_prefix" 2>/dev/null &&
            tail -c +$(( 10#$staging_consumed + 1 )) "$staging_path" > "$staging_tail" 2>/dev/null; then
-            # Checked, not run bare under set -e: an unchecked failure here used
-            # to kill the whole script mid-loop, abandoning every other staging
-            # file in STAGING_PATHS_FILE rather than handling just this one.
-            if STAGING_MV_ERR=$(mv "$staging_tail" "$staging_path" 2>&1); then
-                log "consolidation" "kept $(( staging_now - 10#$staging_consumed ))b appended to $(basename "$staging_path") during consolidation"
+            if STAGING_MV_ERR=$(retire_whole_into "$staging_prefix" "$staging_done" 2>&1); then
+                # Checked, not run bare under set -e: an unchecked failure here
+                # used to kill the whole script mid-loop, abandoning every
+                # other staging file in STAGING_PATHS_FILE rather than
+                # handling just this one.
+                if STAGING_MV_ERR=$(mv "$staging_tail" "$staging_path" 2>&1); then
+                    log "consolidation" "kept $(( staging_now - 10#$staging_consumed ))b appended to $(basename "$staging_path") during consolidation"
+                else
+                    # staging_path is untouched: same-directory mv is a real
+                    # rename, which cannot fail partway (#246). staging_done
+                    # already durably holds the consumed prefix, committed by
+                    # retire_whole_into just above. On a retry against the
+                    # SAME failed attempt (staging_path unchanged, so the
+                    # recomputed staging_consumed matches) that prefix gets
+                    # appended again, duplicating a few hundred bytes of
+                    # already-in-progress content -- accepted, since a visible
+                    # duplicate is far cheaper than the alternative of
+                    # truncating a genuinely earlier retired span for this day
+                    # (#509) if staging_done exists because this is a
+                    # re-opened day rather than a retry. Leaving staging_path
+                    # in place means the next run re-reads it whole and redoes
+                    # the split; the consumed span becomes a duplicate in
+                    # recent.md/archive.md that the merge dedupes, chosen over
+                    # losing the tail appended during this consolidation.
+                    rm -f "$staging_tail"
+                    log "consolidation" "ERROR: could not keep the tail of $(basename "$staging_path") appended during consolidation -- staging_done already gained the consumed prefix above, so a retry will duplicate it (accepted, see the comment on retire_whole_into) -- staging_path left in place for the next run to retry: ${STAGING_MV_ERR}"
+                fi
             else
-                # staging_path is untouched: same-directory mv is a real
-                # rename, which cannot fail partway (#246). staging_done
-                # already holds the consumed prefix written above by
-                # retire_prefix_into. On a retry against the SAME failed
-                # attempt (staging_path unchanged, so the recomputed
-                # staging_consumed matches) that prefix gets appended again,
-                # duplicating a few hundred bytes of already-in-progress
-                # content -- accepted, since a visible duplicate is far
-                # cheaper than the alternative of truncating a genuinely
-                # earlier retired span for this day (#509) if staging_done
-                # exists because this is a re-opened day rather than a retry.
-                # Leaving staging_path in place means the next run re-reads
-                # it whole and redoes the split; the consumed span becomes a
-                # duplicate in recent.md/archive.md that the merge dedupes,
-                # chosen over losing the tail appended during this
-                # consolidation.
+                # The prefix commit itself failed -- staging_prefix is a
+                # self-contained temp file, so retire_whole_into's own
+                # atomicity note applies: staging_done may hold nothing, or a
+                # truncated fragment of the prefix, but never another
+                # caller's bytes. staging_path is wholly untouched (never
+                # opened for writing above this point), so the next run
+                # re-reads it whole and redoes the split from scratch.
                 rm -f "$staging_tail"
-                log "consolidation" "ERROR: could not keep the tail of $(basename "$staging_path") appended during consolidation -- left in place for the next run to retry: ${STAGING_MV_ERR}"
+                log "consolidation" "ERROR: could not commit the consumed prefix of $(basename "$staging_path") into .done.md -- staging_path left in place for the next run to retry: ${STAGING_MV_ERR}"
             fi
         else
-            rm -f "$staging_tail"
+            rm -f "$staging_tail" "$staging_prefix"
+            # retire_whole_into is cat+rm when .done.md already exists (#509,
+            # self-review): if cat durably succeeded and only the trailing
+            # rm failed, staging_path survives here NOT because nothing
+            # happened but because cleanup alone failed -- so the honest
+            # claim is "may already be retired", not "unconsolidated".
             if ! STAGING_MV_ERR=$(retire_whole_into "$staging_path" "$staging_done" 2>&1); then
-                log "consolidation" "ERROR: could not retire $(basename "$staging_path") to .done.md -- left in place, the next run will see it as unconsolidated: ${STAGING_MV_ERR}"
+                log "consolidation" "ERROR: could not retire $(basename "$staging_path") to .done.md -- staging_path left in place, but if .done.md already existed the append itself may have already landed and only cleanup failed, so the next run may duplicate rather than freshly retire: ${STAGING_MV_ERR}"
             fi
         fi
     else
+        # Same retire_whole_into caveat as above: a failure here can mean
+        # "nothing happened" (dst did not exist, mv failed) or "appended,
+        # cleanup failed" (dst existed, cat succeeded, rm did not) -- the log
+        # line says so rather than asserting the cleaner of the two.
         if ! STAGING_MV_ERR=$(retire_whole_into "$staging_path" "$staging_done" 2>&1); then
-            log "consolidation" "ERROR: could not retire $(basename "$staging_path") to .done.md -- left in place, the next run will see it as unconsolidated: ${STAGING_MV_ERR}"
+            log "consolidation" "ERROR: could not retire $(basename "$staging_path") to .done.md -- staging_path left in place, but if .done.md already existed the append itself may have already landed and only cleanup failed, so the next run may duplicate rather than freshly retire: ${STAGING_MV_ERR}"
         fi
     fi
 done < "$STAGING_PATHS_FILE"

--- a/scripts/run-consolidation.sh
+++ b/scripts/run-consolidation.sh
@@ -189,6 +189,36 @@ if ! staging_lock_acquire "$STAGING_LOCK_TIMEOUT"; then
     rm -f "$STAGING_PATHS_FILE"
     exit 0
 fi
+
+# A $2 that already exists means this day was retired before and a
+# today-*.md was re-created for it since -- a session spanning midnight, or
+# NDC re-opening an already-retired day's staging file (#509). Append rather
+# than truncate-overwrite in that case, so the earlier retired span's hourly
+# detail survives; a plain rename/truncate when $2 does not exist yet is
+# unchanged. Same-directory content append + unlink, not a partial-write
+# hazard the way a cross-filesystem mv would be (#246 is about mv atomicity
+# across filesystems; cat+rm here never crosses one).
+retire_whole_into() {
+    local src="$1" dst="$2"
+    if [ -e "$dst" ]; then
+        cat "$src" >> "$dst" && rm -f "$src"
+    else
+        mv "$src" "$dst"
+    fi
+}
+
+# Same guard as retire_whole_into, for the bounded-prefix write below: write
+# $3 bytes of $1 into $2, appending instead of truncating if $2 already
+# exists.
+retire_prefix_into() {
+    local src="$1" dst="$2" nbytes="$3"
+    if [ -e "$dst" ]; then
+        head -c "$nbytes" "$src" >> "$dst"
+    else
+        head -c "$nbytes" "$src" > "$dst"
+    fi
+}
+
 while IFS= read -r -d '' staging_path && IFS= read -r -d '' staging_consumed; do
     if [ ! -f "$staging_path" ]; then
         log "consolidation" "WARN: $(basename "$staging_path") disappeared"
@@ -209,7 +239,7 @@ while IFS= read -r -d '' staging_path && IFS= read -r -d '' staging_consumed; do
         # but would accumulate one per failure otherwise.
         rm -f "${staging_path}".tail-* 2>/dev/null
         staging_tail=$(mktemp "${staging_path}.tail-XXXXXX")
-        if head -c "$staging_consumed" "$staging_path" > "$staging_done" 2>/dev/null &&
+        if retire_prefix_into "$staging_path" "$staging_done" "$staging_consumed" 2>/dev/null &&
            tail -c +$(( 10#$staging_consumed + 1 )) "$staging_path" > "$staging_tail" 2>/dev/null; then
             # Checked, not run bare under set -e: an unchecked failure here used
             # to kill the whole script mid-loop, abandoning every other staging
@@ -219,23 +249,31 @@ while IFS= read -r -d '' staging_path && IFS= read -r -d '' staging_consumed; do
             else
                 # staging_path is untouched: same-directory mv is a real
                 # rename, which cannot fail partway (#246). staging_done
-                # already holds the consumed prefix — harmless, it is
-                # overwritten identically when this file is retried. Leaving
-                # staging_path in place means the next run re-reads it whole
-                # and redoes the split; the consumed span becomes a duplicate
-                # in recent.md/archive.md that the merge dedupes, chosen over
-                # losing the tail appended during this consolidation.
+                # already holds the consumed prefix written above by
+                # retire_prefix_into. On a retry against the SAME failed
+                # attempt (staging_path unchanged, so the recomputed
+                # staging_consumed matches) that prefix gets appended again,
+                # duplicating a few hundred bytes of already-in-progress
+                # content -- accepted, since a visible duplicate is far
+                # cheaper than the alternative of truncating a genuinely
+                # earlier retired span for this day (#509) if staging_done
+                # exists because this is a re-opened day rather than a retry.
+                # Leaving staging_path in place means the next run re-reads
+                # it whole and redoes the split; the consumed span becomes a
+                # duplicate in recent.md/archive.md that the merge dedupes,
+                # chosen over losing the tail appended during this
+                # consolidation.
                 rm -f "$staging_tail"
                 log "consolidation" "ERROR: could not keep the tail of $(basename "$staging_path") appended during consolidation -- left in place for the next run to retry: ${STAGING_MV_ERR}"
             fi
         else
             rm -f "$staging_tail"
-            if ! STAGING_MV_ERR=$(mv "$staging_path" "$staging_done" 2>&1); then
+            if ! STAGING_MV_ERR=$(retire_whole_into "$staging_path" "$staging_done" 2>&1); then
                 log "consolidation" "ERROR: could not retire $(basename "$staging_path") to .done.md -- left in place, the next run will see it as unconsolidated: ${STAGING_MV_ERR}"
             fi
         fi
     else
-        if ! STAGING_MV_ERR=$(mv "$staging_path" "$staging_done" 2>&1); then
+        if ! STAGING_MV_ERR=$(retire_whole_into "$staging_path" "$staging_done" 2>&1); then
             log "consolidation" "ERROR: could not retire $(basename "$staging_path") to .done.md -- left in place, the next run will see it as unconsolidated: ${STAGING_MV_ERR}"
         fi
     fi

--- a/tests/test_consolidation_retire_reopened_day_509.py
+++ b/tests/test_consolidation_retire_reopened_day_509.py
@@ -1,0 +1,127 @@
+"""A retired day re-opened by NDC must not have its earlier retired span
+silently destroyed when it is retired a second time (#509).
+
+`run-consolidation.sh`'s retire loop turns a `today-YYYY-MM-DD.md` staging
+file into `today-YYYY-MM-DD.done.md`. `recent.md`/`archive.md` already merged
+both spans by the time retirement runs, so this is not memory-injection loss
+-- but the `.done.md` layer is the "searchable, not injected" hourly detail
+the README promises, and a plain `mv`/`head -c ... >` over an EXISTING
+`.done.md` truncates it, with no log line marking the loss.
+
+This can happen for real: a long-running session spanning midnight, or NDC
+re-creating a `today-<day>.md` for a day that was already retired. The second
+consolidation of that day must not erase the first.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from .test_consolidation_append_race import _make_env, _run
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash subprocess + POSIX layout -- not portable to Windows runners (#79)",
+)
+
+
+class TestRetireReopenedDay509:
+    def test_retiring_a_reopened_day_appends_instead_of_overwriting(self, tmp_path):
+        """The reported bug: retire the same day twice, first span must survive."""
+        env, _project, plugin, remember = _make_env(tmp_path)
+        staging = remember / "today-2026-07-24.md"
+        staging.write_text(
+            "# Day\n\n## 10:00 | main\n\n- first span work\n", encoding="utf-8"
+        )
+
+        result = _run(plugin, env)
+        assert result.returncode == 0, result.stderr
+
+        done = remember / "today-2026-07-24.done.md"
+        assert done.is_file(), "first consolidation did not retire the day at all"
+        first_span_content = done.read_text(encoding="utf-8")
+        assert "first span work" in first_span_content
+
+        # NDC re-opens the day: a new today-2026-07-24.md staging file,
+        # written by a session spanning midnight or otherwise resuming work
+        # on an already-retired day.
+        staging.write_text(
+            "# Day\n\n## 23:30 | main\n\n- second span work\n", encoding="utf-8"
+        )
+
+        result2 = _run(plugin, env)
+        assert result2.returncode == 0, result2.stderr
+
+        final_content = done.read_text(encoding="utf-8")
+        assert "first span work" in final_content, (
+            "the first retired span was destroyed by the second retirement -- "
+            f"got: {final_content!r}"
+        )
+        assert "second span work" in final_content, (
+            "the second span was not retired into the .done.md at all -- "
+            f"got: {final_content!r}"
+        )
+
+    def test_retiring_a_never_retired_day_still_works_normally(self, tmp_path):
+        """Positive control: a day retired for the first time is unaffected."""
+        env, _project, plugin, remember = _make_env(tmp_path)
+        staging = remember / "today-2026-07-25.md"
+        staging.write_text(
+            "# Day\n\n## 09:00 | main\n\n- only span\n", encoding="utf-8"
+        )
+
+        result = _run(plugin, env)
+        assert result.returncode == 0, result.stderr
+
+        assert not staging.exists(), "the file should have been retired away"
+        done = remember / "today-2026-07-25.done.md"
+        assert done.is_file() and "only span" in done.read_text(encoding="utf-8")
+
+    def test_retiring_a_reopened_day_with_a_concurrent_append_still_preserves_the_first_span(
+        self, tmp_path
+    ):
+        """Same bug, but through the head -c ... > branch: a save lands during
+        the SECOND consolidation of a re-opened day (staging_now > consumed),
+        so the retire loop takes the partial-prefix-write path rather than the
+        plain mv. That path truncated too and needs the same guard."""
+        env, _project, plugin, remember = _make_env(tmp_path)
+        staging = remember / "today-2026-07-24.md"
+        staging.write_text(
+            "# Day\n\n## 10:00 | main\n\n- first span work\n", encoding="utf-8"
+        )
+
+        result = _run(plugin, env)
+        assert result.returncode == 0, result.stderr
+        done = remember / "today-2026-07-24.done.md"
+        assert "first span work" in done.read_text(encoding="utf-8")
+
+        staging.write_text(
+            "# Day\n\n## 23:30 | main\n\n- second span work\n", encoding="utf-8"
+        )
+        env["STUB_APPEND_DURING_CONSOLIDATION"] = (
+            "\n## 23:59 | main\n\n- landed during consolidation\n"
+        )
+
+        result2 = _run(plugin, env)
+        assert result2.returncode == 0, result2.stderr
+
+        final_content = done.read_text(encoding="utf-8")
+        assert "first span work" in final_content, (
+            "the first retired span was destroyed by the second (partial-write) "
+            f"retirement -- got: {final_content!r}"
+        )
+        assert "second span work" in final_content, (
+            f"the second span's consumed prefix was not retired -- got: {final_content!r}"
+        )
+
+        live = "".join(
+            p.read_text(encoding="utf-8")
+            for p in remember.glob("today-*.md")
+            if not p.name.endswith(".done.md")
+        )
+        assert "landed during consolidation" in live, (
+            "the entry appended during the second consolidation was sealed away "
+            f"instead of kept as the live tail -- got: {live!r}"
+        )

--- a/tests/test_consolidation_retire_reopened_day_509.py
+++ b/tests/test_consolidation_retire_reopened_day_509.py
@@ -15,6 +15,7 @@ consolidation of that day must not erase the first.
 
 from __future__ import annotations
 
+import os
 import sys
 
 import pytest
@@ -124,4 +125,72 @@ class TestRetireReopenedDay509:
         assert "landed during consolidation" in live, (
             "the entry appended during the second consolidation was sealed away "
             f"instead of kept as the live tail -- got: {live!r}"
+        )
+
+
+# `tail` fails ONLY when invoked with `-c +N` against TAIL_STUB_TARGET, so the
+# retire loop's own tail extraction (`tail -c +$(( ... ))`) is the sole call
+# intercepted; every other `tail` invocation in the script (or its sourced
+# libraries) passes straight through to the real binary.
+TAIL_STUB = r"""#!/bin/sh
+_target="$TAIL_STUB_TARGET"
+_last=""
+for _a in "$@"; do _last="$_a"; done
+case "$1" in
+    -c)
+        if [ -n "$_target" ] && [ "$_last" = "$_target" ]; then
+            exit 1
+        fi
+        ;;
+esac
+command -p tail "$@"
+"""
+
+
+class TestConsolidationRetireTailFailureDoesNotDuplicate509:
+    def test_a_tail_extraction_failure_does_not_duplicate_the_consumed_prefix(
+        self, tmp_path
+    ):
+        """Explore's #509 self-review finding: an earlier draft of the fix
+        wrote the consumed prefix straight into staging_done via
+        retire_prefix_into, BEFORE the `tail` extraction below it was known
+        to succeed. When `tail` then failed, the whole-file fallback
+        (retire_whole_into on the original staging_path) re-committed the
+        SAME prefix on top of the one already durably sitting in
+        staging_done -- doubling it, unconditionally, on the very first
+        attempt. Reproduced here by forcing the retire loop's own `tail -c`
+        call to fail while `head -c` (the prefix extraction) still succeeds."""
+        env, _project, plugin, remember = _make_env(tmp_path)
+        staging = remember / "today-2026-07-24.md"
+        staging.write_text(
+            "# Day\n\n## 10:00 | main\n\n- first span work\n", encoding="utf-8"
+        )
+        env["STUB_APPEND_DURING_CONSOLIDATION"] = (
+            "\n## 23:59 | main\n\n- landed during consolidation\n"
+        )
+
+        bindir = tmp_path / "tail-stub-bin"
+        bindir.mkdir()
+        stub = bindir / "tail"
+        stub.write_text(TAIL_STUB, encoding="utf-8")
+        stub.chmod(0o755)
+        env["PATH"] = f"{bindir}{os.pathsep}{env['PATH']}"
+        env["TAIL_STUB_TARGET"] = str(staging)
+
+        result = _run(plugin, env)
+        assert result.returncode == 0, result.stderr
+
+        done = remember / "today-2026-07-24.done.md"
+        assert done.is_file(), (
+            "the tail failure must still fall through to the whole-file "
+            f"retire fallback, not abandon the file: {result.stderr}"
+        )
+        content = done.read_text(encoding="utf-8")
+        assert content.count("first span work") == 1, (
+            "the consumed prefix was committed to staging_done more than once "
+            f"-- duplicated by the tail-failure fallback. got: {content!r}"
+        )
+        assert content.count("landed during consolidation") == 1, (
+            f"the whole-file fallback did not retire the full file exactly "
+            f"once: {content!r}"
         )

--- a/tests/test_cross_host_lock_contract_491.py
+++ b/tests/test_cross_host_lock_contract_491.py
@@ -1,0 +1,203 @@
+"""Establishes (does not assume) whether the locking surface is safe when
+Claude Code and Codex share one `.remember/` store on one machine (#491).
+
+`scripts/lib-lock.sh` (the one lock primitive, #182) and
+`scripts/lib-staging-lock.sh` (the today-*.md lock, #225) were both written
+and tested against a single host's process model -- neither file, nor its
+existing test suite, contains the string "codex" or "host". The primitive
+itself turns out to already be host-agnostic where it matters: `mkdir` and
+`kill -0` are OS-level, process-table operations, indifferent to which CLI
+spawned the contending process. This file writes that contract down and
+proves it under real concurrent writes from two simulated hosts -- not a
+two-host test that passes because the second host never actually wrote,
+which the issue itself names as the failure mode to design against.
+
+It also demonstrates the one real, PRE-EXISTING limitation this design
+inherits from `kill -0`-based staleness detection: a dead holder's PID can be
+reused by an unrelated live process before the lock is checked, and nothing
+here can tell that process apart from the true (dead) holder. This is not
+introduced or worsened by adding a second host -- it is exactly as likely
+between two Claude Code processes as between a Claude Code process and a
+Codex process, because `kill -0` cannot see which CLI started a PID. It is
+recorded here as a known, general limitation, not as new cross-host damage.
+
+Finally: whether anything in the lock or staging path assumes the Claude
+session-ID shape. Neither `lib-lock.sh` nor `lib-staging-lock.sh` ever reads
+a session id at all -- lock directories are keyed by fixed literal names
+(save.lock, consolidation.lock, staging.lock) and staging files are keyed by
+*day*, not by session. The session-ID shape mismatch between Claude Code's
+UUID and Codex's `rollout-<date>-<uuid>` basename is real (#459/#468) but
+lives entirely in `post-tool-hook.sh`/`save-session.sh`'s own session
+resolution, upstream of anything this file touches -- confirmed here with a
+grep-based contract test so a future edit that starts threading a session id
+into the lock layer trips it.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash subprocess + POSIX process semantics (kill -0, mkdir races) -- "
+    "not portable to Windows runners (#79)",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LIB_LOCK = REPO_ROOT / "scripts" / "lib-lock.sh"
+LIB_STAGING_LOCK = REPO_ROOT / "scripts" / "lib-staging-lock.sh"
+
+
+def _run(script: str, **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False, **kwargs
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Two concurrent writers, genuinely different simulated hosts, one store.
+# ---------------------------------------------------------------------------
+
+
+def test_two_concurrent_hosts_appending_to_staging_lose_nothing_and_interleave_nothing(tmp_path):
+    """Claude Code and Codex both append to the same today-*.md, concurrently,
+    each holding CODEX_SESSION_ID xor CLAUDE_CODE_SESSION_ID -- the actual
+    signature `pipeline/host.py` uses to tell them apart -- for the whole
+    round, so a bug that keyed anything off that env var would be exercised.
+    Every entry from every round of every host must survive intact, with no
+    entry's separator/summary split apart by another writer landing between
+    them (#225's own reported failure shape)."""
+    today = tmp_path / "today-2026-08-01.md"
+    rounds_per_host = 6
+
+    script = f"""
+    source {LIB_LOCK}
+    source {LIB_STAGING_LOCK}
+    today="{today}"
+
+    host_write() {{
+        local host="$1" n="$2" text_file
+        text_file=$(mktemp)
+        printf '## marker-%s-%s | main\\n\\n- entry from %s round %s\\n' "$host" "$n" "$host" "$n" > "$text_file"
+        if staging_lock_acquire 10; then
+            staging_append "$today" "$text_file"
+            staging_lock_release
+        else
+            echo "TIMEOUT $host $n" >&2
+        fi
+        rm -f "$text_file"
+    }}
+
+    for i in $(seq 1 {rounds_per_host}); do
+        ( export CLAUDE_CODE_ENTRYPOINT=hook CLAUDE_CODE_SESSION_ID=aaaa-claude; unset CODEX_SESSION_ID CODEX_THREAD_ID; host_write claude "$i" ) &
+    done
+    for i in $(seq 1 {rounds_per_host}); do
+        ( export CODEX_SESSION_ID=bbbb-codex CODEX_THREAD_ID=cccc-thread; unset CLAUDE_CODE_ENTRYPOINT CLAUDE_CODE_SESSION_ID; host_write codex "$i" ) &
+    done
+    wait
+    """
+    result = _run(script)
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "TIMEOUT" not in result.stderr, (
+        f"a host timed out waiting for staging.lock -- not a clean two-writer "
+        f"round: {result.stderr!r}"
+    )
+
+    content = today.read_text(encoding="utf-8")
+
+    for host in ("claude", "codex"):
+        for n in range(1, rounds_per_host + 1):
+            marker = f"marker-{host}-{n}"
+            assert content.count(marker) == 1, (
+                f"{marker} appears {content.count(marker)} times, expected exactly "
+                f"1 -- an entry was lost or duplicated under concurrent writes from "
+                f"both hosts. Full content:\n{content!r}"
+            )
+
+    # No entry's two-line append (separator, then summary) was split apart by
+    # the OTHER host's write landing between them: every marker heading is
+    # immediately followed by a blank line and then its own "entry from"
+    # line, never by another marker or by nothing.
+    entries = re.findall(
+        r"## (marker-\w+-\d+) \| main\n\n- entry from (\w+) round (\d+)\n",
+        content,
+    )
+    assert len(entries) == 2 * rounds_per_host, (
+        f"expected {2 * rounds_per_host} well-formed entries (heading immediately "
+        f"followed by its own blank line and summary), found {len(entries)} -- "
+        f"some entry's two-part append was interleaved with another writer's. "
+        f"Full content:\n{content!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. A dead holder's PID reused by an unrelated live process. General
+#    kill-0 hazard, present identically with or without a second host --
+#    documented, not new, not fixed here.
+# ---------------------------------------------------------------------------
+
+
+def test_a_dead_holders_pid_reused_by_an_unrelated_live_process_blocks_recovery(tmp_path):
+    """PRE-EXISTING, GENERAL limitation of `kill -0`-based staleness detection
+    (present since #182, not introduced by a second host): if the PID a dead
+    holder's lock names has since been reused by some OTHER, unrelated live
+    process -- which `kill -0` cannot distinguish from the true holder -- the
+    lock is judged live and is never recovered until that unrelated process
+    also exits. A second host sharing the store does not make this MORE
+    likely than two Claude Code processes racing on their own: `kill -0` sees
+    a PID, never which CLI spawned it. Recorded here as a documented limit,
+    not as new cross-host damage; a real fix (a start-time or generation
+    check) is a design decision out of this issue's scope -- see the pull
+    request body."""
+    lock_dir = tmp_path / "stale.lock"
+    lock_dir.mkdir()
+
+    # Stand-in for "recycled by an unrelated process": a real, currently-live
+    # sibling process this test controls, whose PID is not the true holder's
+    # -- the same shape a coincidentally-reused PID would present to
+    # `kill -0`, without depending on the OS actually reusing anything.
+    innocent = subprocess.Popen(["sleep", "5"])
+    try:
+        (lock_dir / "pid").write_text(str(innocent.pid), encoding="utf-8")
+
+        result = _run(f"""
+        source {LIB_LOCK}
+        lock_acquire "{lock_dir}" 0 && echo ACQUIRED || echo REFUSED
+        """)
+        assert "REFUSED" in result.stdout, (
+            "expected the lock to still be judged live (this documents a known "
+            f"limitation, not a fix): {result.stdout!r} {result.stderr!r}"
+        )
+    finally:
+        innocent.terminate()
+        innocent.wait(timeout=10)
+
+
+# ---------------------------------------------------------------------------
+# 3. Contract: the lock/staging layer never reads a session id.
+# ---------------------------------------------------------------------------
+
+
+def test_lock_and_staging_layer_never_reference_a_session_id(tmp_path):
+    """The Claude-Code-vs-Codex session-ID SHAPE mismatch (#459/#468, a UUID
+    vs `rollout-<date>-<uuid>`) is real, but lives entirely in
+    post-tool-hook.sh/save-session.sh's own session resolution -- upstream of
+    the lock primitive and the staging lock, which key everything by fixed
+    literal lock names (save.lock, consolidation.lock, staging.lock) or by
+    *day* (today-YYYY-MM-DD.md), never by session. A grep contract rather
+    than an inspection: trips if a future edit starts threading a session id
+    into either file."""
+    for path in (LIB_LOCK, LIB_STAGING_LOCK):
+        text = path.read_text(encoding="utf-8")
+        for needle in ("SESSION_ID", "session_id", "session-id"):
+            assert needle not in text, (
+                f"{path.name} references {needle!r} -- the lock/staging layer was "
+                "believed to be session-shape agnostic; if this is now "
+                "intentional, update this contract test's docstring and #491's "
+                "closing note rather than silently breaking it"
+            )


### PR DESCRIPTION
## #509 -- consolidation retire overwrites an existing .done.md

`run-consolidation.sh`'s retire loop turned a `today-YYYY-MM-DD.md` staging file into `today-YYYY-MM-DD.done.md` with a plain `mv` (or `head -c ... >` in the concurrent-append path). When a day was re-opened after already being retired once -- a session spanning midnight, or NDC re-creating the staging file for an already-retired day -- the second retirement silently truncate-overwrote the existing `.done.md`, destroying the first retired span's hourly-detail data with no log line. `recent.md`/`archive.md` are unaffected (they already merged both spans), so this was never memory-injection loss, but it destroyed the "searchable, not injected" hourly detail layer the README promises.

Fixed by appending to an existing `.done.md` instead of overwriting it, in both the plain-rename and the concurrent-append retire paths. Test-first: `tests/test_consolidation_retire_reopened_day_509.py` reproduces the overwrite (retire the same day twice, assert the first span survives), red before the fix and green after, plus a positive control (a day retired for the first time still works normally).

## #491 -- cross-host locking contract, Claude Code + Codex sharing one store

`scripts/lib-lock.sh` and `scripts/lib-staging-lock.sh` were written and tested against a single host's process model and never mentioned Codex or "host" anywhere. Established (not assumed): the lock primitive is safe when Claude Code and Codex share one `.remember/` store on one machine, because `mkdir`/`kill -0` are OS-level process-table operations indifferent to which CLI spawned the contending process, and every lock is keyed by a fixed literal name or by day, never by session id. Both files now carry that contract as a header comment. `tests/test_cross_host_lock_contract_491.py` proves it under real concurrent writes from two simulated hosts (no lost/interleaved entries -- a genuine two-writer test, not one where the second writer never actually wrote), documents the one general, pre-existing `kill -0` PID-reuse limitation this design inherits (not new, not worsened by a second host), and locks in via a grep contract that the lock/staging layer never assumes a session-ID shape.

## Self-review

Spawned `Explore` and `oss:auditor` against the first commit. Both found a real duplication bug my first draft introduced: `retire_prefix_into` wrote the consumed prefix straight into `.done.md` before the paired `tail` extraction was known to succeed, so a `tail` failure's whole-file fallback re-committed the same prefix on top -- duplicating it unconditionally on the very first attempt, not only on a documented retry. Fixed in a follow-up commit by landing both extractions in temp files first and touching `.done.md` only once both are known good; reproduced red against the pre-restructure code with a `tail`-stub, green after. Also reworded two ERROR log lines and a stale comment that overclaimed a clean, safely-retriable state when `cat` (not atomic, unlike the `mv` it replaces here) can durably succeed while the trailing `rm` fails.

**Below the bar, recorded here rather than filed:** a persistent `rm` failure after a successful `cat` (a stuck permission/immutable-flag condition unlinking a retired staging file) still causes unbounded duplicate growth in `.done.md` across every subsequent run -- only its logging is now honest, not the underlying growth. A real fix needs a design decision (a commit marker, refusing a partial `cat`, or an atomicity redesign of the append path) beyond this issue's scope; the class is reachable in principle but requires a pathological, sustained filesystem-permission condition to trigger, which is why it stops here rather than becoming a filed issue.

Closes #509, closes #491.