### PR TITLE
Triage the 95 Windows CI blanket win32-skip modules against resolve_bash() (#497)

### DIFF
--- a/changelog.d/497.added.md
+++ b/changelog.d/497.added.md
@@ -1,13 +1,14 @@
-- **A per-module triage of the 94 Windows CI legs' blanket `win32` skips** (#497,
+- **A per-module triage of the 95 Windows CI legs' blanket `win32` skips** (#497,
   follow-up to #507's own skip-ratio report). `docs/windows-skip-triage.md` lists
   every test module that still carries a module-level
-  `pytestmark = pytest.mark.skipif(sys.platform == "win32", ...)`, its skip
-  reason, and a verdict against `tests/_bash_runner.py`'s `resolve_bash()` route
-  -- `convertible`, `not-convertible`, or `unclear` where the reason string
-  alone cannot say. Not a mass rewrite: no test file was converted here. The
-  issue's own re-verified count (107, by a grep that also catches two docstring
-  mentions and eleven modules that already moved to the `resolve_bash()` route)
-  is corrected to 94 by `scripts/windows_skip_triage_497.py`'s AST-based count,
-  which `tests/test_windows_skip_triage_497.py` re-derives on every run so the
-  list cannot silently drift out of sync with the tree the way the issue itself
+  `pytestmark = pytest.mark.skipif(sys.platform == "win32", ...)` -- a bare call
+  or one arm of a list of marks -- its skip reason, and a verdict against
+  `tests/_bash_runner.py`'s `resolve_bash()` route -- `convertible`,
+  `not-convertible`, or `unclear` where the reason string alone cannot say. Not
+  a mass rewrite: no test file was converted here. The issue's own re-verified
+  count (107, by a grep that also catches two docstring mentions and eleven
+  modules that already moved to the `resolve_bash()` route) is corrected to 95
+  by `scripts/windows_skip_triage_497.py`'s AST-based count, which
+  `tests/test_windows_skip_triage_497.py` re-derives on every run so the list
+  cannot silently drift out of sync with the tree the way the issue itself
   describes happening (92 -> 107 with nothing announcing it).

--- a/changelog.d/497.added.md
+++ b/changelog.d/497.added.md
@@ -1,0 +1,13 @@
+- **A per-module triage of the 94 Windows CI legs' blanket `win32` skips** (#497,
+  follow-up to #507's own skip-ratio report). `docs/windows-skip-triage.md` lists
+  every test module that still carries a module-level
+  `pytestmark = pytest.mark.skipif(sys.platform == "win32", ...)`, its skip
+  reason, and a verdict against `tests/_bash_runner.py`'s `resolve_bash()` route
+  -- `convertible`, `not-convertible`, or `unclear` where the reason string
+  alone cannot say. Not a mass rewrite: no test file was converted here. The
+  issue's own re-verified count (107, by a grep that also catches two docstring
+  mentions and eleven modules that already moved to the `resolve_bash()` route)
+  is corrected to 94 by `scripts/windows_skip_triage_497.py`'s AST-based count,
+  which `tests/test_windows_skip_triage_497.py` re-derives on every run so the
+  list cannot silently drift out of sync with the tree the way the issue itself
+  describes happening (92 -> 107 with nothing announcing it).

--- a/docs/windows-skip-triage.md
+++ b/docs/windows-skip-triage.md
@@ -12,8 +12,9 @@ mass conversion of these modules, but "a recorded list with a per-module
 verdict" against `tests/_bash_runner.py`'s `resolve_bash()` route -- the
 thing that already replaced this exact pattern in the four modules #432
 converted (`tests/test_hook_cwd_leak_417.py`, `tests/test_transcript_path_leak_424.py`,
-`tests/test_session_end_log_names_488.py`, `tests/test_stdin_extractor_top_level_wins_447.py`,
-plus `tests/test_autonomous_log_retention_487.py`).
+`tests/test_session_end_log_names_488.py`, `tests/test_stdin_extractor_top_level_wins_447.py`),
+plus a fifth, `tests/test_autonomous_log_retention_487.py`, which adopted the
+same route for its own #487 rather than being converted by #432 itself.
 
 ## The count: 94, not 107 (and not the issue's original 92)
 
@@ -43,14 +44,14 @@ silently drift out of sync with the tree the way the issue itself describes
 
 - **convertible** -- the skip reason is plausibly about a POSIX-only *tool*
   (bash itself, a POSIX-only shell construct) that `resolve_bash()` could
-  supply on a Windows runner via Git Bash. 8 modules.
+  supply on a Windows runner via Git Bash. 7 modules.
 - **not-convertible** -- the reason names something Git-Bash discovery
   cannot fix: POSIX file permissions/mode bits, process signals (`kill -0`,
   `fork`), `flock`, `umask`, NTFS/ACL semantics, or an explicit POSIX-vs-Windows
   path-format incompatibility. 12 modules.
 - **unclear** -- the reason string alone does not say enough to tell; reading
   it is not the same as reading the test body, and this list is deliberately
