### PR TITLE
chore: clear the /oss:doctor warnings

### DIFF
--- a/.claude/jit-context/paths/01-oss/oss-config.md
+++ b/.claude/jit-context/paths/01-oss/oss-config.md
@@ -31,4 +31,13 @@ every section was tagged: the same audit, and a decision on record. A list names
 The scaffolded CI leg and the fragment rule both render from this key, so the answer is written once.
 Versions, not tags: `0.1.0`, never `v0.1.0`. A declared version with no matching section is a finding.
 
+**`user_visible_paths` has the same shape as `changelog_untagged`, and the empty-list case is the
+one to get right.** It lists regexes naming which changed paths this repository considers
+user-visible, so the generated changelog gate can exempt a pull request that touches none of them.
+Absent or `null` means nobody declared anything -- the gate stays unconditional, exactly today's
+behaviour. Unlike `changelog_untagged`, `[]` is NOT a legal "declared, and nothing is user-visible":
+it is refused at validation, because reading an empty list that way would silently turn the gate off
+for the whole repository. A list names the patterns; `oss_config.user_visible_paths_problem` is
+where all three states are decided.
+
 **No key here holds a credential.** The file is committed; tokens live in the forge CLI's own auth.

--- a/.github/workflows/oss-changelog.yml
+++ b/.github/workflows/oss-changelog.yml
@@ -248,14 +248,36 @@ jobs:
             exit 0
           fi
 
+          # `user_visible_paths` in .oss.json (#779): a list of regexes THIS
+          # repository has declared as user-visible, joined by
+          # `user_visible_pattern()` at scaffold time into one `grep -E`
+          # alternation. Empty (the substituted value below) when nothing is
+          # declared -- absent/null, the default -- so `[ -n '' ]` is false and
+          # this guard never fires: every non-empty diff with no fragment still
+          # falls through to the label/dependabot/failure branches below,
+          # unchanged from before this key existed.
+          #
+          # Placed BELOW every branch above that can find or lose a fragment on
+          # purpose: a deleted fragment was already refused, above, before this
+          # line is reached, so declaring `user_visible_paths` cannot make that
+          # bypass possible again -- the `$removed && ! $assembled` branch at
+          # the top of this step already returned.
+          if [ -n '' ]; then
+            if ! printf '%s\n' "$changed" | grep -Eq ''; then
+              echo "changelog: skipped (no user-visible paths changed)"
+              exit 0
+            fi
+          fi
+
           # Every pull request is asked for one, including a docs-only or tests-only
-          # change. The alternative -- exempting paths by regex, as some repositories
-          # do -- needs a list of what is user-visible, and that is a fact about YOUR
-          # repository which this template cannot know: guessing `docs/` and `tests/`
-          # is silent in the dangerous direction for a project whose product is its
-          # documentation. The escape hatch is the label, which a human applies and a
-          # reviewer can see; `gh api` above is what makes it actually take effect on
-          # a re-run rather than only on the next push.
+          # change, UNLESS this repository has declared `user_visible_paths` above and
+          # none of the changed paths matched it. Guessing `docs/` and `tests/` by
+          # default is still refused -- silent in the dangerous direction for a
+          # project whose product is its documentation -- so the unconfigured
+          # default stays exactly this strict. The escape hatch below is the label,
+          # which a human applies and a reviewer can see; `gh api` above is what
+          # makes it actually take effect on a re-run rather than only on the next
+          # push.
           #
           # One author is exempt, and it is placed HERE -- last, after every branch above --
           # so that it changes exactly one outcome: the one that currently fails with
@@ -271,10 +293,12 @@ jobs:
           # before the first failure exists, which is why it is a condition here and not a
           # label somebody applies afterwards.
           #
-          # This is an AUTHOR check and not a path check, which is the distinction that keeps
-          # the paragraph above honest: which paths are user-visible is a fact about YOUR
-          # repository that this template cannot know, while who opened the pull request is a
-          # fact the event hands it. It matches one exact login -- the bot that
+          # This is an AUTHOR check and not a path check. `user_visible_paths` above is
+          # the path-based route, and it is opt-in -- a repository that has not declared
+          # it is in exactly the position this comment used to describe unconditionally:
+          # which paths are user-visible is a fact this template does not guess at, so
+          # the escape hatch for a bot that cannot use the label is who opened the pull
+          # request, not what it touched. It matches one exact login -- the bot that
           # `.github/dependabot.yml`, scaffolded beside this file, actually produces.
           #
           # It is a skip that announces itself, not a silent pass. Read that line if you point

