### PR TITLE
Rename the in-repo Codex dev marketplace to remember-dev

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,5 +1,5 @@
 {
-  "name": "dpt-plugins",
+  "name": "remember-dev",
   "interface": {
     "displayName": "Digital Process Tools plugins"
   },

--- a/changelog.d/540.fixed.md
+++ b/changelog.d/540.fixed.md
@@ -1,0 +1,8 @@
+- **The in-repo Codex marketplace no longer collides with the published catalogue** (#540).
+  `.agents/plugins/marketplace.json` -- a development catalogue with one plugin and a
+  local source path, used to run `codex plugin marketplace add .` against a checkout --
+  declared itself `"name": "dpt-plugins"`, the same name the published
+  `Digital-Process-Tools/codex-marketplace` catalogue uses. On a machine that had added
+  both, `remember@dpt-plugins` meant the checkout in one session and the published repo
+  in another. Renamed to `"remember-dev"`, the `<plugin>-dev` shape
+  `claude-jit-context` already ships as `claude-jit-context-dev`.

--- a/tests/test_marketplace_dev_name_540.py
+++ b/tests/test_marketplace_dev_name_540.py
@@ -1,0 +1,40 @@
+"""The in-repo Codex marketplace's own name must not collide with the
+published catalogue (#540).
+
+`.agents/plugins/marketplace.json` is a *development* catalogue -- one
+plugin, local source, `./` -- that lets a maintainer `codex plugin
+marketplace add .` a checkout. It used to declare itself `"name":
+"dpt-plugins"`, which is also the name of the *published* Codex catalogue in
+Digital-Process-Tools/codex-marketplace. On a machine that has added both,
+`remember@dpt-plugins` means two different things depending on which session
+you are in. The fix renames the in-repo catalogue to `remember-dev`, the
+same `<plugin>-dev` shape claude-jit-context already ships as
+`claude-jit-context-dev`.
+
+This test would still pass if the rename had never happened, if it only
+asserted the field was present -- so it pins the exact value, and it pins
+that the value is NOT the published catalogue's name, so a future revert
+back to `dpt-plugins` fails loudly here rather than silently colliding
+again.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MARKETPLACE = REPO_ROOT / ".agents" / "plugins" / "marketplace.json"
+
+
+def test_marketplace_name_is_the_dev_catalogue_not_the_published_one():
+    data = json.loads(MARKETPLACE.read_text(encoding="utf-8"))
+    assert data.get("name") == "remember-dev", (
+        f"marketplace.json 'name' is {data.get('name')!r}, expected 'remember-dev' -- "
+        "the in-repo dev catalogue must not answer to the same name as the "
+        "published Digital-Process-Tools/codex-marketplace catalogue (#540)"
+    )
+    assert data.get("name") != "dpt-plugins", (
+        "marketplace.json 'name' must not be 'dpt-plugins' -- that name now "
+        "belongs to the published Codex catalogue (#540)"
+    )


### PR DESCRIPTION
Closes #540.

`.agents/plugins/marketplace.json` -- a development catalogue with one plugin and a local source path, used to run `codex plugin marketplace add .` against a checkout -- declared itself `"name": "dpt-plugins"`. That name now also belongs to the newly published Codex catalogue in `Digital-Process-Tools/codex-marketplace`. On a machine that has added both (the issue author's own `~/.codex/config.toml`), `remember@dpt-plugins` meant the checkout in one session and the published repo in another, and nothing in the plugin id says which. Renamed the field's value to `"remember-dev"` -- the issue's own proposal, and the `<plugin>-dev` shape `claude-jit-context` already ships in the same position (`claude-jit-context-dev`).

## What changed

- `.agents/plugins/marketplace.json`: `"name": "dpt-plugins"` -> `"name": "remember-dev"`. One line.
- `tests/test_marketplace_dev_name_540.py` (new): reads the file directly, asserts `name == "remember-dev"` AND `name != "dpt-plugins"` -- red before the rename (asserted `dpt-plugins`, failed), green after. The negative half guards against a future revert reintroducing the collision silently.
- `changelog.d/540.fixed.md` (new).

## Searched for other references to the old name

Grepped the whole repo for `dpt-plugins`. Every other hit -- `README.md:37`, `README.md:130`, `.claude/jit-context/vocabulary/01-oss/plugin-currency.md:13` -- names the **published** `Digital-Process-Tools/claude-marketplace`/`codex-marketplace` catalogues (the plugin id `remember@dpt-plugins` a stranger types, and the installed-cache path under `~/.claude/plugins/cache/dpt-plugins/...`), not this repo's own dev catalogue. None of those needed to change -- only the local file's own self-declared name did. `docs_targets` (`README.md`) checked against this specifically: no-change-needed, confirmed by reading, not assumed.

## The open question the issue leaves open (not settled here)

The issue explicitly raises and declines to settle whether `.agents/plugins/marketplace.json` should be committed at all, rather than renamed -- the author leans rename ("not strongly"). This PR implements the rename only, since that is #540's literal ask and the title names it; the deletion question is the maintainer's to decide, not preempted here. Below-bar hypothesis for the maintainer to weigh, not a recommendation: nothing in the diff or the review found a reason the file's current existence is unsafe or misleading beyond what the issue itself already says, so there is no new evidence tipping the lean either way -- it stays exactly as open as the issue left it.

## Review

Self-reviewed by two spawns against the committed diff (Explore + oss:auditor), both returned `FINDINGS: 0`, both classified `no-findings` by `scripts/review_return.py`. Full verbatim returns kept in the developer lane's own note rather than repeated here.

## Tests

`pytest tests/test_marketplace_dev_name_540.py tests/test_codex_manifest_410.py -q --no-cov`: 14 passed. Changelog fragment checked with `.oss/assemble_changelog.py --check` and `--check-links`: both `ok`. Full `test_command` intentionally not run locally (CI is the merge gate); this diff touches no code path the local narrowed run wouldn't already exercise.