### PR TITLE
Harden cmd_save_position: validate session_id before path use (#538)

### DIFF
--- a/changelog.d/538.fixed.md
+++ b/changelog.d/538.fixed.md
@@ -1,0 +1,12 @@
+- **`cmd_save_position` now validates `session_id` before it becomes a path
+  component** (#538). `pipeline/shell.py` built the position sidecar path
+  (`position.<session_id>`) and the evicted-sidecar removal path by
+  interpolating `session_id` directly, without ever calling
+  `pipeline.extract._validate_session_id` -- the same check `find_session()`
+  already runs before its own equivalent join. Both shell callers
+  (`scripts/post-tool-hook.sh`, `scripts/session-end-hook.sh`) and
+  `scripts/save-session.sh` already filter the id before Python ever sees
+  it, so nothing reachable today was exploitable; this is hardening so a
+  future caller reaching `cmd_save_position` by another route -- a test
+  helper, a new hook, a different host's adapter -- inherits the same
+  guarantee instead of nothing.

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -395,11 +395,16 @@ def cmd_save_position(
     # #140 fixed for last-save.json, reintroduced through its own mirror.
     # Best-effort: a session that is gone from the store losing its sidecar a
     # little late (a failed unlink here) is no worse than #353 not existing.
+    # `evicted_id` comes from a key already present in the persisted store, so
+    # a store written before #538 -- or hand-edited -- can hold one that fails
+    # `_validate_session_id` today. That must not abort the save that has
+    # already landed above: treat a rejected id the same as a failed unlink,
+    # never let it become worse than #353 not existing.
     for evicted_id in evicted:
-        _validate_session_id(evicted_id)
         try:
+            _validate_session_id(evicted_id)
             os.remove(os.path.join(sidecar_dir, f"position.{evicted_id}"))
-        except OSError:
+        except (OSError, ValueError):
             pass
 
     # #450: keep the unread-envelope quarantine in step with the position it

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -33,6 +33,7 @@ import sys
 
 from .extract import (
     _is_line_number,
+    _validate_session_id,
     clear_unread_envelope,
     extract_session,
     mark_unread_envelope,
@@ -333,6 +334,7 @@ def cmd_save_position(
             when ``envelope`` is ``"unrecognised"``; falls back to
             ``position`` if omitted.
     """
+    _validate_session_id(session_id)
     sessions = read_positions(last_save_file)
     # Re-insert at the end: dicts keep insertion order, so the oldest entry is
     # simply the first one, and a session that keeps saving keeps its slot.
@@ -394,6 +396,7 @@ def cmd_save_position(
     # Best-effort: a session that is gone from the store losing its sidecar a
     # little late (a failed unlink here) is no worse than #353 not existing.
     for evicted_id in evicted:
+        _validate_session_id(evicted_id)
         try:
             os.remove(os.path.join(sidecar_dir, f"position.{evicted_id}"))
         except OSError:

--- a/tests/test_save_position_validates_session_id_538.py
+++ b/tests/test_save_position_validates_session_id_538.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 import pytest
 
-from pipeline.shell import cmd_save_position
+from pipeline.shell import _POSITION_SLOTS, cmd_save_position
 
 WELL_FORMED = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa"
 
@@ -59,3 +59,37 @@ def test_well_formed_session_id_still_writes_sidecar(store):
     sidecar = remember / "tmp" / f"position.{WELL_FORMED}"
     assert sidecar.exists(), "well-formed session_id must still write its sidecar"
     assert sidecar.read_text() == "120"
+
+
+def test_poisoned_legacy_eviction_id_does_not_abort_the_save(store):
+    """Reviewer finding (#538 self-review): a store written before this fix
+    -- or hand-edited -- can hold an already-invalid key in `sessions`. When
+    that key is the one about to be evicted, cmd_save_position must still
+    complete the save (last-save.json committed, new sidecar written, evicted
+    slot made room for) rather than raising ValueError out of the eviction
+    loop and aborting everything after it, including the trailing #450
+    quarantine bookkeeping.
+    """
+    import json
+
+    remember, path = store
+    poisoned = "../../etc/evil"
+    sessions = {poisoned: 0}
+    for i in range(_POSITION_SLOTS - 1):
+        sessions[f"session-{i:04d}"] = i
+    Path(path).write_text(json.dumps(
+        {"sessions": sessions, "session": "session-0000", "line": 0}
+    ))
+
+    # This save evicts the oldest entry, which is the poisoned one (dicts
+    # keep insertion order, and it was inserted first).
+    cmd_save_position(path, WELL_FORMED, 42)
+
+    saved = json.loads(Path(path).read_text())
+    assert saved["sessions"][WELL_FORMED] == 42, (
+        "the save itself must land even though eviction hit a poisoned id"
+    )
+    assert poisoned not in saved["sessions"], "the poisoned id must still be evicted"
+
+    sidecar = remember / "tmp" / f"position.{WELL_FORMED}"
+    assert sidecar.exists(), "the new session's own sidecar must still be written"

--- a/tests/test_save_position_validates_session_id_538.py
+++ b/tests/test_save_position_validates_session_id_538.py
@@ -1,0 +1,61 @@
+"""cmd_save_position must validate session_id before it becomes a path
+component (#538).
+
+pipeline/shell.py builds both the position sidecar path and the evicted-
+sidecar removal path by interpolating session_id directly into a filename
+(`position.{session_id}`), without ever calling
+pipeline.extract._validate_session_id -- the same check find_session()
+already runs before it does the equivalent join. Both shell callers
+(scripts/post-tool-hook.sh, scripts/session-end-hook.sh) and
+scripts/save-session.sh already filter the id before Python ever sees it,
+so this is hardening against a future caller reaching cmd_save_position by
+another route, not a fix for an exploit reachable today.
+
+The negative case is paired with a positive control in the same test, per
+CLAUDE.md's bar: a hostile session_id must raise, and a well-formed one
+must still write its sidecar, so the "must raise" case cannot pass because
+nothing happened at all (e.g. the write failing for an unrelated reason).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pipeline.shell import cmd_save_position
+
+WELL_FORMED = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa"
+
+
+@pytest.fixture()
+def store(tmp_path: Path):
+    remember = tmp_path / ".remember"
+    (remember / "tmp").mkdir(parents=True)
+    return remember, str(remember / "tmp" / "last-save.json")
+
+
+@pytest.mark.parametrize("hostile_id", [
+    "../../etc/evil",
+    "foo/bar",
+    "foo\\bar",
+    "..",
+])
+def test_hostile_session_id_is_rejected(store, hostile_id):
+    """A session_id carrying a path separator or traversal must raise,
+    never silently produce a sidecar path outside the store."""
+    _remember, path = store
+    with pytest.raises(ValueError):
+        cmd_save_position(path, hostile_id, 1)
+
+
+def test_well_formed_session_id_still_writes_sidecar(store):
+    """Positive control: validation must not reject a normal id, and the
+    sidecar must actually land, so the negative case above cannot be
+    passing because cmd_save_position stopped doing anything at all."""
+    remember, path = store
+    cmd_save_position(path, WELL_FORMED, 120)
+
+    sidecar = remember / "tmp" / f"position.{WELL_FORMED}"
+    assert sidecar.exists(), "well-formed session_id must still write its sidecar"
+    assert sidecar.read_text() == "120"


### PR DESCRIPTION
## What

`cmd_save_position` (`pipeline/shell.py`) built the position sidecar path
(`position.<session_id>`) and the evicted-sidecar removal path by
interpolating `session_id` directly into a filename, without ever calling
`pipeline.extract._validate_session_id` -- the same check `find_session()`
already runs before its own equivalent join.

Both current shell callers (`scripts/post-tool-hook.sh`,
`scripts/session-end-hook.sh`, `scripts/save-session.sh`) already filter the
id before Python ever sees it, so nothing reachable today was exploitable;
this is hardening, not a vulnerability fix, matching the issue's own
classification -- a future caller reaching `cmd_save_position` by another
route now inherits the same guarantee instead of nothing.

## Change

- `cmd_save_position` now calls `_validate_session_id(session_id)` at the
  top, matching `find_session`.
- Each `evicted_id` in the sidecar-cleanup loop is also validated, inside
  the existing `try/except` so a poisoned legacy id (a store written before
  this fix, or hand-edited) degrades to "sidecar survives a little late" --
  exactly what the surrounding comment already documents for a failed
  unlink -- rather than raising an uncaught `ValueError` that would abort
  the save already in progress.

## Self-review

Two reviewers (`Explore`, `oss:auditor`) were spawned against the first
commit and both independently found the same regression: the eviction-loop
validation, in its first form, sat outside the `try/except`, so a poisoned
legacy id would raise uncaught mid-save -- worse than doing nothing, since
none of the shell callers check the exit status of `save-position`. Fixed
in the second commit, with a regression test proven red against the
un-fixed shape and green against the fixed one.

**Below the bar, not fixed here:** `_validate_session_id` itself (unchanged
by this diff, in `pipeline/extract.py`) rejects `/`, `\` and `..` but not
`:`, so a colon-bearing session_id would reach `position.<id>` and, on
NTFS, could land as an Alternate Data Stream on `position.<prefix>` rather
than a distinct file. This is a pre-existing gap in a function this diff
only calls, shared with `find_session` and every other caller -- fixing it
is a decision about that function's own contract, out of this issue's blast
radius. Reported for filing as a separate issue rather than fixed here.

## Tests

- `tests/test_save_position_validates_session_id_538.py` (new): a hostile
  `session_id` (`../../etc/evil`, `foo/bar`, `foo\bar`, `..`) passed
  directly to `cmd_save_position` must raise, paired with a positive
  control that a well-formed id still writes its sidecar -- red before the
  fix (4 failed, 1 passed), green after.
- Same file: a poisoned id already present in the store's eviction slot
  must not abort the save -- red against the first-commit shape (1 failed),
  green after moving the validation inside the `try`.
- Ran narrowed: `pytest tests/test_save_position_validates_session_id_538.py
  tests/test_position_store.py tests/test_position_sidecar_353.py` -- 57
  passed. Full `test_command` intentionally not run locally; CI is the
  merge gate.

Closes #538
