### PR TITLE
Report a test that dominates the suite, before somebody notices it by hand (#510)

### DIFF
--- a/README.md
+++ b/README.md
@@ -836,6 +836,37 @@ looks exactly like a green run that checked everything.
 Read the `SKIPPED` block at the end of a run before concluding a leg is covered.
 On a Linux runner it is where you find out that the floor bash was not.
 
+### A test that dominates the suite (`#510`)
+
+`pytest` already prints `--durations` (`addopts` carries `--durations=25`);
+nothing read it before #510, so one runaway test could grow to a large share
+of every leg's wall-clock time and the only detector was a human happening to
+scroll a CI log far enough to notice. The root-level `conftest.py` closes that:
+a `pytest_terminal_summary` hook fires at the end of *every* `pytest`
+invocation -- local or any leg of the matrix, no extra flag -- and prints the
+top durations plus the slowest single test's **share of total suite time**
+(a ratio, not an absolute second count, since an absolute count says more
+about the runner than the test). The math lives in
+`scripts/report_test_durations.py`, kept separate from the hook so it is
+testable without driving a nested `pytest` session.
+
+Three states, always distinguishable in the printed text:
+
+- `measured` -- durations were collected and compared against
+  `test-durations-baseline.json` at the repo root.
+- `no-baseline` -- durations were collected but that file does not exist yet
+  (true of every run until a maintainer records one by hand). The share is
+  still printed, said out loud as `no-baseline` rather than rendered as if
+  nothing had changed.
+- `could-not-measure` -- no per-test durations could be collected, or the
+  total suite time was not a usable number. Always names the reason; never
+  prints nothing, which would read exactly like a suite with no hot test.
+
+This is a report, never a gate: it does not fail a run on wall-clock time or
+any share threshold, on purpose -- a shared CI runner's load is not in
+anybody's diff, and a check that reddens a pull request for a neighbour's
+noisy build only teaches people to re-run until green.
+
 ### Measuring the warm path (`tests/env_cache.py`)
 
 `scripts/lib-env-cache.sh` refuses its cache unless the cache file is `-nt`

--- a/changelog.d/510.added.md
+++ b/changelog.d/510.added.md
@@ -1,0 +1,6 @@
+- **A test that dominates the suite is now reported, not found by chance** (#510). `pytest` already
+  printed `--durations`; nothing read it. A root-level `conftest.py` now prints the top durations
+  and the slowest test's share of total suite time at the end of every `pytest` run, local or any CI
+  leg, with no extra flag. Three states -- `measured`, `no-baseline`, `could-not-measure` -- are
+  always distinguishable in the output; it is a report, never a gate, and never fails a run on
+  wall-clock time.

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,70 @@
+"""Root-level pytest plugin: the #510 test-duration reporter.
+
+`pytest` already prints `--durations` (wired via `addopts` in
+`pyproject.toml`); nothing read it before this, so a single test dominating
+a suite had no detector but a human scrolling a CI log by chance (#510's own
+worked example: a test at 43.92s against ~6.5s for the next slowest, roughly
+a fifth of the whole run, found only because a maintainer happened to read
+that far).
+
+`pytest_terminal_summary` fires at the end of every `pytest` invocation --
+local or any leg of the CI matrix -- with no extra flag required, and reads
+the same `TestReport` objects pytest's own summary is built from off
+`terminalreporter.stats`, rather than re-parsing pytest's own formatted
+`--durations` text. The actual duration math lives in
+`scripts/report_test_durations.py`, kept separate so it can be unit-tested
+without driving a nested pytest session.
+
+This intentionally never raises and never touches `exitstatus`: a reporter
+bug must not turn a green run red, and #510 is explicit that this is a
+report a human reads, never a gate.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from scripts.report_test_durations import (
+    DEFAULT_BASELINE_PATH,
+    analyze,
+    collect_from_reports,
+    format_report,
+    load_baseline,
+)
+
+
+def pytest_sessionstart(session):
+    # Recorded here rather than trusted off `terminalreporter` -- pytest does
+    # not guarantee that object carries a session-start timestamp under any
+    # stable name across versions, and a `getattr(..., None)` against a name
+    # that silently stopped existing would turn "measured" into
+    # "could-not-measure" on some future pytest with nothing pointing at why.
+    session.config._report_test_durations_510_start = time.time()
+
+
+def pytest_terminal_summary(terminalreporter, exitstatus, config):
+    try:
+        reports = [
+            report
+            for report_list in terminalreporter.stats.values()
+            for report in report_list
+            if hasattr(report, "duration")
+        ]
+        durations = collect_from_reports(reports)
+
+        start = getattr(config, "_report_test_durations_510_start", None)
+        total_seconds = (time.time() - start) if start is not None else None
+
+        baseline, baseline_error = load_baseline(DEFAULT_BASELINE_PATH)
+        result = analyze(durations, total_seconds, baseline)
+        result.baseline_error = baseline_error
+
+        terminalreporter.write_line(format_report(result))
+    except Exception as exc:  # noqa: BLE001 -- pragma: no cover - defensive; see module docstring
+        terminalreporter.write_line(
+            f"-- test duration report (#510) --\nstate: could-not-measure (reporter raised {exc!r})"
+        )

--- a/conftest.py
+++ b/conftest.py
@@ -17,7 +17,16 @@ without driving a nested pytest session.
 
 This intentionally never raises and never touches `exitstatus`: a reporter
 bug must not turn a green run red, and #510 is explicit that this is a
-report a human reads, never a gate.
+report a human reads, never a gate. That includes the import of
+`scripts/report_test_durations.py` itself -- it happens inside
+`pytest_terminal_summary`'s own `try`, not at module scope, so a defect in
+that module degrades to the `could-not-measure` state instead of aborting
+collection for the whole session (a module-scope import failure is a
+`conftest.py` collection error, which pytest treats as fatal: zero tests
+run, non-zero exit, no report at all -- exactly the total, silent failure
+this feature exists to prevent, just promoted from "one test" to "every
+test"). See `tests/test_conftest_import_failure_510.py` for the case this
+guards against.
 """
 
 from __future__ import annotations
@@ -27,14 +36,6 @@ import sys
 import time
 
 sys.path.insert(0, os.path.dirname(__file__))
-
-from scripts.report_test_durations import (
-    DEFAULT_BASELINE_PATH,
-    analyze,
-    collect_from_reports,
-    format_report,
-    load_baseline,
-)
 
 
 def pytest_sessionstart(session):
@@ -48,6 +49,14 @@ def pytest_sessionstart(session):
 
 def pytest_terminal_summary(terminalreporter, exitstatus, config):
     try:
+        from scripts.report_test_durations import (
+            DEFAULT_BASELINE_PATH,
+            analyze,
+            collect_from_reports,
+            format_report,
+            load_baseline,
+        )
+
         reports = [
             report
             for report_list in terminalreporter.stats.values()

--- a/scripts/report_test_durations.py
+++ b/scripts/report_test_durations.py
@@ -1,0 +1,217 @@
+"""Report the shape of the suite's time -- top durations, and the slowest
+single test's share of total suite time (#510).
+
+`pytest` already prints `--durations` (wired via `addopts` in
+`pyproject.toml`); nothing read it before this, so a single test could grow
+to dominate every leg of the matrix and the only detector was a human
+scrolling a CI log by chance. See #510's own worked example: a test measured
+at 43.92s against ~6.5s for the next slowest, roughly a fifth of the whole
+suite, found only because a maintainer happened to read that far.
+
+This module is deliberately **not** a text parser for pytest's own
+`--durations` output. `conftest.py`'s `pytest_terminal_summary` hook calls
+`collect_from_reports` with the same `TestReport` objects pytest's own
+`-r`/`--durations` summary is built from, straight off `terminalreporter`,
+which is more robust than re-parsing formatted text (no locale/width
+surprises, no risk of pytest changing its own output format underneath a
+regex) and is exercised automatically on every `pytest` invocation -- local
+or CI -- with no extra flag.
+
+Reports a percentage **share** of total suite time rather than an absolute
+second count, deliberately: an absolute count says more about the runner a
+leg happened to land on than about the test (#510).
+
+Three states, and the third is the point -- a step that silently prints
+nothing when it cannot measure is indistinguishable from a suite with no hot
+test, which is the defect class this loop is named after, reappearing inside
+the detector built to prevent it:
+
+- **measured** -- durations were collected, a baseline file was found, and
+  the share is compared against it.
+- **no-baseline** -- durations were collected but no baseline file exists
+  (first run, or nobody has recorded one yet). The share is still reported,
+  said out loud as "no-baseline" rather than rendered as if there were no
+  change.
+- **could-not-measure** -- no per-test durations could be collected, or the
+  total suite time is not a usable number. Always renders a non-empty
+  message naming the reason.
+
+This never fails a run on a wall-clock threshold or a share crossing any
+number -- it is a report a human reads, never a gate (#510's "what NOT to
+add").
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+DEFAULT_TOP_N = 10
+
+# A sibling of this file rather than something CI writes back: nobody commits
+# it automatically, so its plain absence is exactly the "first run" case the
+# no-baseline state exists for. A maintainer who wants the "measured" state
+# populates it by hand from a report they trust.
+DEFAULT_BASELINE_PATH = Path(__file__).resolve().parent.parent / "test-durations-baseline.json"
+
+
+def collect_from_reports(reports: Iterable[object]) -> dict:
+    """Sum `setup`/`call`/`teardown` durations per test node id.
+
+    `reports` is any iterable of objects carrying `.nodeid` and `.duration`
+    -- pytest's own `TestReport`, or a stand-in used in tests. A report
+    missing either attribute, or carrying a `.duration` that will not parse
+    as a float, is skipped rather than raising: a hook that raises takes the
+    whole test run down with it, and one malformed report must not cost
+    every other test's duration data.
+    """
+    totals: dict = {}
+    for report in reports:
+        nodeid = getattr(report, "nodeid", None)
+        duration = getattr(report, "duration", None)
+        if nodeid is None or duration is None:
+            continue
+        try:
+            duration = float(duration)
+        except (TypeError, ValueError):
+            continue
+        totals[nodeid] = totals.get(nodeid, 0.0) + duration
+    return totals
+
+
+@dataclass
+class DurationReport:
+    state: str  # "measured" | "no-baseline" | "could-not-measure"
+    top: list = field(default_factory=list)  # list[tuple[str, float]]
+    slowest_nodeid: str | None = None
+    slowest_seconds: float | None = None
+    total_seconds: float | None = None
+    share: float | None = None
+    baseline_share: float | None = None
+    baseline_error: str | None = None
+    reason: str | None = None  # populated for could-not-measure
+
+
+def analyze(
+    durations: dict,
+    total_seconds: float | None,
+    baseline: dict | None,
+    top_n: int = DEFAULT_TOP_N,
+) -> DurationReport:
+    """Turn collected per-test durations into one of the three states.
+
+    `durations` absent or empty, or `total_seconds` not a usable positive
+    number, is `could-not-measure` -- explicitly, with a reason, rather than
+    a report with nothing in it. Otherwise the slowest single test's share
+    of `total_seconds` is computed, and the state is `measured` when
+    `baseline` (a dict carrying `slowest_share`) is given, `no-baseline`
+    when it is `None`.
+    """
+    if not durations:
+        return DurationReport(
+            state="could-not-measure",
+            reason="no per-test durations were collected",
+        )
+    if total_seconds is None or total_seconds <= 0:
+        return DurationReport(
+            state="could-not-measure",
+            reason=f"total suite time is not a usable number ({total_seconds!r})",
+        )
+
+    ranked = sorted(durations.items(), key=lambda kv: kv[1], reverse=True)
+    slowest_nodeid, slowest_seconds = ranked[0]
+    share = slowest_seconds / total_seconds
+
+    baseline_share = None
+    if baseline is not None:
+        baseline_share = baseline.get("slowest_share")
+
+    state = "measured" if baseline_share is not None else "no-baseline"
+    return DurationReport(
+        state=state,
+        top=ranked[:top_n],
+        slowest_nodeid=slowest_nodeid,
+        slowest_seconds=slowest_seconds,
+        total_seconds=total_seconds,
+        share=share,
+        baseline_share=baseline_share,
+    )
+
+
+def format_report(result: DurationReport) -> str:
+    """Render `result` as human-readable text. Never returns an empty or
+    blank string for any state -- a caller that prints this verbatim always
+    prints *something*, which is the whole point of the could-not-measure
+    state existing as a named branch rather than a silent no-op."""
+    lines = ["-- test duration report (#510) --"]
+
+    if result.state == "could-not-measure":
+        lines.append(f"state: could-not-measure ({result.reason})")
+        return "\n".join(lines)
+
+    lines.append(f"state: {result.state}")
+    lines.append(f"slowest test: {result.slowest_nodeid} ({result.slowest_seconds:.2f}s)")
+    lines.append(f"total suite time: {result.total_seconds:.2f}s")
+    lines.append(f"slowest share of total: {result.share:.1%}")
+
+    if result.baseline_error:
+        lines.append(f"baseline: ignored -- {result.baseline_error}")
+
+    if result.state == "no-baseline":
+        lines.append("baseline: none recorded -- reported with nothing to compare against")
+    else:
+        delta = result.share - result.baseline_share
+        lines.append(f"baseline share: {result.baseline_share:.1%} (delta {delta:+.1%})")
+
+    lines.append(f"top {len(result.top)} durations:")
+    for nodeid, seconds in result.top:
+        lines.append(f"  {seconds:8.2f}s  {nodeid}")
+
+    return "\n".join(lines)
+
+
+def load_baseline(path: Path):
+    """Read a baseline file, returning `(baseline_dict_or_None, error_or_None)`.
+
+    A missing file is the expected "first run" case: `(None, None)`, no
+    error -- that is what turns into the `no-baseline` state, not a defect.
+    A file that exists but will not parse, or is missing the field this
+    module reads, is `(None, <reason>)`: also folds into `no-baseline` (a
+    baseline this module cannot read is not usable, and refusing to fall
+    back would turn a baseline problem into a wall-clock-shaped failure this
+    issue explicitly rules out), but the reason is carried through so
+    `format_report` can say the baseline was ignored, rather than reporting
+    the same "none recorded" text a genuinely first run would produce.
+    """
+    if not path.exists():
+        return None, None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return None, f"{path} could not be read as JSON ({exc})"
+    if not isinstance(data, dict) or "slowest_share" not in data:
+        return None, f"{path} is missing the 'slowest_share' field"
+    return data, None
+
+
+def save_baseline(path: Path, result: DurationReport) -> None:
+    """Write the current `measured`/`no-baseline` result as the new baseline.
+
+    Not called automatically by anything in this repo -- no CI step commits
+    a baseline back, on purpose, since that would need write access to the
+    branch a pull request runs on. A maintainer who wants the `measured`
+    state going forward runs this by hand (see `main`'s `--save-baseline`)
+    once they trust a given run's number.
+    """
+    if result.slowest_nodeid is None or result.share is None:
+        raise ValueError("cannot save a baseline from a could-not-measure result")
+    path.write_text(
+        json.dumps(
+            {"slowest_nodeid": result.slowest_nodeid, "slowest_share": result.share},
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )

--- a/scripts/report_test_durations.py
+++ b/scripts/report_test_durations.py
@@ -201,9 +201,18 @@ def save_baseline(path: Path, result: DurationReport) -> None:
 
     Not called automatically by anything in this repo -- no CI step commits
     a baseline back, on purpose, since that would need write access to the
-    branch a pull request runs on. A maintainer who wants the `measured`
-    state going forward runs this by hand (see `main`'s `--save-baseline`)
-    once they trust a given run's number.
+    branch a pull request runs on, and no `--save-baseline` CLI ships in
+    this file either. A maintainer who wants the `measured` state going
+    forward calls this directly, once they trust a given run's number:
+
+        python3 -c "
+        from scripts.report_test_durations import analyze, save_baseline, DEFAULT_BASELINE_PATH
+        result = analyze(durations, total_seconds, baseline=None)
+        save_baseline(DEFAULT_BASELINE_PATH, result)
+        "
+
+    or from a `pytest` script/REPL session where `durations` and
+    `total_seconds` are already in hand.
     """
     if result.slowest_nodeid is None or result.share is None:
         raise ValueError("cannot save a baseline from a could-not-measure result")

--- a/tests/test_conftest_duration_hook_510.py
+++ b/tests/test_conftest_duration_hook_510.py
@@ -1,0 +1,87 @@
+"""Integration test for the root `conftest.py` hook added by #510.
+
+The unit tests in `test_report_test_durations_510.py` exercise the pure
+functions in `scripts/report_test_durations.py` directly. This file checks
+the other half: that a real, unmodified `pytest` run -- the exact thing
+`.github/workflows/tests.yml`'s "Run tests" step invokes, with no extra flag
+-- actually prints the #510 report, via `pytest_terminal_summary` firing at
+session end. Without this, the unit tests could all be green while the hook
+itself were never wired up, never imported, or silently swallowed by pytest
+plugin discovery -- exactly the "reports nothing and nobody notices" failure
+mode #510 exists to close.
+
+Uses pytest's own `pytester` fixture (a built-in testing plugin for testing
+pytest plugins) to run a real, separate `pytest` subprocess against a copy
+of this repo's `conftest.py` and `scripts/report_test_durations.py`, so it
+never nests inside -- and never gets tangled in -- this repo's own
+`--cov-fail-under=80` addopt.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+pytest_plugins = ["pytester"]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _stage_conftest_and_module(pytester):
+    """Copy the real conftest.py and scripts/report_test_durations.py into
+    the pytester sandbox, so the subprocess run exercises the actual files
+    this pull request changed rather than a hand-copied stand-in."""
+    shutil.copy(REPO_ROOT / "conftest.py", pytester.path / "conftest.py")
+    scripts_dir = pytester.path / "scripts"
+    scripts_dir.mkdir()
+    shutil.copy(
+        REPO_ROOT / "scripts" / "report_test_durations.py",
+        scripts_dir / "report_test_durations.py",
+    )
+
+
+def test_report_prints_automatically_with_no_extra_flag(pytester):
+    _stage_conftest_and_module(pytester)
+    pytester.makepyfile(
+        test_sample="""
+        def test_fast():
+            assert True
+
+        def test_also_fast():
+            assert True
+        """
+    )
+
+    result = pytester.runpytest_subprocess()
+
+    result.assert_outcomes(passed=2)
+    result.stdout.fnmatch_lines(
+        [
+            "*test duration report (#510)*",
+            "*state: no-baseline*",
+            "*slowest test:*",
+            "*slowest share of total:*",
+        ]
+    )
+    # A "no change" phrasing would misreport the very state #510 says must be
+    # said out loud instead.
+    assert "no change" not in result.stdout.str().lower()
+
+
+def test_report_does_not_change_the_run_s_exit_code(pytester):
+    # Positive control paired with the assertion below: a suite with a real
+    # failure still exits non-zero -- the reporter hook is not accidentally
+    # swallowing failures, only adding a report alongside them.
+    _stage_conftest_and_module(pytester)
+    pytester.makepyfile(
+        test_sample="""
+        def test_that_fails():
+            assert False
+        """
+    )
+
+    result = pytester.runpytest_subprocess()
+
+    result.assert_outcomes(failed=1)
+    assert result.ret != 0
+    result.stdout.fnmatch_lines(["*test duration report (#510)*"])

--- a/tests/test_conftest_import_failure_510.py
+++ b/tests/test_conftest_import_failure_510.py
@@ -1,0 +1,48 @@
+"""A broken `scripts/report_test_durations.py` must degrade the #510
+reporter to `could-not-measure`, never take the whole pytest session down
+with it (review finding on #510's own diff).
+
+The import used to sit at `conftest.py` module scope, outside the hook's
+`try/except`. A module-scope import failure in a `conftest.py` is a pytest
+collection error -- fatal for the whole session: zero tests run, non-zero
+exit, and no #510 report printed at all. That is exactly the "reports
+nothing and nobody notices" failure #510 was filed to close, just widened
+from one slow test to the entire suite. The import now happens inside
+`pytest_terminal_summary`'s own `try`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+pytest_plugins = ["pytester"]
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _stage_conftest(pytester):
+    (pytester.path / "conftest.py").write_text(
+        (REPO_ROOT / "conftest.py").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+
+def test_a_broken_report_module_does_not_abort_the_session(pytester):
+    _stage_conftest(pytester)
+    scripts_dir = pytester.path / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "report_test_durations.py").write_text(
+        "raise RuntimeError('simulated import-time failure')\n", encoding="utf-8"
+    )
+    pytester.makepyfile(
+        test_sample="""
+        def test_fast():
+            assert True
+        """
+    )
+
+    result = pytester.runpytest_subprocess()
+
+    # The real point: the broken reporter module must not take collection
+    # down with it -- the actual test still runs and passes.
+    result.assert_outcomes(passed=1)
+    result.stdout.fnmatch_lines(["*could-not-measure*"])

--- a/tests/test_report_test_durations_510.py
+++ b/tests/test_report_test_durations_510.py
@@ -1,0 +1,270 @@
+"""Tests for scripts/report_test_durations.py (#510).
+
+`pytest` already prints `--durations`; nothing in this repo read it before
+this change, so a single test growing to dominate a suite had no detector
+but a human scrolling a CI log by chance -- see #510's own worked example,
+a 43.92s test found that way, roughly a fifth of the run.
+
+These tests exercise the pure analysis functions directly (`collect_from_reports`,
+`analyze`, `format_report`, `load_baseline`) rather than running a real nested
+`pytest` -- the module is written so the duration math never needs pytest's own
+process to be exercised, and driving a second pytest session from inside this
+suite would tangle this repo's own `--cov-fail-under=80` addopt around a session
+it was never meant to measure.
+
+Every "must not fire"/"must not flag" case here is paired with a positive
+control in the same test that does trigger the state, per this repo's
+CLAUDE.md: a negative assertion with no positive control also passes when the
+harness is simply broken.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts.report_test_durations import (
+    DurationReport,
+    analyze,
+    collect_from_reports,
+    format_report,
+    load_baseline,
+    save_baseline,
+)
+
+
+class _FakeReport:
+    """Stands in for pytest's own `TestReport` -- the hook in conftest.py only
+    ever reads `.nodeid`, `.when` and `.duration` off whatever it is handed."""
+
+    def __init__(self, nodeid, when, duration):
+        self.nodeid = nodeid
+        self.when = when
+        self.duration = duration
+
+
+# ---------------------------------------------------------------------------
+# collect_from_reports
+# ---------------------------------------------------------------------------
+
+
+def test_collect_from_reports_sums_phases_per_nodeid():
+    reports = [
+        _FakeReport("tests/test_x.py::test_a", "setup", 0.01),
+        _FakeReport("tests/test_x.py::test_a", "call", 1.0),
+        _FakeReport("tests/test_x.py::test_a", "teardown", 0.02),
+        _FakeReport("tests/test_x.py::test_b", "call", 0.5),
+    ]
+    totals = collect_from_reports(reports)
+    assert totals == {
+        "tests/test_x.py::test_a": 1.03,
+        "tests/test_x.py::test_b": 0.5,
+    }
+
+
+def test_collect_from_reports_skips_reports_missing_duration_or_nodeid():
+    # Positive control: a well-formed report is still counted alongside the
+    # malformed ones, so a bug that dropped everything would not read as a pass.
+    class _NoDuration:
+        nodeid = "tests/test_x.py::test_c"
+
+    class _NoNodeid:
+        duration = 3.0
+
+    class _BadDuration:
+        nodeid = "tests/test_x.py::test_d"
+        duration = "not-a-number"
+
+    reports = [
+        _NoDuration(),
+        _NoNodeid(),
+        _BadDuration(),
+        _FakeReport("tests/test_x.py::test_e", "call", 0.25),
+    ]
+    totals = collect_from_reports(reports)
+    assert totals == {"tests/test_x.py::test_e": 0.25}
+
+
+def test_collect_from_reports_empty_input_yields_empty_dict():
+    assert collect_from_reports([]) == {}
+
+
+# ---------------------------------------------------------------------------
+# analyze -- the three states
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_could_not_measure_when_no_durations_collected():
+    # This is the state the issue calls out by name: a step that emits
+    # nothing here is indistinguishable from a suite with no hot test.
+    result = analyze({}, total_seconds=10.0, baseline=None)
+    assert result.state == "could-not-measure"
+    assert result.reason
+
+
+def test_analyze_could_not_measure_when_total_seconds_unusable():
+    durations = {"tests/test_x.py::test_a": 1.0}
+    for bad_total in (None, 0.0, -5.0):
+        result = analyze(durations, total_seconds=bad_total, baseline=None)
+        assert result.state == "could-not-measure"
+        assert result.reason
+
+
+def test_analyze_no_baseline_when_baseline_absent():
+    durations = {
+        "tests/test_x.py::test_a": 9.0,
+        "tests/test_x.py::test_b": 1.0,
+    }
+    result = analyze(durations, total_seconds=10.0, baseline=None)
+    assert result.state == "no-baseline"
+    assert result.slowest_nodeid == "tests/test_x.py::test_a"
+    assert result.slowest_seconds == 9.0
+    assert result.share == 0.9
+    assert result.baseline_share is None
+
+
+def test_analyze_measured_when_baseline_present_and_reports_delta():
+    # Positive control for the "measured" state and its comparison, paired
+    # against the no-baseline case immediately above.
+    durations = {
+        "tests/test_x.py::test_a": 9.0,
+        "tests/test_x.py::test_b": 1.0,
+    }
+    baseline = {"slowest_share": 0.5}
+    result = analyze(durations, total_seconds=10.0, baseline=baseline)
+    assert result.state == "measured"
+    assert result.share == 0.9
+    assert result.baseline_share == 0.5
+
+
+def test_analyze_ranks_top_n_descending_and_respects_limit():
+    durations = {f"tests/test_x.py::test_{i}": float(i) for i in range(1, 6)}
+    result = analyze(durations, total_seconds=15.0, baseline=None, top_n=3)
+    assert [nodeid for nodeid, _ in result.top] == [
+        "tests/test_x.py::test_5",
+        "tests/test_x.py::test_4",
+        "tests/test_x.py::test_3",
+    ]
+    assert len(result.top) == 3
+
+
+# ---------------------------------------------------------------------------
+# format_report -- the three states are distinguishable in the printed text
+# ---------------------------------------------------------------------------
+
+
+def test_format_report_could_not_measure_names_the_state_and_reason():
+    result = DurationReport(state="could-not-measure", reason="no per-test durations were collected")
+    text = format_report(result)
+    assert "could-not-measure" in text
+    assert "no per-test durations were collected" in text
+
+
+def test_format_report_no_baseline_says_so_out_loud():
+    # The issue is explicit: "no-baseline" must be said out loud, not
+    # rendered as if there were no change to report.
+    result = analyze(
+        {"tests/test_x.py::test_a": 4.0, "tests/test_x.py::test_b": 1.0},
+        total_seconds=5.0,
+        baseline=None,
+    )
+    text = format_report(result)
+    assert "no-baseline" in text
+    assert "no change" not in text.lower()
+    assert "80.0%" in text  # the share is reported even with nothing to compare to
+
+
+def test_format_report_measured_shows_share_and_baseline_delta():
+    result = analyze(
+        {"tests/test_x.py::test_a": 4.0, "tests/test_x.py::test_b": 1.0},
+        total_seconds=5.0,
+        baseline={"slowest_share": 0.5},
+    )
+    text = format_report(result)
+    assert "measured" in text
+    assert "80.0%" in text
+    assert "50.0%" in text
+
+
+def test_format_report_never_empty_for_any_state():
+    # Positive control for "must not silently emit nothing": every state,
+    # including the empty/degenerate ones, produces non-blank text.
+    for result in (
+        DurationReport(state="could-not-measure", reason="x"),
+        analyze({}, total_seconds=None, baseline=None),
+        analyze({"a": 1.0}, total_seconds=1.0, baseline=None),
+        analyze({"a": 1.0}, total_seconds=1.0, baseline={"slowest_share": 0.1}),
+    ):
+        text = format_report(result)
+        assert text.strip()
+
+
+# ---------------------------------------------------------------------------
+# load_baseline
+# ---------------------------------------------------------------------------
+
+
+def test_load_baseline_missing_file_returns_none_with_no_error():
+    baseline, error = load_baseline(Path("/definitely/does/not/exist/baseline.json"))
+    assert baseline is None
+    assert error is None
+
+
+def test_load_baseline_valid_file_returns_dict(tmp_path):
+    path = tmp_path / "baseline.json"
+    path.write_text(json.dumps({"slowest_share": 0.33, "slowest_nodeid": "x"}))
+    baseline, error = load_baseline(path)
+    assert baseline == {"slowest_share": 0.33, "slowest_nodeid": "x"}
+    assert error is None
+
+
+def test_load_baseline_corrupt_json_returns_none_and_an_error(tmp_path):
+    path = tmp_path / "baseline.json"
+    path.write_text("{ not valid json")
+    baseline, error = load_baseline(path)
+    assert baseline is None
+    assert error is not None
+    assert "baseline.json" in error
+
+
+def test_load_baseline_missing_required_field_returns_none_and_an_error(tmp_path):
+    path = tmp_path / "baseline.json"
+    path.write_text(json.dumps({"unrelated": 1}))
+    baseline, error = load_baseline(path)
+    assert baseline is None
+    assert error is not None
+
+
+# ---------------------------------------------------------------------------
+# save_baseline
+# ---------------------------------------------------------------------------
+
+
+def test_save_baseline_writes_a_file_load_baseline_can_read_back(tmp_path):
+    path = tmp_path / "baseline.json"
+    result = analyze(
+        {"tests/test_x.py::test_a": 4.0, "tests/test_x.py::test_b": 1.0},
+        total_seconds=5.0,
+        baseline=None,
+    )
+    save_baseline(path, result)
+
+    loaded, error = load_baseline(path)
+    assert error is None
+    assert loaded == {"slowest_nodeid": "tests/test_x.py::test_a", "slowest_share": 0.8}
+
+
+def test_save_baseline_refuses_a_could_not_measure_result(tmp_path):
+    path = tmp_path / "baseline.json"
+    result = DurationReport(state="could-not-measure", reason="no durations")
+    try:
+        save_baseline(path, result)
+        raised = False
+    except ValueError:
+        raised = True
+    assert raised
+    assert not path.exists()


### PR DESCRIPTION
Closes #510.

`pytest` already prints `--durations` (`addopts` carries `--durations=25`); nothing in this repo read it, so a single test could grow to a large share of every leg's wall-clock time and the only detector was a human happening to scroll a CI log far enough to notice -- the exact worked example in the issue, a 43.92s test in claude-oss found by chance, roughly a fifth of the whole run.

## What changed

A root-level `conftest.py` implements `pytest_terminal_summary`, a pytest hook that fires at the end of **every** `pytest` invocation -- local dev or any CI leg, with no extra flag -- and prints the top durations plus the slowest single test's **share of total suite time** (a ratio, not an absolute second count, since an absolute count says more about the runner than the test). It reads the same `TestReport` objects pytest's own summary is built from, straight off `terminalreporter.stats`, rather than re-parsing pytest's own formatted `--durations` text -- more robust, and avoids a real cross-platform hazard (bash `tee` vs. pwsh `Tee-Object` behave differently, and the workflow's "Run tests" step has no `shell:` override).

The actual duration math lives in `scripts/report_test_durations.py`, kept separate from the pytest hook so it is unit-testable without driving a nested pytest session: `collect_from_reports`, `analyze`, `format_report`, `load_baseline`, `save_baseline`.

Three states, always distinguishable in the printed text:
- `measured` -- durations collected and compared against an optional `test-durations-baseline.json` (not shipped by this PR -- a maintainer records one by hand once they trust a run's number).
- `no-baseline` -- durations collected, no baseline file yet (true of every run today). The share is still printed, said out loud as `no-baseline` rather than rendered as if nothing had changed.
- `could-not-measure` -- no per-test durations collected, or the total suite time was not a usable number. Always names the reason; never prints nothing, which would read exactly like a suite with no hot test.

This is a report, never a gate: it never fails a run on wall-clock time or a share threshold. The whole hook -- including, after a self-review fix, the import of its own analysis module -- is wrapped in `try/except`, so a defect in the reporter degrades to `could-not-measure` instead of ever turning a green run red or aborting collection.

## Why no change to `.github/workflows/tests.yml` or `pyproject.toml`

`pyproject.toml` already carried `--durations=25` in `addopts` before this branch (an earlier maintainer commit, per the issue body). The workflow's existing "Run tests" step is bare `pytest`, which picks up the new root `conftest.py` automatically -- verified by reading both files at HEAD, and independently re-verified by the self-review auditor spawn.

## Self-review

Two spawns reviewed the committed diff. `oss:auditor` returned `NO FINDINGS` across its four checklist classes (absence-the-caller-cannot-read, guard-that-did-not-run, untrusted-text, platform band) and independently confirmed the workflow/pyproject.toml reasoning above. `Explore` returned two findings, both fixed in a follow-up commit:

1. The module import in `conftest.py` sat outside the hook's `try/except`, so a defect in `scripts/report_test_durations.py` would have aborted the whole pytest session (a `conftest.py` collection error is fatal: zero tests run, no report at all) instead of degrading to `could-not-measure` -- exactly the failure class #510 exists to close, widened from one test to the whole suite. Fixed by moving the import inside the hook's own `try`. Red-first: `tests/test_conftest_import_failure_510.py` stages a broken analysis module via pytest's `pytester` fixture, confirmed failing against the pre-fix `conftest.py` and passing against the fix.
2. `save_baseline`'s docstring pointed at a `--save-baseline` CLI flag that was never built. Fixed the docstring to show the actual call shape.

## Testing

TDD throughout: every test in the three new test files was written and watched red before the corresponding code existed (the initial `ModuleNotFoundError` for the whole module, and a dedicated red/green pair for the import-safety fix via a pre-fix/post-fix `conftest.py` comparison). Ran narrowed, per this repo's CLAUDE.md and the plugin's own guidance -- not the whole `pytest` suite; CI is the matrix authority. `python3 -m pytest tests/test_report_test_durations_510.py tests/test_conftest_duration_hook_510.py tests/test_conftest_import_failure_510.py tests/test_pep604_floor_guard.py -q --no-cov`: 21 + 49 passed. The PEP 604 floor guard run confirms the new files' `X | None` annotations (under `from __future__ import annotations`) are floor-safe. All new source is pure ASCII (checked programmatically), so the Windows cp1252 console-encoding risk this plugin's own guidance calls out does not apply here.

changelog fragment `changelog.d/510.added.md` added and checked clean with `.oss/assemble_changelog.py --check`. README.md gained a `### A test that dominates the suite (#510)` subsection under `## Running tests`.