### PR TITLE
Reject ':' in _validate_session_id (#544)

### DIFF
--- a/changelog.d/544.fixed.md
+++ b/changelog.d/544.fixed.md
@@ -1,0 +1,6 @@
+- `_validate_session_id()` now rejects `:` in a session_id, alongside the
+  existing path-separator and `..` traversal checks. On NTFS a colon in a
+  filename is read as an Alternate Data Stream separator
+  (`filename:stream`), so a colon-bearing session_id could otherwise land
+  as an ADS on an existing file instead of a distinct file of its own when
+  joined into `position.<session_id>` (#544).

--- a/pipeline/extract.py
+++ b/pipeline/extract.py
@@ -249,8 +249,21 @@ def clear_unread_envelope(path: str, session_id: str) -> None:
 
 
 def _validate_session_id(session_id: str) -> None:
-    """Reject session IDs containing path traversal characters."""
-    if "/" in session_id or "\\" in session_id or ".." in session_id:
+    """Reject session IDs containing path traversal or ADS-stream characters.
+
+    ``:`` is rejected alongside the path-separator and traversal checks
+    because on NTFS a colon in a filename is read as an Alternate Data
+    Stream separator (``filename:stream``) rather than a literal
+    character -- a colon-bearing session_id joined into
+    ``position.<session_id>`` could silently write to/read from an
+    existing file's ADS instead of a distinct file of its own (#544).
+    """
+    if (
+        "/" in session_id
+        or "\\" in session_id
+        or ".." in session_id
+        or ":" in session_id
+    ):
         raise ValueError(f"invalid session_id: {session_id}")
 
 

--- a/tests/test_validate_session_id_rejects_colon_544.py
+++ b/tests/test_validate_session_id_rejects_colon_544.py
@@ -1,0 +1,43 @@
+"""_validate_session_id must reject ':' (#544).
+
+On NTFS, a colon in a filename is read as an Alternate Data Stream separator
+(`filename:stream`), so a session_id such as "foo:bar" joined into
+`position.{session_id}` could silently write to/read from an existing
+file's ADS instead of a distinct file of its own. `_validate_session_id`
+(pipeline/extract.py) already rejects '/', '\\' and '..' but not ':'.
+
+Mirrors tests/test_save_position_validates_session_id_538.py's shape: a
+negative case (colon-bearing id must raise) paired with a positive control
+(a well-formed UUID id must still pass), so the "must raise" assertion
+cannot be trivially true because nothing happened at all.
+
+This is platform-independent by design (CLAUDE.md / agents/developer.md
+bar on cross-platform claims): the exploit mechanics are NTFS-specific and
+unobserved on this machine (darwin), but the validation itself is a plain
+string-shape check with no filesystem dependency, so asserting the ValueError
+directly -- rather than gating behind a Windows-only fixture or actually
+attempting an ADS write -- exercises the real code path on every platform
+CI runs, which a skip-elsewhere fixture would not.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pipeline.extract import _validate_session_id
+
+WELL_FORMED = "aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa"
+
+
+def test_colon_bearing_session_id_is_rejected():
+    """A ':' in session_id must raise, never silently pass through to
+    become `position.<id>` where NTFS would read the tail as an ADS name."""
+    with pytest.raises(ValueError):
+        _validate_session_id("foo:bar")
+
+
+def test_well_formed_session_id_still_passes():
+    """Positive control: a plain UUID session_id must not be rejected, so
+    the negative case above cannot be passing because validation now
+    rejects everything."""
+    _validate_session_id(WELL_FORMED)  # must not raise


### PR DESCRIPTION
Closes #544

_validate_session_id() in pipeline/extract.py rejected path separators and ".." but not ":". On NTFS a colon in a filename is read as an Alternate Data Stream separator (filename:stream), so a colon-bearing session_id joined into position.<session_id> could silently write to/read from an existing file's ADS instead of a distinct file of its own.

This adds ":" to the same check, shared by find_session() and (since #538/#541) cmd_save_position() and its eviction-loop cleanup.

No caller today supplies a colon-bearing session_id -- every current caller passes Claude Code's own UUID-shaped ids -- so this is hardening against a future caller, the same framing #538 used for the traversal check.

## Test plan

- New file tests/test_validate_session_id_rejects_colon_544.py: a negative case (colon-bearing id must raise) paired with a positive control (a well-formed UUID id must still pass), mirroring tests/test_save_position_validates_session_id_538.py's shape.
- Red confirmed before the fix: test_colon_bearing_session_id_is_rejected failed with "DID NOT RAISE ValueError".
- Green after: 8 passed (the new file's 2 tests plus the existing #538 regression file's 6).
- Platform-independent by design: the exploit mechanics are NTFS-specific, but _validate_session_id itself is a plain string-shape check with no filesystem dependency, so asserting the ValueError directly exercises the real code path on every CI leg (Linux/macOS/Windows x4 interpreters) rather than being gated behind a Windows-only fixture that would only run on one of them.
- Scoped narrowly to what the issue asked: only ":" is added. Other NTFS-reserved characters (<, >, |, *, ?, NUL, reserved device names) are not concretely reachable through any current caller and were left out per the issue's own scoping.
- No README change: this is internal hardening with no user-facing behavior change; README does not document _validate_session_id's internal character checks.
- Self-reviewed: two spawns (Explore reviewer, oss:auditor) against the committed diff both returned NO FINDINGS.