--- a/.oss.json
+++ b/.oss.json
@@ -20,7 +20,8 @@
       "priority:low",
       "priority:medium"
     ],
-    "lanes": []
+    "lanes": [],
+    "filed_by_loop": "filed-by-loop"
   },
   "milestones": [],
   "release": {

--- a/.oss/README.md
+++ b/.oss/README.md
@@ -21,6 +21,14 @@ cannot live in here: a forge reads workflows only from `.github/workflows/` itse
 subdirectories are not supported and a symlink there fails outright. So it keeps the
 `oss-` prefix and carries the same note in its own header.
 
+## Exclude this directory from your own linter
+
+Every `.py` file here is vendored and replaced wholesale on every `/oss:scaffold`
+run, so a style finding your own linter (ruff, flake8, …) reports inside `.oss`
+is not actionable: any fix you make is reverted the next time this directory is
+regenerated. Add `.oss` to your linter's exclude list — for `ruff`, an `exclude`
+entry under `[tool.ruff]` in `pyproject.toml`.
+
 ## What is here
 
 Every file this directory holds, and nothing else — `/oss:scaffold` writes these and

--- a/.oss/statusline.py
+++ b/.oss/statusline.py
@@ -2292,10 +2292,19 @@ def main(argv=None):
             pass
         return 0
 
-    try:
-        payload = json.load(sys.stdin)
-    except (ValueError, OSError):
+    # #846: `sys.stdin` is `None` when the harness hands this process a closed
+    # or unopenable standard input -- `json.load(None)` then raises
+    # `AttributeError`, which neither `ValueError` nor `OSError` below
+    # catches. The rest of `main()` already treats an empty/unreadable
+    # payload as the ordinary "no session context" case, so the same
+    # fallback applies here rather than crashing before it can.
+    if sys.stdin is None:
         payload = {}
+    else:
+        try:
+            payload = json.load(sys.stdin)
+        except (ValueError, OSError):
+            payload = {}
     start = (payload.get("workspace") or {}).get("current_dir") or os.getcwd()
     root = repo_root(start)
     if root is None:


### PR DESCRIPTION
`/oss:doctor` reported 8 warnings. This clears the ones that live in the repo; two were cleared on the forge and one is not a defect.

## In this diff

**`labels.filed_by_loop` was not declared.** `dispatch_rank.rank` answers `could-not-rank` for *every* issue on a board that declares no loop-filed label, so the two-axis dispatch order (author before priority within a band, #798) was inert rather than merely unranked today. Declared as `filed-by-loop`, which is the spelling the plugin's own `.oss.json` uses and which `/oss:setup` writes; the label now exists on this tracker.

**Owned files were behind the installed plugin copy.** `/oss:scaffold --apply` replaces them wholesale, so re-running is the only delivery mechanism for a fix to one of them:

- `.oss/statusline.py` picks up the #846 fix. `sys.stdin` is `None` when the harness hands the process a closed or unopenable standard input, and `json.load(None)` raises `AttributeError`, which neither `ValueError` nor `OSError` catches — the status line crashed instead of falling back to the no-session-context path it already had.
- `.github/workflows/oss-changelog.yml` gains the `user_visible_paths` guard (#779). **This repo declares no such key**, so the substituted pattern is empty, `[ -n '' ]` is false, and the guard never fires: the gate behaves exactly as it did before. Verified by running both audits the workflow runs, against this tree — `--check` reports 8 fragments parsing clean, `--check-links` reports 40 release sections each carrying a link ref.
- `.oss/README.md` and `.claude/jit-context/paths/01-oss/oss-config.md`: prose only, nothing they do changes.

No owned file here carried a local edit worth keeping — the only differences were the plugin's own newer content.

## Done on the forge, not in this diff

- **secret scanning** and **push protection** enabled (both were off).
- **CodeQL default setup** configured; code scanning had never run. Its first run is what put `main` in a not-green state on `c0ad3a9` — nothing failed, CodeQL had simply not concluded yet.

## Left alone

- `clone HEAD: on readme-restructure (not main)` — that is #549's work in flight (PR #550), not a fault.
- `latest skew: could not be determined` — a transient failed live read; the cache reads 0.26.0, which matches the installed version.

## Testing

The changed files are the scaffolded furniture, not the package — `pytest` covers none of them. What was actually run: both changelog audits (above), `json.load` on `.oss.json`, and `.oss/statusline.py` on both an empty stdin and a closed one, exit 0 for each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bv6BGZD2EdZ9EuJ7tPDTb7