-  not that read. 74 modules.
+  not that read. 75 modules.
 
 **The `unclear` majority is the honest result, not a shortcut.** The great
 bulk of these 94 reasons is one of a handful of near-identical templated
@@ -129,7 +130,7 @@ verdict is the useful artifact").
 | `tests/test_ndc_tail_failure_no_truncate.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
 | `tests/test_ndc_truncate_race.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
 | `tests/test_nested_summarizer.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
-| `tests/test_non_ascii_paths.py` | bash subprocess assertions — not portable to Windows runners (#79) | convertible | reason names only the bash-subprocess dependency, no other blocker |
+| `tests/test_non_ascii_paths.py` | bash subprocess assertions — not portable to Windows runners (#79) | unclear | reason names only bash, but the test body runs the real sed function under several hostile locales (`LC_CTYPE=C.UTF-8`, `LC_ALL=C.utf8`, `LC_ALL=en_US.UTF-8`) whose availability and byte/character semantics under Git Bash/MSYS are not established here -- read on inspection, downgraded from the reason-string-only rule below |
 | `tests/test_now_md_append_atomicity.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
 | `tests/test_path_resolution.py` | POSIX path layouts (/c/Users vs C:\Users) + bash subprocess assertions — not portable to Windows | not-convertible | names a specific POSIX-only primitive (permissions/signals/fork/flock/umask/NTFS/path-format) that Git-Bash discovery cannot supply |
 | `tests/test_plugin_root_validated_471.py` | bash subprocess assertions -- not portable to Windows runners (#79) | convertible | reason names only the bash-subprocess dependency, no other blocker |

--- a/docs/windows-skip-triage.md
+++ b/docs/windows-skip-triage.md
@@ -16,7 +16,7 @@ converted (`tests/test_hook_cwd_leak_417.py`, `tests/test_transcript_path_leak_4
 plus a fifth, `tests/test_autonomous_log_retention_487.py`, which adopted the
 same route for its own #487 rather than being converted by #432 itself.
 
-## The count: 94, not 107 (and not the issue's original 92)
+## The count: 95, not 107 (and not the issue's original 92)
 
 The issue's own re-verified count -- `grep -rl "pytestmark = pytest.mark.skipif"
 tests | xargs grep -l "win32"` -- returns 107 on this tree. That command only
@@ -34,17 +34,21 @@ an actual `pytestmark` skip condition.
 `scripts/windows_skip_triage_497.py` recomputes the set precisely instead: it
 parses every test module with `ast`, and only counts a file that has an
 actual module-level `pytestmark = pytest.mark.skipif(<expr containing
-"win32">, reason=...)` assignment. That finds **94** modules on this tree at
-this commit. `tests/test_windows_skip_triage_497.py` recomputes this same set
+"win32">, reason=...)` assignment -- a bare call, or one arm of a
+list/tuple of marks (pytest ORs a list, so any one arm mentioning "win32"
+is a real blanket skip). That finds **95** modules on this tree at this
+commit. `tests/test_windows_skip_triage_497.py` recomputes this same set
 on every run and diffs it against the table below, so this list cannot
 silently drift out of sync with the tree the way the issue itself describes
-(92 -> 107 with nothing announcing the drift).
+(92 -> 107 with nothing announcing the drift) -- though see the note at the
+end of the Verdicts section: that guard has its own blind spot, caught
+once already during review.
 
 ## Verdicts
 
 - **convertible** -- the skip reason is plausibly about a POSIX-only *tool*
   (bash itself, a POSIX-only shell construct) that `resolve_bash()` could
-  supply on a Windows runner via Git Bash. 7 modules.
+  supply on a Windows runner via Git Bash. 8 modules.
 - **not-convertible** -- the reason names something Git-Bash discovery
   cannot fix: POSIX file permissions/mode bits, process signals (`kill -0`,
   `fork`), `flock`, `umask`, NTFS/ACL semantics, or an explicit POSIX-vs-Windows
@@ -53,8 +57,21 @@ silently drift out of sync with the tree the way the issue itself describes
   it is not the same as reading the test body, and this list is deliberately
   not that read. 75 modules.
 
+**A blind spot in the scanner itself, caught once already.** An earlier
+version of `scripts/windows_skip_triage_497.py` only matched a bare
+`pytestmark = pytest.mark.skipif(...)` call, not the list-of-marks form
+(`pytestmark = [pytest.mark.skipif(...), pytest.mark.skipif(...)]`), and so
+silently missed `tests/test_slug_vectors_294.py` -- which the doc and its
+own drift-detection test then agreed was absent, because the test recomputes
+its "live" baseline from that same scanner function and cannot see a module
+class the function never looked for. A second, independent reviewer's read
+of the diff caught it; the scanner now walks both forms. The fix is
+mechanical, but the lesson generalizes: this list's accuracy is bounded by
+what the AST matcher was written to recognize, not by an exhaustive read of
+every skip expression in `tests/`.
+
 **The `unclear` majority is the honest result, not a shortcut.** The great
-bulk of these 94 reasons is one of a handful of near-identical templated
+bulk of these 95 reasons is one of a handful of near-identical templated
 strings -- `"bash subprocess + POSIX layout -- not portable to Windows
 runners"`, `"bash hook subprocess + POSIX semantics -- not portable to
 Windows runners"`, and near-variants -- that bundle the one thing
@@ -160,6 +177,7 @@ verdict is the useful artifact").
 | `tests/test_session_start_prev_session_270.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
 | `tests/test_slug_index_297.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
 | `tests/test_slug_parity.py` | bash subprocess assertions — not portable to Windows runners (#79) | convertible | reason names only the bash-subprocess dependency, no other blocker |
+| `tests/test_slug_vectors_294.py` | bash subprocess assertions — not portable to Windows runners (#79) | convertible | reason names only the bash-subprocess dependency, no other blocker (same reason string as test_slug_parity.py above); module-level pytestmark here is a list of two skipif marks rather than a bare call, which an earlier version of the AST scanner missed entirely -- see scripts/windows_skip_triage_497.py's own docstring |
 | `tests/test_staging_growth_warning_349.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
 | `tests/test_staging_lock.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
 | `tests/test_staging_lock_config_unread_399.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |

--- a/docs/windows-skip-triage.md
+++ b/docs/windows-skip-triage.md
@@ -1,0 +1,170 @@
+# Windows blanket-skip triage (#497)
+
+#497 measured the `windows-latest` CI legs reporting green while most of the
+suite skips: modules that carry a module-level
+
+    pytestmark = pytest.mark.skipif(sys.platform == "win32", reason=...)
+
+skip every test in the file, unconditionally, on that leg. #507 made the
+resulting skip *ratio* visible on every run (`scripts/report_windows_skip_floor.py`,
+wired into `conftest.py`). This file is the other half #497 asked for: not a
+mass conversion of these modules, but "a recorded list with a per-module
+verdict" against `tests/_bash_runner.py`'s `resolve_bash()` route -- the
+thing that already replaced this exact pattern in the four modules #432
+converted (`tests/test_hook_cwd_leak_417.py`, `tests/test_transcript_path_leak_424.py`,
+`tests/test_session_end_log_names_488.py`, `tests/test_stdin_extractor_top_level_wins_447.py`,
+plus `tests/test_autonomous_log_retention_487.py`).
+
+## The count: 94, not 107 (and not the issue's original 92)
+
+The issue's own re-verified count -- `grep -rl "pytestmark = pytest.mark.skipif"
+tests | xargs grep -l "win32"` -- returns 107 on this tree. That command only
+requires both substrings to appear *somewhere* in the file; it does not
+require them to form one real module-level skip. Two files fail that test
+outright: `tests/test_bash_runner_432.py` and
+`tests/test_sanctioned_divergence_state_440.py` only *quote* the pattern in a
+docstring, describing modules that used to carry it. Eleven more already
+carry the `resolve_bash()`-style route -- a local `_find_bash()` whose own
+probe order happens to mention `sys.platform == "win32"`, with a skip reason
+of `"bash not available"` or `"Git Bash not found (...)"`, never a blanket
+win32 skip -- so the grep's `win32` hit lands inside that probe, not inside
+an actual `pytestmark` skip condition.
+
+`scripts/windows_skip_triage_497.py` recomputes the set precisely instead: it
+parses every test module with `ast`, and only counts a file that has an
+actual module-level `pytestmark = pytest.mark.skipif(<expr containing
+"win32">, reason=...)` assignment. That finds **94** modules on this tree at
+this commit. `tests/test_windows_skip_triage_497.py` recomputes this same set
+on every run and diffs it against the table below, so this list cannot
+silently drift out of sync with the tree the way the issue itself describes
+(92 -> 107 with nothing announcing the drift).
+
+## Verdicts
+
+- **convertible** -- the skip reason is plausibly about a POSIX-only *tool*
+  (bash itself, a POSIX-only shell construct) that `resolve_bash()` could
+  supply on a Windows runner via Git Bash. 8 modules.
+- **not-convertible** -- the reason names something Git-Bash discovery
+  cannot fix: POSIX file permissions/mode bits, process signals (`kill -0`,
+  `fork`), `flock`, `umask`, NTFS/ACL semantics, or an explicit POSIX-vs-Windows
+  path-format incompatibility. 12 modules.
+- **unclear** -- the reason string alone does not say enough to tell; reading
+  it is not the same as reading the test body, and this list is deliberately
+  not that read. 74 modules.
+
+**The `unclear` majority is the honest result, not a shortcut.** The great
+bulk of these 94 reasons is one of a handful of near-identical templated
+strings -- `"bash subprocess + POSIX layout -- not portable to Windows
+runners"`, `"bash hook subprocess + POSIX semantics -- not portable to
+Windows runners"`, and near-variants -- that bundle the one thing
+`resolve_bash()` fixes (no bash on PATH) with an unnamed "POSIX
+semantics"/"layout" claim. Spot-reading a handful of these modules
+(`tests/test_now_md_append_atomicity.py`, `tests/test_windows_drive_slug_263.py`)
+confirmed the ambiguity is real, not just a property of the template: the
+former genuinely depends on POSIX `rename(2)` atomicity semantics a bash
+substitute would not by itself supply; the latter turned out to depend on
+nothing but a bash subprocess running two of this repo's own `.sh` scripts.
+Both share the same templated reason string. Telling them apart needs a
+per-module read of the test body against the shell script(s) it drives --
+exactly the work this list is scoped not to do (see #497's own "what would
+settle it": "not a mass rewrite ... a recorded list with a per-module
+verdict is the useful artifact").
+
+## The table
+
+| module | skip reason | verdict | basis |
+| --- | --- | --- | --- |
+| `tests/test_bootstrap_readonly_root.py` | POSIX mode bits + bash — read-only enforcement is not portable to NTFS (#79) | not-convertible | names a specific POSIX-only primitive (permissions/signals/fork/flock/umask/NTFS/path-format) that Git-Bash discovery cannot supply |
+| `tests/test_capture_gap_notice.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_case_divergence_298.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_codex_stdin_session_id_468.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_codex_transcript_path_459.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_consolidate_read_race.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_consolidation_append_race.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_consolidation_retire_reopened_day_509.py` | bash subprocess + POSIX layout -- not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_consolidation_staging_mv_atomicity.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_consolidation_trigger_source_342.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_cross_host_lock_contract_491.py` | bash subprocess + POSIX process semantics (kill -0, mkdir races) -- not portable to Windows runners (#79) | not-convertible | names a specific POSIX-only primitive (permissions/signals/fork/flock/umask/NTFS/path-format) that Git-Bash discovery cannot supply |
+| `tests/test_delivery_record_per_machine_285.py` | bash hook subprocess + POSIX git semantics — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_delivery_record_pruning_373.py` | bash subprocess + POSIX session-start hook -- not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_dispatch_timeout_286.py` | drives the real hooks through a bash subprocess — not portable to Windows (see tests/test_path_resolution.py) | not-convertible | cross-references test_path_resolution.py, whose own reason names an explicit POSIX-vs-Windows path-format incompatibility (/c/Users vs C:\Users) |
+| `tests/test_doctor.py` | bash subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_doctor_cap_disabled_360.py` | bash subprocess + POSIX semantics -- not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_doctor_json_408.py` | bash subprocess + POSIX semantics -- not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_doctor_oversized_store_348.py` | bash subprocess + POSIX semantics -- not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_doctor_session_end_370.py` | bash subprocess + POSIX semantics -- not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_doctor_session_end_survives_backup_cleanup_401.py` | bash subprocess + POSIX semantics -- not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_doctor_timezone_357.py` | bash subprocess + POSIX semantics -- not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_doctor_verdict_ordering_359.py` | bash subprocess + POSIX semantics -- not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_doctor_verdict_ordering_404.py` | bash subprocess + POSIX semantics -- not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_env_cache_hook_cwd_key_469.py` | bash subprocess assertions -- not portable to Windows runners (#79) | convertible | reason names only the bash-subprocess dependency, no other blocker |
+| `tests/test_env_cache_probe_303.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_env_cache_publish_unwritable_logs_358.py` | chmod-based unwritability and bash hook subprocess are not portable to Windows runners; POSIX permission bits do not model an ACL-unwritable directory there the way they do here. | not-convertible | names a specific POSIX-only primitive (permissions/signals/fork/flock/umask/NTFS/path-format) that Git-Bash discovery cannot supply |
+| `tests/test_external_data_dir.py` | bash subprocess + POSIX session-start hook — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_git_backup_hook.py` | bash hook subprocess + POSIX flock/git semantics — not portable to Windows runners (#79) | not-convertible | names a specific POSIX-only primitive (permissions/signals/fork/flock/umask/NTFS/path-format) that Git-Bash discovery cannot supply |
+| `tests/test_git_backup_push_rejected_253.py` | bash hook subprocess + POSIX flock/git semantics — not portable to Windows runners (#79) | not-convertible | names a specific POSIX-only primitive (permissions/signals/fork/flock/umask/NTFS/path-format) that Git-Bash discovery cannot supply |
+| `tests/test_git_backup_silent_stops_257.py` | bash hook subprocess + POSIX flock/git semantics — not portable to Windows runners (#79) | not-convertible | names a specific POSIX-only primitive (permissions/signals/fork/flock/umask/NTFS/path-format) that Git-Bash discovery cannot supply |
+| `tests/test_git_restore_hook_253.py` | bash hook subprocess + POSIX flock/git semantics — not portable to Windows runners (#79) | not-convertible | names a specific POSIX-only primitive (permissions/signals/fork/flock/umask/NTFS/path-format) that Git-Bash discovery cannot supply |
+| `tests/test_handoff_delivery_count_source_341.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_handoff_per_session_363.py` | bash subprocess + POSIX session-start hook — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_handoff_preservation.py` | bash subprocess + POSIX session-start hook — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_home_dir_migration.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_hook_cwd_end_to_end_411.py` | bash hook subprocess + POSIX semantics -- not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_hook_cwd_fallback_444.py` | bash hook subprocess + POSIX semantics -- not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_hook_stdout_labelling_280.py` | drives the real hooks through a bash subprocess — not portable to Windows (see tests/test_path_resolution.py) | not-convertible | cross-references test_path_resolution.py, whose own reason names an explicit POSIX-vs-Windows path-format incompatibility (/c/Users vs C:\Users) |
+| `tests/test_host_shell_parity_407.py` | bash subprocess assertions -- not portable to Windows runners (#79) | convertible | reason names only the bash-subprocess dependency, no other blocker |
+| `tests/test_hot_path_cost_pin_330.py` | bash hook subprocess + POSIX semantics -- not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_jq_free_config.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_last_entry_read_failure_251.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_layered_config.py` | bash subprocess + POSIX lib-memory-dir.sh — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_legacy_logs_untracking_288.py` | bash hook subprocess + POSIX git semantics — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_lock_primitive.py` | POSIX process semantics (kill -0, fork races) — the lock is exercised on ubuntu/macos runners | not-convertible | names a specific POSIX-only primitive (permissions/signals/fork/flock/umask/NTFS/path-format) that Git-Bash discovery cannot supply |
+| `tests/test_lock_timing.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_log_rotation.py` | bash subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_marker_range_guard_326.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_ndc_commit_atomicity.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_ndc_commit_lock.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_ndc_day_boundary.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_ndc_reject_gate.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_ndc_tail_failure_no_truncate.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_ndc_truncate_race.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_nested_summarizer.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_non_ascii_paths.py` | bash subprocess assertions — not portable to Windows runners (#79) | convertible | reason names only the bash-subprocess dependency, no other blocker |
+| `tests/test_now_md_append_atomicity.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_path_resolution.py` | POSIX path layouts (/c/Users vs C:\Users) + bash subprocess assertions — not portable to Windows | not-convertible | names a specific POSIX-only primitive (permissions/signals/fork/flock/umask/NTFS/path-format) that Git-Bash discovery cannot supply |
+| `tests/test_plugin_root_validated_471.py` | bash subprocess assertions -- not portable to Windows runners (#79) | convertible | reason names only the bash-subprocess dependency, no other blocker |
+| `tests/test_position_sidecar_353.py` | bash hook subprocess + POSIX semantics -- not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_post_tool_cooldown.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_post_tool_fast_path_350.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_post_tool_hook_spawns.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_post_tool_hook_stdin_size.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_post_tool_session_id.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_project_root_cwd_fallback_411.py` | bash subprocess + POSIX semantics -- not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_prompt_hook_spawns.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_prompt_stamp_301.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_provider_logging_461.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_recovery_transcript_leak_407.py` | bash hook subprocess + POSIX semantics -- not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_reject_gate_visibility.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_resolve_paths.py` | bash subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_rotated_archive_recall.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_save_session_branch_override.py` | bash dispatch + git command form -- not portable to Windows Git Bash without fixtures | convertible | reason itself frames the gap as missing fixtures under Git Bash, not an unfixable POSIX primitive |
+| `tests/test_save_session_force_lock_race.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_save_session_gates.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_save_session_lock_ownership.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_save_session_marker_arithmetic_322.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_session_end_hook_345.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_session_end_log_swept_483.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_session_slug_record_294.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_session_start_compact_recap_339.py` | bash hook subprocess + POSIX semantics -- not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_session_start_prev_session_270.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_slug_index_297.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_slug_parity.py` | bash subprocess assertions — not portable to Windows runners (#79) | convertible | reason names only the bash-subprocess dependency, no other blocker |
+| `tests/test_staging_growth_warning_349.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_staging_lock.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_staging_lock_config_unread_399.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_staging_lock_missing_log_dependency_394.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_stdin_source_top_level_wins_344.py` | bash hook subprocess + POSIX semantics -- not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_umask.py` | POSIX umask + mode bits don't apply to NTFS (umask is a no-op on Windows) | not-convertible | names a specific POSIX-only primitive (permissions/signals/fork/flock/umask/NTFS/path-format) that Git-Bash discovery cannot supply |
+| `tests/test_windows_drive_slug_263.py` | bash subprocess assertions — not portable to Windows runners (#79) | convertible | reason names only the bash-subprocess dependency, no other blocker |
+| `tests/test_windows_long_path_slug_294.py` | bash subprocess assertions — not portable to Windows runners (#79) | convertible | reason names only the bash-subprocess dependency, no other blocker |
+| `tests/test_worktree_memory.py` | bash subprocess + POSIX git worktree layout — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |

--- a/scripts/windows_skip_triage_497.py
+++ b/scripts/windows_skip_triage_497.py
@@ -1,0 +1,96 @@
+"""Recompute the live set of win32 blanket-skip test modules (#497).
+
+`grep -rl "pytestmark = pytest.mark.skipif" tests | xargs grep -l "win32"`
+-- the command #497's own brief and `scripts/report_windows_skip_floor.py`'s
+docstring both cite (92, then 107) -- over-counts. It requires only that both
+substrings appear *somewhere* in the file, not that they form one real
+`pytestmark` assignment. On this tree it catches a docstring that merely
+*quotes* `pytestmark = pytest.mark.skipif(...)` as prose (`test_bash_runner_432.py`,
+`test_sanctioned_divergence_state_440.py`) and, more importantly, files that
+already carry the `resolve_bash()`-style route -- a local `_find_bash()` whose
+own probe order happens to test `sys.platform == "win32"` and whose skip
+reason is `"bash not available"` / `"Git Bash not found (...)"`, not a blanket
+win32 skip at all (`test_stale_config_sweep_362.py`, `test_tmpdir_cleanup.py`,
+`test_trap_quoting_375.py`, `test_log_sh.py`, `test_migration.py`,
+`test_security_fixes.py`, plus the four files this issue's own #432 already
+converted). Counted on this tree at the base commit for #497 (718a10f): the
+grep-shape check finds 107 files; this AST-based check, requiring an actual
+module-level `pytestmark = pytest.mark.skipif(...)` assignment whose test
+expression mentions `win32`, finds 94.
+
+Used by both `docs/windows-skip-triage.md`'s own generation and by
+`tests/test_windows_skip_triage_497.py`, which recomputes this set fresh on
+every run and diffs it against the file the doc lists -- so the doc cannot
+silently drift out of sync with the tree the way the issue itself describes
+happening to the grep-based count.
+"""
+
+from __future__ import annotations
+
+import ast
+import glob
+import os
+
+
+def find_blanket_skip_modules(tests_dir: str) -> dict[str, str | None]:
+    """Return {relative POSIX path: skip reason} for every test module under
+    `tests_dir` that carries a module-level
+    `pytestmark = pytest.mark.skipif(<expr mentioning win32>, reason=...)`.
+
+    `tests_dir` is the tests directory itself (e.g. `.../tests`); returned
+    paths are relative to its parent, POSIX-separated, so they match the
+    literal path strings a human (or this repo's own doc) would write.
+    """
+    root = os.path.dirname(os.path.abspath(tests_dir))
+    found: dict[str, str | None] = {}
+
+    for path in sorted(glob.glob(os.path.join(tests_dir, "**", "*.py"), recursive=True)):
+        try:
+            with open(path, encoding="utf-8") as fh:
+                src = fh.read()
+            tree = ast.parse(src, filename=path)
+        except (OSError, SyntaxError):
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if "pytestmark" not in targets:
+                continue
+            if not isinstance(node.value, ast.Call):
+                continue
+            func = node.value.func
+            is_skipif = (
+                isinstance(func, ast.Attribute)
+                and func.attr == "skipif"
+                and isinstance(func.value, ast.Attribute)
+                and func.value.attr == "mark"
+            )
+            if not is_skipif:
+                continue
+            segment = ast.get_source_segment(src, node) or ""
+            if "win32" not in segment:
+                continue
+
+            reason = None
+            for kw in node.value.keywords:
+                if kw.arg == "reason":
+                    try:
+                        reason = ast.literal_eval(kw.value)
+                    except ValueError:
+                        reason = ast.get_source_segment(src, kw.value)
+
+            rel = os.path.relpath(path, root).replace(os.sep, "/")
+            found[rel] = reason
+
+    return found
+
+
+if __name__ == "__main__":
+    here = os.path.dirname(os.path.abspath(__file__))
+    tests_dir = os.path.join(os.path.dirname(here), "tests")
+    modules = find_blanket_skip_modules(tests_dir)
+    print(f"{len(modules)} blanket win32-skip modules found under {tests_dir}")
+    for path in sorted(modules):
+        print(f"  {path}: {modules[path]!r}")

--- a/scripts/windows_skip_triage_497.py
+++ b/scripts/windows_skip_triage_497.py
@@ -15,8 +15,14 @@ win32 skip at all (`test_stale_config_sweep_362.py`, `test_tmpdir_cleanup.py`,
 `test_security_fixes.py`, plus the four files this issue's own #432 already
 converted). Counted on this tree at the base commit for #497 (718a10f): the
 grep-shape check finds 107 files; this AST-based check, requiring an actual
-module-level `pytestmark = pytest.mark.skipif(...)` assignment whose test
-expression mentions `win32`, finds 94.
+module-level `pytestmark = pytest.mark.skipif(...)` assignment (a bare call,
+or one arm of a list/tuple of marks -- pytest ORs a list, so any one arm
+mentioning `win32` is a real blanket skip, e.g. `test_slug_vectors_294.py`)
+whose test expression mentions `win32`, finds 95. An earlier version of this
+scanner only matched the bare-call form and undercounted at 94, missing the
+list-form file above -- caught by review, not by the drift-detection test
+below, since that test recomputes its own baseline from this same function
+and so cannot see a module class the function itself never looked for.
 
 Used by both `docs/windows-skip-triage.md`'s own generation and by
 `tests/test_windows_skip_triage_497.py`, which recomputes this set fresh on
@@ -58,39 +64,58 @@ def find_blanket_skip_modules(tests_dir: str) -> dict[str, str | None]:
             targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
             if "pytestmark" not in targets:
                 continue
-            if not isinstance(node.value, ast.Call):
-                continue
-            func = node.value.func
-            is_skipif = (
-                isinstance(func, ast.Attribute)
-                and func.attr == "skipif"
-                and isinstance(func.value, ast.Attribute)
-                and func.value.attr == "mark"
-            )
-            if not is_skipif:
-                continue
-            segment = ast.get_source_segment(src, node) or ""
-            if "win32" not in segment:
+
+            # `pytestmark` is either one bare `pytest.mark.skipif(...)` call,
+            # or a list/tuple of marks (pytest ORs them -- any one firing
+            # skips the whole module), e.g. `pytestmark = [mark.skipif(...),
+            # mark.skipif(...)]`. Check every candidate call either way.
+            if isinstance(node.value, ast.Call):
+                candidates = [node.value]
+            elif isinstance(node.value, (ast.List, ast.Tuple)):
+                candidates = [elt for elt in node.value.elts if isinstance(elt, ast.Call)]
+            else:
                 continue
 
-            reason = None
-            for kw in node.value.keywords:
-                if kw.arg == "reason":
-                    try:
-                        reason = ast.literal_eval(kw.value)
-                    except ValueError:
-                        reason = ast.get_source_segment(src, kw.value)
+            for call in candidates:
+                func = call.func
+                is_skipif = (
+                    isinstance(func, ast.Attribute)
+                    and func.attr == "skipif"
+                    and isinstance(func.value, ast.Attribute)
+                    and func.value.attr == "mark"
+                )
+                if not is_skipif:
+                    continue
+                segment = ast.get_source_segment(src, call) or ""
+                if "win32" not in segment:
+                    continue
 
-            rel = os.path.relpath(path, root).replace(os.sep, "/")
-            found[rel] = reason
+                reason = None
+                for kw in call.keywords:
+                    if kw.arg == "reason":
+                        try:
+                            reason = ast.literal_eval(kw.value)
+                        except ValueError:
+                            reason = ast.get_source_segment(src, kw.value)
+
+                rel = os.path.relpath(path, root).replace(os.sep, "/")
+                found[rel] = reason
 
     return found
 
 
 if __name__ == "__main__":
+    # A reason string here can carry a printable non-ASCII character (an em
+    # dash is routine in this tree's skip reasons). `repr()` leaves such
+    # characters literal, and a default Windows console codepage (e.g.
+    # cp1252) raises UnicodeEncodeError writing them to stdout -- killing
+    # this script mid-report, after the scan work it is reporting already
+    # ran. `ascii()` instead of `!r` guarantees pure-ASCII output (escaping
+    # non-ASCII to backslash-u-XXXX) so the print itself can never fail on
+    # codepage grounds, on any platform.
     here = os.path.dirname(os.path.abspath(__file__))
     tests_dir = os.path.join(os.path.dirname(here), "tests")
     modules = find_blanket_skip_modules(tests_dir)
     print(f"{len(modules)} blanket win32-skip modules found under {tests_dir}")
     for path in sorted(modules):
-        print(f"  {path}: {modules[path]!r}")
+        print(f"  {path}: {modules[path]!a}")

--- a/tests/test_windows_skip_triage_497.py
+++ b/tests/test_windows_skip_triage_497.py
@@ -1,0 +1,80 @@
+"""The docs/windows-skip-triage.md list must match the tree it triages (#497).
+
+#497's own body describes exactly this drift already happening once: the
+issue cited "92" blanket-skip modules, and by the time this fix landed the
+live tree had 107 by the same grep-shape count (and 94 by the corrected,
+AST-based count this repo now uses -- see `scripts/windows_skip_triage_497.py`'s
+own module docstring for why the two numbers differ). A triage doc that is
+never checked against the tree it lists is exactly the kind of number nobody
+re-derives before quoting it.
+
+This test recomputes the *live* set of win32 blanket-skip modules itself,
+via `scripts.windows_skip_triage_497.find_blanket_skip_modules` -- never a
+hardcoded count -- and diffs it against the set of module paths the doc
+actually lists. Per this repo's CLAUDE.md ("a negative assertion needs a
+positive control"), the real doc's "must match" case is paired with a "must
+fire" case: a deliberately wrong fixture list is asserted to fail the same
+comparison, so the test cannot pass merely because comparison logic never
+runs.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts.windows_skip_triage_497 import find_blanket_skip_modules
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TESTS_DIR = os.path.join(REPO_ROOT, "tests")
+DOC_PATH = os.path.join(REPO_ROOT, "docs", "windows-skip-triage.md")
+
+# Every row in the doc's table opens with a path cell in backticks, e.g.
+# "| `tests/test_foo.py` | ... |". This is the same shape for every row
+# regardless of verdict, so it does not need to know the verdict vocabulary.
+_ROW_PATH_RE = re.compile(r"^\|\s*`(tests/[^`]+\.py)`\s*\|", re.MULTILINE)
+
+
+def _doc_listed_paths(doc_text: str) -> set[str]:
+    return set(_ROW_PATH_RE.findall(doc_text))
+
+
+def test_doc_lists_exactly_the_live_blanket_skip_modules():
+    live = set(find_blanket_skip_modules(TESTS_DIR))
+    assert live, "sanity: the live tree must have at least one blanket-skip module"
+
+    with open(DOC_PATH, encoding="utf-8") as fh:
+        doc_text = fh.read()
+    listed = _doc_listed_paths(doc_text)
+
+    missing_from_doc = live - listed
+    stale_in_doc = listed - live
+    assert not missing_from_doc, (
+        f"{len(missing_from_doc)} module(s) blanket-skip on win32 but are not "
+        f"triaged in {DOC_PATH}: {sorted(missing_from_doc)}"
+    )
+    assert not stale_in_doc, (
+        f"{len(stale_in_doc)} module(s) are listed in {DOC_PATH} but no longer "
+        f"blanket-skip on win32 on the live tree: {sorted(stale_in_doc)}"
+    )
+
+
+def test_a_deliberately_wrong_list_is_caught():
+    # MUST fire: a positive control for the assertions above. Without this,
+    # a broken `_doc_listed_paths` regex (e.g. one that matches nothing) would
+    # make both `missing_from_doc` and `stale_in_doc` above vacuously empty,
+    # and the real test would pass whether or not the doc says anything true.
+    live = set(find_blanket_skip_modules(TESTS_DIR))
+    assert live
+
+    fake_doc = "\n".join(f"| `{p}` | fake reason | unclear |" for p in sorted(live)[:-1])
+    listed = _doc_listed_paths(fake_doc)
+
+    missing_from_doc = live - listed
+    assert missing_from_doc, (
+        "positive control failed to fire: dropping one real module from the "
+        "fixture list should have produced a nonempty missing_from_doc set"
+    )


### PR DESCRIPTION
Closes #497

## What this is

Item 1 of #497 (make the skip ratio visible in CI) already shipped in #507/#521. This is item 2: "a recorded list with a per-module verdict" against `tests/_bash_runner.py`'s `resolve_bash()` route -- not a mass conversion. No test file is converted here.

`docs/windows-skip-triage.md` lists every module that still carries a module-level `pytestmark = pytest.mark.skipif(sys.platform == "win32", ...)` -- a bare call, or one arm of a list of marks -- its own skip reason, and a verdict: `convertible`, `not-convertible`, or `unclear`.

## The count: 95, not 107 (and not the issue's original 92)

Same overcount story as before (grep catches 2 docstring-only mentions and 11 already-`resolve_bash()` files) but the AST-based figure itself moved during review: `scripts/windows_skip_triage_497.py`'s first pass only matched a bare `pytestmark = pytest.mark.skipif(...)` call and missed the list-of-marks form (`pytestmark = [pytest.mark.skipif(...), pytest.mark.skipif(...)]`), silently dropping `tests/test_slug_vectors_294.py` from both the count and the doc. Two independently spawned reviewers (Explore, oss:auditor) caught this in the same review pass; the scanner now walks both forms, the doc gained the missing row (verdict `convertible`, same reason string as the neighboring `test_slug_parity.py`), and the count is 95.

Notably the drift-detection test could not have caught this on its own: it recomputes its "live" baseline from the same scanner function the doc's generation used, so a module class the scanner never looked for is invisible to both sides of the comparison at once. Documented directly in the doc now, as a warning about the list's own accuracy bound.

## Verdict breakdown

- convertible: 8
- not-convertible: 12
- unclear: 75

## Second finding: Windows-console print crash

The auditor also flagged `scripts/windows_skip_triage_497.py`'s `__main__` block: `!r` on a reason string containing an em dash (routine in this tree's skip reasons) can raise `UnicodeEncodeError` on a default Windows console codepage (e.g. cp1252), crashing the process mid-report after the scan work already completed -- and nothing in CI exercises this `__main__` path. Switched to `!a` (`ascii()`) so the print output is always pure ASCII. Reasoned, not observed -- no Windows console available in this environment.

## Review

The developer agent's own session had no `Agent`/`Task` tool, so it could not spawn its own reviewers and did a self-review instead (documented in the first-pass report). The orchestrating conversation then spawned `Explore` and `oss:auditor` directly against the committed diff to cover that gap. Both findings above came from that pass and are fixed in this commit.

## Tests

`python3 -m pytest tests/test_windows_skip_triage_497.py tests/test_slug_vectors_294.py -q --no-cov` -- 76 passed. Ruff clean on both changed Python files. Full suite not run locally, per this repo's CLAUDE.md -- CI is the gate across 3 OSes and 4 interpreters.

## Also noticed, not fixed

`scripts/report_windows_skip_floor.py`'s own module docstring (#507) still cites the old grep-based 107-by-grep figure, now doubly stale (94 was already wrong, 95 is the corrected number). Not fixed here -- it is prose backing a `DEFAULT_FLOOR` pick, out of this lane's declared scope.
