### PR TITLE
Harden config(): reject a $key not shaped like a dotted path (#539)

### DIFF
--- a/changelog.d/539.fixed.md
+++ b/changelog.d/539.fixed.md
@@ -13,3 +13,9 @@
   fallback) ever sees it -- the earlier shape check this used, a `case` glob
   requiring a leading `.`, silently let a key with *no* leading dot fall
   through unfiltered, which is exactly the shape a real injection takes.
+  The match runs under `LC_ALL=C`: `[A-Za-z]` is a POSIX collation range,
+  not a byte range, and widens to accept accented letters under a UTF-8
+  locale (the same trap `lib-slug.sh` already documents and guards against
+  elsewhere in this file). And with `REMEMBER_DEBUG=1`, a rejection is now
+  reported on stderr, so it reads differently from a key that is simply
+  absent from config.json -- both used to print the same default silently.

--- a/changelog.d/539.fixed.md
+++ b/changelog.d/539.fixed.md
@@ -1,0 +1,15 @@
+- **`config()` no longer splices `$key` unquoted into the jq program it
+  builds** (#539). `scripts/log.sh`'s `config()` reads `config.json` by
+  building `if $key == null then "" else ($key | tostring) end` and handing
+  it to `jq -r` -- `$key` was interpolated into the program text, twice,
+  rather than passed as data. Every call site in this repo passes a
+  hardcoded literal key (`.timezone`, `.cooldowns.save_seconds`, and so on),
+  so nothing exploited this, but nothing enforced that contract either: a
+  future caller that read a key name out of a variable would have had it
+  evaluated as jq against the user's config instead of looked up as a path.
+  `config()` now rejects any key that is not a plain dotted path
+  (`^\.[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*$`) up front and returns the caller's
+  default, before the config table is loaded and before jq (or its jq-free
+  fallback) ever sees it -- the earlier shape check this used, a `case` glob
+  requiring a leading `.`, silently let a key with *no* leading dot fall
+  through unfiltered, which is exactly the shape a real injection takes.

--- a/changelog.d/539.fixed.triage.md
+++ b/changelog.d/539.fixed.triage.md
@@ -1,0 +1,15 @@
+- **`docs/windows-skip-triage.md` now carries a row for
+  `tests/test_config_key_injection_539.py`** (#539). The #539 fix's own new
+  test module carries the module-level win32 blanket-skip pattern
+  `tests/test_windows_skip_triage_497.py` enforces coverage of; it had no
+  row, so the guard (correctly) failed on every `windows-latest` CI leg.
+  Triaged as `unclear` -- the reason string is the same templated
+  "bash subprocess + POSIX layout" boilerplate the majority of this table
+  already carries, and reading the test body confirms real bash/locale
+  behavior (an `LC_ALL=C`-scoped collation-range regex, `tmp_path`-derived
+  paths sourced into the shell) without settling whether `resolve_bash()`
+  alone would make it portable. The table's live module count and the
+  `unclear` subtotal in the doc's own header prose were also one short of
+  the table's actual row count independent of this addition (96 rows vs. a
+  stated 95, i.e. 75 `unclear`) -- fixed alongside this addition so the
+  header prose and the table agree again.

--- a/docs/windows-skip-triage.md
+++ b/docs/windows-skip-triage.md
@@ -16,7 +16,7 @@ converted (`tests/test_hook_cwd_leak_417.py`, `tests/test_transcript_path_leak_4
 plus a fifth, `tests/test_autonomous_log_retention_487.py`, which adopted the
 same route for its own #487 rather than being converted by #432 itself.
 
-## The count: 95, not 107 (and not the issue's original 92)
+## The count: 97, not 107 (and not the issue's original 92)
 
 The issue's own re-verified count -- `grep -rl "pytestmark = pytest.mark.skipif"
 tests | xargs grep -l "win32"` -- returns 107 on this tree. That command only
@@ -36,7 +36,7 @@ parses every test module with `ast`, and only counts a file that has an
 actual module-level `pytestmark = pytest.mark.skipif(<expr containing
 "win32">, reason=...)` assignment -- a bare call, or one arm of a
 list/tuple of marks (pytest ORs a list, so any one arm mentioning "win32"
-is a real blanket skip). That finds **95** modules on this tree at this
+is a real blanket skip). That finds **97** modules on this tree at this
 commit. `tests/test_windows_skip_triage_497.py` recomputes this same set
 on every run and diffs it against the table below, so this list cannot
 silently drift out of sync with the tree the way the issue itself describes
@@ -55,7 +55,7 @@ once already during review.
   path-format incompatibility. 12 modules.
 - **unclear** -- the reason string alone does not say enough to tell; reading
   it is not the same as reading the test body, and this list is deliberately
-  not that read. 75 modules.
+  not that read. 77 modules.
 
 **A blind spot in the scanner itself, caught once already.** An earlier
 version of `scripts/windows_skip_triage_497.py` only matched a bare
@@ -71,7 +71,7 @@ what the AST matcher was written to recognize, not by an exhaustive read of
 every skip expression in `tests/`.
 
 **The `unclear` majority is the honest result, not a shortcut.** The great
-bulk of these 95 reasons is one of a handful of near-identical templated
+bulk of these 97 reasons is one of a handful of near-identical templated
 strings -- `"bash subprocess + POSIX layout -- not portable to Windows
 runners"`, `"bash hook subprocess + POSIX semantics -- not portable to
 Windows runners"`, and near-variants -- that bundle the one thing
@@ -97,6 +97,7 @@ verdict is the useful artifact").
 | `tests/test_case_divergence_298.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
 | `tests/test_codex_stdin_session_id_468.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
 | `tests/test_codex_transcript_path_459.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
+| `tests/test_config_key_injection_539.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; the test body sources scripts/log.sh's config() through a bash subprocess against tmp_path-derived PROJECT_DIR/PIPELINE_DIR/HOME and separately exercises an LC_ALL=C-scoped bracket-range regex under a UTF-8 locale -- real bash/locale-collation behavior, not merely the interpreter's presence, so this is not "reason names only bash" (convertible); but nothing here names a specific POSIX-only primitive either (not-convertible) -- reading the body narrows this to the templated majority rather than settling it |
 | `tests/test_consolidate_read_race.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
 | `tests/test_consolidation_append_race.py` | bash subprocess + POSIX layout — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
 | `tests/test_consolidation_retire_reopened_day_509.py` | bash subprocess + POSIX layout -- not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |

--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -269,8 +269,31 @@ config() {
     # jq interpolation below unfiltered. `[[ =~ ]]` (already used elsewhere
     # in this file, e.g. the KEY=VALUE parser below) can anchor the WHOLE
     # string against a real grammar instead: one leading dot, then one or
-    # more [A-Za-z0-9_.]+ segments joined by single dots, nothing else.
-    if ! [[ "$key" =~ ^\.[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*$ ]]; then
+    # more [A-Za-z0-9_]+ segments, each joined to the next by a single
+    # literal dot -- the dot is the separator BETWEEN segments, never a
+    # character a segment's own class accepts, so `.foo..bar` (an empty
+    # segment) is correctly rejected rather than swallowed.
+    #
+    # Under LC_ALL=C only: `[A-Za-z]` is a POSIX bracket RANGE, and a range
+    # is matched by collation order, not byte value, once LC_COLLATE (via
+    # LANG/LC_ALL) selects a UTF-8 locale -- lib-slug.sh hits the identical
+    # trap and documents it at length. Under en_US.UTF-8, `[A-Za-z]` also
+    # matches accented Latin letters, so `.café` would pass a guard whose own
+    # comment claims to accept only ASCII. A subshell (not a bare `LC_ALL=C`
+    # assignment, which does not apply to `[[`, a compound command, the way
+    # it would to a simple one) scopes this to the one match and restores
+    # nothing, because nothing outside it was ever changed.
+    if ! ( LC_ALL=C; [[ "$key" =~ ^\.[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*$ ]] ); then
+        # Same convention as _config_load's own '#refuse' report just above
+        # in this file: a rejection here and a genuine cache miss a few
+        # lines below both print $default, and without this line they are
+        # indistinguishable from the outside -- "config() keeps returning my
+        # default" reads identically whether the key was malformed or simply
+        # absent. Debug-gated, not unconditional, for the same reason that
+        # one is: a warning that fires on ordinary lookups is a warning
+        # nobody reads.
+        [ "${REMEMBER_DEBUG:-}" = "1" ] && \
+            echo "remember: config() key '$key' is not a plain dotted path -- returning the default rather than evaluating it" >&2
         echo "$default"
         return
     fi

--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -251,26 +251,45 @@ config() {
     local key="$1"
     local default="$2"
 
+    # $key is spliced into the jq program below by string interpolation, not
+    # passed as data (#539) -- `if $key == null then ... else ($key |
+    # tostring) end`, with $key substituted verbatim, twice. Every call site
+    # in this repo passes a hardcoded literal, so nothing exploits this
+    # today, but the function's contract never said the argument had to be a
+    # literal, and nothing enforced it. Reject anything that is not a plain
+    # dotted path up front, before the config table is even loaded, so a
+    # future caller that builds $key from data fails closed to the default
+    # instead of having it evaluated as jq.
+    #
+    # A `case` glob CANNOT express this: the earlier form here,
+    # `""|.|.*[!A-Za-z0-9_.]*`, only rejected a key that literally started
+    # with "." and later contained a bad character -- a key with no leading
+    # dot at all (`("INJECTED"|length>0)`, say) matched none of that
+    # pattern's arms, fell through the whole case silently, and reached the
+    # jq interpolation below unfiltered. `[[ =~ ]]` (already used elsewhere
+    # in this file, e.g. the KEY=VALUE parser below) can anchor the WHOLE
+    # string against a real grammar instead: one leading dot, then one or
+    # more [A-Za-z0-9_.]+ segments joined by single dots, nothing else.
+    if ! [[ "$key" =~ ^\.[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*$ ]]; then
+        echo "$default"
+        return
+    fi
+
     # Lazily, and again if a caller repointed REMEMBER_CONFIG at another file.
     if [ -z "$_REMEMBER_CFG_STATE" ] || \
        [ "$_REMEMBER_CFG_LOADED_FROM" != "${REMEMBER_CONFIG:-}" ]; then
         _config_load
     fi
 
+    # $key is already known to match the dotted-path grammar above, so this
+    # branch no longer needs its own shape check -- it only has to fall
+    # through when the table state cannot answer (fallback / private key).
     if [ "$_REMEMBER_CFG_STATE" = "ok" ] && ! _config_is_private_key "$key"; then
-        case "$key" in
-            ""|.|.*[!A-Za-z0-9_.]*)
-                # Not a plain dotted key — the table cannot name it. Fall
-                # through to the per-key reader, which speaks jq.
-                ;;
-            .?*)
-                local _slot="_RCFG_${key#.}"
-                _slot="${_slot//./_}"
-                local _hit="${!_slot:-}"
-                [ -n "$_hit" ] && echo "$_hit" || echo "$default"
-                return
-                ;;
-        esac
+        local _slot="_RCFG_${key#.}"
+        _slot="${_slot//./_}"
+        local _hit="${!_slot:-}"
+        [ -n "$_hit" ] && echo "$_hit" || echo "$default"
+        return
     fi
 
     if [ ! -f "${REMEMBER_CONFIG:-}" ]; then
@@ -279,6 +298,10 @@ config() {
     fi
     local val=""
     if command -v jq >/dev/null 2>&1; then
+        # $key is spliced into this program by string interpolation below --
+        # safe ONLY because the guard at the top of this function already
+        # rejected anything not shaped like a plain dotted path (#539). Do
+        # not remove that guard to "simplify" this branch.
         # NOT `$key // empty`: jq's // treats false the same as null, so every
         # boolean option set to false read back as its default and could never
         # be switched off (#159). features.ndc_compression and features.recovery

--- a/tests/test_config_key_injection_539.py
+++ b/tests/test_config_key_injection_539.py
@@ -1,0 +1,137 @@
+"""``config()`` (scripts/log.sh:294) builds its jq program by splicing $key
+straight into the program text, twice:
+
+    jq -r "if $key == null then \"\" else ($key | tostring) end" "$REMEMBER_CONFIG"
+
+Every call site today passes a hardcoded literal, so nothing exploits this in
+the shipped code. But the function's contract does not say the argument must
+be a literal, and nothing enforces it -- a future caller that reads a key name
+out of a variable turns a lookup into jq execution against the user's config.
+(#539)
+
+This asserts config() rejects anything that is not a plain dotted path
+(``^\\.[A-Za-z0-9_]+(\\.[A-Za-z0-9_]+)*$``) and returns the caller's default
+instead of evaluating it as jq -- with jq on PATH, where the interpolation
+actually lives, and paired with a positive control reading a real key so the
+malicious-key case cannot pass merely because config() always prints nothing.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash subprocess + POSIX layout — not portable to Windows runners (#79)",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DETECT_SCRIPT = REPO_ROOT / "scripts" / "detect-tools.sh"
+LIB_SCRIPT = REPO_ROOT / "scripts" / "lib-memory-dir.sh"
+LOG_SH = REPO_ROOT / "scripts" / "log.sh"
+
+# A key that is not a literal config path but valid jq: if it is spliced
+# unquoted into `if $key == null then "" else ($key | tostring) end`, jq
+# evaluates the injected expression and prints "true" -- a value that is
+# neither the caller's default nor anything in the config file.
+_INJECTED_KEY = '("INJECTED"|length>0)'
+
+
+def _dirs(tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+    pipeline = tmp_path / "plugin"
+    pipeline.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    return project, pipeline, home
+
+
+def _run_config(tmp_path: Path, key: str, default: str, config_json: dict,
+                 without_jq: bool = False) -> str:
+    """Source detect-tools + lib-memory-dir + log.sh against a per-project
+    config override, and return what config() prints for `key`."""
+    project, pipeline, home = _dirs(tmp_path)
+    (pipeline / "config.json").write_text(json.dumps({}))
+    remember = project / ".remember"
+    remember.mkdir()
+    (remember / "config.json").write_text(json.dumps(config_json))
+
+    script = f"""
+    set -e
+    export PROJECT_DIR={project}
+    export PIPELINE_DIR={pipeline}
+    export HOME={home}
+    source {DETECT_SCRIPT}
+    source {LIB_SCRIPT}
+    source {LOG_SH}
+    config '{key}' '{default}'
+    """
+    env = {**os.environ}
+    if without_jq:
+        fake_bin = tmp_path / "no-jq-bin"
+        fake_bin.mkdir()
+        for d in os.environ.get("PATH", "").split(os.pathsep):
+            try:
+                names = os.listdir(d)
+            except OSError:
+                continue
+            for name in names:
+                if name == "jq":
+                    continue
+                target = fake_bin / name
+                if target.exists() or target.is_symlink():
+                    continue
+                try:
+                    os.symlink(os.path.join(d, name), target)
+                except OSError:
+                    pass
+        env["PATH"] = str(fake_bin)
+    result = subprocess.run(["bash", "-c", script], env=env, check=False,
+                            capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, f"config() sourcing failed:\n{result.stderr}"
+    return result.stdout.strip()
+
+
+@pytest.mark.skipif(shutil.which("jq") is None, reason="exercises the jq-based interpolation directly")
+class TestConfigKeyInjectionWithJq:
+
+    def test_injected_key_returns_default_not_evaluated(self, tmp_path):
+        """A key that is valid jq but not a real config path must not be
+        evaluated as jq -- config() must fail closed to the default."""
+        out = _run_config(tmp_path, _INJECTED_KEY, "safe-default", {"model": "sonnet"})
+        assert out == "safe-default", (
+            f"config() evaluated the key as a jq program and returned "
+            f"{out!r} instead of the default -- the jq interpolation in "
+            f"scripts/log.sh's config() is not guarding its $key argument"
+        )
+
+    def test_positive_control_real_key_still_reads(self, tmp_path):
+        """Paired positive control: a genuine dotted key must still read its
+        real value, so the injected-key case above cannot pass merely
+        because config() stopped returning anything at all."""
+        out = _run_config(tmp_path, ".model", "haiku", {"model": "sonnet"})
+        assert out == "sonnet"
+
+
+class TestConfigKeyInjectionWithoutJq:
+    """Same two cases through the jq-free fallback path, which reads the key
+    by splitting on '.' rather than interpolating it -- already safe from
+    this class of injection, but the guard in config() must reject the
+    malformed key uniformly regardless of which branch would have handled
+    it, so the two paths cannot diverge on which keys they accept."""
+
+    def test_injected_key_returns_default_not_evaluated(self, tmp_path):
+        out = _run_config(tmp_path, _INJECTED_KEY, "safe-default",
+                           {"model": "sonnet"}, without_jq=True)
+        assert out == "safe-default"
+
+    def test_positive_control_real_key_still_reads(self, tmp_path):
+        out = _run_config(tmp_path, ".model", "haiku", {"model": "sonnet"},
+                           without_jq=True)
+        assert out == "sonnet"

--- a/tests/test_config_key_injection_539.py
+++ b/tests/test_config_key_injection_539.py
@@ -52,10 +52,14 @@ def _dirs(tmp_path):
     return project, pipeline, home
 
 
-def _run_config(tmp_path: Path, key: str, default: str, config_json: dict,
-                 without_jq: bool = False) -> str:
-    """Source detect-tools + lib-memory-dir + log.sh against a per-project
-    config override, and return what config() prints for `key`."""
+def _run_config_raw(tmp_path: Path, key: str, default: str, config_json: dict,
+                     without_jq: bool = False, env_extra: "dict | None" = None
+                     ) -> subprocess.CompletedProcess:
+    """Same sourcing as _run_config, but returns the whole CompletedProcess
+    (stdout AND stderr) rather than just the printed value -- needed by the
+    locale test below, where the printed value alone cannot tell "the guard
+    correctly rejected this key" from "the key was accepted but is simply
+    absent from config.json either way" (see that test's own docstring)."""
     project, pipeline, home = _dirs(tmp_path)
     (pipeline / "config.json").write_text(json.dumps({}))
     remember = project / ".remember"
@@ -72,7 +76,7 @@ def _run_config(tmp_path: Path, key: str, default: str, config_json: dict,
     source {LOG_SH}
     config '{key}' '{default}'
     """
-    env = {**os.environ}
+    env = {**os.environ, **(env_extra or {})}
     if without_jq:
         fake_bin = tmp_path / "no-jq-bin"
         fake_bin.mkdir()
@@ -95,7 +99,15 @@ def _run_config(tmp_path: Path, key: str, default: str, config_json: dict,
     result = subprocess.run(["bash", "-c", script], env=env, check=False,
                             capture_output=True, text=True, timeout=30)
     assert result.returncode == 0, f"config() sourcing failed:\n{result.stderr}"
-    return result.stdout.strip()
+    return result
+
+
+def _run_config(tmp_path: Path, key: str, default: str, config_json: dict,
+                 without_jq: bool = False, env_extra: "dict | None" = None) -> str:
+    """Source detect-tools + lib-memory-dir + log.sh against a per-project
+    config override, and return what config() prints for `key`."""
+    return _run_config_raw(tmp_path, key, default, config_json,
+                            without_jq=without_jq, env_extra=env_extra).stdout.strip()
 
 
 @pytest.mark.skipif(shutil.which("jq") is None, reason="exercises the jq-based interpolation directly")
@@ -117,6 +129,114 @@ class TestConfigKeyInjectionWithJq:
         because config() stopped returning anything at all."""
         out = _run_config(tmp_path, ".model", "haiku", {"model": "sonnet"})
         assert out == "sonnet"
+
+
+def _utf8_locale_available() -> "str | None":
+    """An installed locale that ACTUALLY widens [A-Za-z] to accept "é" under
+    this machine's bash -- not just any UTF-8-named locale. Not every UTF-8
+    locale reproduces the collation quirk (confirmed empirically: nl_NL.UTF-8
+    on this repo's own CI-adjacent macOS box does not widen the range, while
+    en_US.UTF-8 does), so picking the first UTF-8 name from `locale -a`
+    without checking is not good enough -- it can silently pick a locale that
+    never triggers the thing under test, at which point the test passes for
+    a reason unrelated to the fix. en_US.UTF-8 is tried first since it is
+    the one already confirmed to reproduce this; every other installed
+    UTF-8-ish locale is tried after it as a fallback. None found (or none
+    installed at all) returns None, and the caller skips loudly rather than
+    passing vacuously."""
+    try:
+        out = subprocess.run(["locale", "-a"], capture_output=True, text=True,
+                              timeout=10, check=False).stdout
+    except (OSError, subprocess.SubprocessError):
+        return None
+    candidates = [line.strip() for line in out.splitlines()
+                  if "utf8" in line.lower() or "utf-8" in line.lower()]
+    for preferred in ("en_US.UTF-8", "en_US.utf8"):
+        if preferred in candidates:
+            candidates.remove(preferred)
+            candidates.insert(0, preferred)
+    for name in candidates:
+        try:
+            probe = subprocess.run(
+                ["bash", "-c", '[[ "é" =~ ^[A-Za-z]+$ ]]'],
+                env={**os.environ, "LC_ALL": name, "LANG": name},
+                capture_output=True, timeout=10, check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if probe.returncode == 0:
+            return name
+    return None
+
+
+class TestConfigGuardIsLocaleIndependent:
+    """The guard's own comment claims to accept only [A-Za-z0-9_] -- ASCII.
+    But `[A-Za-z]` is a POSIX bracket RANGE, matched by collation order
+    rather than byte value once LC_COLLATE (via LANG/LC_ALL) selects a
+    UTF-8-collating locale, and scripts/lib-slug.sh already documents
+    hitting this exact trap elsewhere in this codebase. Under such a locale,
+    plain `[[ "$key" =~ [A-Za-z]+ ]]` also matches accented Latin letters,
+    which would let a key like `.café` slip past a guard whose whole job is
+    rejecting anything the ASCII allowlist does not name.
+
+    This cannot be asserted through config()'s PRINTED VALUE alone: a key
+    like `.café` is never a real entry in any config.json this suite writes
+    (config.json keys are always ASCII, and the flattener refuses the whole
+    file the moment any key is not), so whether the guard correctly rejects
+    `.café` or incorrectly waves it through, the final answer is "safe-
+    default" either way -- rejected by the guard in the first case, or
+    absent from the config in the second. Confirmed empirically: run this
+    same assertion against a scratch copy of scripts/log.sh with the
+    guard's `( LC_ALL=C; ... )` subshell removed, and the printed value is
+    STILL "safe-default" under en_US.UTF-8 -- a test written against the
+    printed value would pass whether or not the fix exists, failing this
+    repo's own bar (CLAUDE.md: "would this test still pass if the code did
+    nothing?").
+
+    So this asserts the one thing that DOES discriminate: with
+    REMEMBER_DEBUG=1, the guard's own rejection line
+    ("... is not a plain dotted path ...") on stderr. That line is only
+    ever printed from inside the guard's reject branch, so its presence is
+    direct evidence the regex actually rejected the key -- not a downstream
+    coincidence."""
+
+    def test_accented_key_still_rejected_under_utf8_locale(self, tmp_path):
+        locale_name = _utf8_locale_available()
+        if locale_name is None:
+            pytest.skip(
+                "no UTF-8 locale installed on this runner -- the "
+                "locale-widening this test guards against cannot be "
+                "reproduced here, so this leg tests nothing about it"
+            )
+        result = _run_config_raw(
+            tmp_path, ".café", "safe-default", {"model": "sonnet"},
+            env_extra={"LC_ALL": locale_name, "LANG": locale_name,
+                       "REMEMBER_DEBUG": "1"})
+        assert result.stdout.strip() == "safe-default"
+        assert "is not a plain dotted path" in result.stderr, (
+            f"config() did not report rejecting '.café' under "
+            f"{locale_name!r} -- [A-Za-z] likely widened under this "
+            f"locale's collation to match the accented letter and the "
+            f"guard let it through silently (the printed value alone "
+            f"cannot show this: see this class's docstring), the same "
+            f"trap scripts/lib-slug.sh documents and guards against with "
+            f"LC_ALL=C"
+        )
+
+    def test_positive_control_real_key_still_reads_under_utf8_locale(self, tmp_path):
+        locale_name = _utf8_locale_available()
+        if locale_name is None:
+            pytest.skip("no UTF-8 locale installed on this runner")
+        result = _run_config_raw(
+            tmp_path, ".model", "haiku", {"model": "sonnet"},
+            env_extra={"LC_ALL": locale_name, "LANG": locale_name,
+                       "REMEMBER_DEBUG": "1"})
+        assert result.stdout.strip() == "sonnet"
+        assert "is not a plain dotted path" not in result.stderr, (
+            "a genuine, present config key was rejected as malformed -- "
+            "the rejection-line assertion above would be meaningless if "
+            "the guard fired on ordinary valid keys too"
+        )
 
 
 class TestConfigKeyInjectionWithoutJq:

--- a/trap.d/539.tree-snapshot-scratchpad-vanished.md
+++ b/trap.d/539.tree-snapshot-scratchpad-vanished.md
@@ -1,0 +1,29 @@
+The tree_snapshot.py before/after check (agents/developer/review.md) asks the
+lane to `snapshot > <scratchpad>/before_snapshot.json` before spawning the
+two reviewers, then `compare --before -` after. In this run, both reviewers
+took a long time (~3-4 minutes each, run concurrently in the background) and
+by the time their completion notifications arrived and I went to run the
+compare step, the scratchpad file I had written earlier in the SAME session
+(`/private/tmp/claude-501/.../<session-id>/scratchpad/before_snapshot.json`)
+no longer existed -- `ls` of the same directory showed every other file I'd
+written around the same time (edit4.toml through edit10.toml, commit_msg2.txt,
+etc.) still present, just not that one. No error was raised when I wrote it;
+`cat | head -c 300` right after the write showed valid JSON content. It was
+simply gone several tool calls later.
+
+Cost: could not do the mutation check the review phase asks for. Had to fall
+back to inspecting `git status --porcelain=v1 -uall` (empty) as weaker
+indirect evidence, and report the check itself as `could-not-compare` rather
+than `clean` in the final report, per the phase file's own instruction that
+`could-not-compare` must never be reported as `clean`.
+
+Not established: whether this is scratchpad-directory garbage collection
+racing a long-running background agent, a duplicate/collision on the session
+id used for the scratchpad path, or something else. Confirmed only that: the
+file existed once, verified once, and was absent later with no error at any
+point.
+
+Possible mitigation for whoever curates this: writing the before-snapshot to
+a path inside the worktree itself (e.g. a gitignored `.oss-tmp/` dir) rather
+than the shared scratchpad might survive a scratchpad GC pass, if that's what
+this is -- untested, just a guess at the mechanism.


### PR DESCRIPTION
## What

`config()` in `scripts/log.sh` built its jq program by splicing its `$key`
argument straight into the program text -- `if $key == null then "" else
($key | tostring) end` -- twice, rather than passing it to jq as data. Every
call site in this repo passes a hardcoded literal key today, so nothing
exploits this in the shipped code, but nothing enforced that the argument
had to be a literal either: a future caller that computed a key from a
variable would have had it evaluated as a jq program against the user's
config instead of read as a lookup path.

Closes #539.

## Fix

`config()` now rejects any key that does not match
`^\.[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*$` up front, before the config table is
loaded and before jq (or its jq-free Python fallback) ever sees the key, and
returns the caller's default instead. The match runs inside a subshell that
forces `LC_ALL=C`, because `[A-Za-z]` is a POSIX collation range rather than
a byte range and widens to accept accented letters under a UTF-8 locale --
the identical trap `scripts/lib-slug.sh` already documents and guards
against elsewhere in this file (self-review caught this; see below). With
`REMEMBER_DEBUG=1`, a rejection now prints a line to stderr, so it reads
differently from a key that is simply absent from `config.json` -- both
used to print the same default silently.

The prior shape check (a `case` glob requiring a leading `.`) is what this
replaces: it only rejected a key that literally started with `.` and later
contained a bad character, so a key with **no** leading dot at all fell
through unfiltered -- exactly the shape the injection test below uses.

## Tests

`tests/test_config_key_injection_539.py` (new): a jq-syntax key
(`("INJECTED"|length>0)`) must return the default rather than being
evaluated, exercised both with jq present (where the interpolation lives)
and without it (the jq-free fallback), each with a positive control reading
a real key. Genuinely red before the fix -- printed `'true'` (the injected
jq boolean) instead of the default -- and green after.

A second test class, `TestConfigGuardIsLocaleIndependent`, regresses the
locale-widening finding below. It asserts on the `REMEMBER_DEBUG=1`
rejection line rather than the printed return value: `.café` is never a
real `config.json` key in this suite (keys are always ASCII, and the
flattener refuses the whole file the moment one is not), and jq itself
errors on a bare non-ASCII field access, so the printed value returns the
default whether the guard correctly rejects `.café` or silently waves it
through -- confirmed empirically against a scratch copy with the
`LC_ALL=C` subshell removed. The rejection line is the one thing that
discriminates, and only prints from inside the guard's own reject branch.

## Self-review

Two agents (`Explore`, `oss:auditor`) reviewed the first commit and found
three real issues, all fixed in a second commit:

- **oss:auditor**: the guard's rejection and a genuine cache miss both
  printed the default silently, indistinguishable from the outside --
  added a `REMEMBER_DEBUG=1`-gated stderr line, matching the identical
  convention `_config_load` already uses a few lines above.
- **Explore**: `[A-Za-z0-9_]` widens under a UTF-8 locale (see Fix, above).
  Rated low severity / not currently exploitable -- no jq-dangerous
  punctuation character is a "letter" in any tested locale, so no working
  injection payload was constructed -- but a real gap worth closing.
- **Explore**: the guard's own comment described each dotted segment's
  character class as including the dot, contradicting the actual regex and
  the sentence around it ("joined by single dots"). Corrected.
