### PR TITLE
Fix: distinguish scan-cap from genuine exhaustion in sniff_file_envelope_status (#556)

### DIFF
--- a/changelog.d/556.fixed.md
+++ b/changelog.d/556.fixed.md
@@ -1,0 +1,9 @@
+- Fixed: `sniff_file_envelope_status()` (pipeline/extract.py) folded a third
+  cause into the same "unrecognised, and not unreadable" return that #543's
+  50-line scan cap already shared with genuine exhaustion, so a transcript
+  whose scan gave up at the cap was indistinguishable from one that was
+  fully read. The function now returns a third element, `capped`, and
+  `pipeline/haiku.py`'s fallback warning ("could not identify the host from
+  transcript ... (unreadable or an unrecognised shape)") now names the cap
+  specifically instead of lumping it in with a shape genuinely never
+  recognised (#556).

--- a/pipeline/extract.py
+++ b/pipeline/extract.py
@@ -378,11 +378,14 @@ def sniff_file_envelope_status(path: str) -> tuple[str, bool, bool]:
     * ``unreadable=True`` means the file could not even be opened (an
       ``OSError`` -- a permission error, a bad mount, a file that vanished
       between listing and open).
-    * ``capped=True`` means the file WAS opened, but the scan gave up after
+    * ``capped=True`` means the file WAS opened, the scan reached
       ``_ENVELOPE_SNIFF_SCAN_CAP`` parseable-but-unplaceable lines without
-      ever resolving -- a genuinely foreign run of bookkeeping-shaped lines
-      long enough to hit the cap, or (in principle) a resolving line that
-      exists past it and was never reached.
+      ever resolving, AND at least one more line exists past the cap that
+      was never looked at -- a genuinely foreign run of bookkeeping-shaped
+      lines long enough to hit the cap, or (in principle) a resolving line
+      that exists past it. A file whose unplaceable count happens to land
+      exactly on the cap and then ends is genuine exhaustion, not this --
+      there is no unread line left for a later build to ever find.
     * Both ``False`` means the file was opened and read to genuine
       exhaustion (or found empty) -- every parseable line was inspected,
       well within the cap, and none of them named a known host shape.
@@ -423,7 +426,15 @@ def sniff_file_envelope_status(path: str) -> tuple[str, bool, bool]:
                     return envelope, False, False
                 scanned += 1
                 if scanned >= _ENVELOPE_SNIFF_SCAN_CAP:
-                    return "unrecognised", False, True
+                    # A file whose scanned-unplaceable count happens to hit
+                    # the cap on its very last line is NOT "gave up with
+                    # more file left" -- it is genuine exhaustion that
+                    # coincided with the cap, and reporting it as capped
+                    # would tell #450's quarantine a later build could
+                    # never clear it, when nothing was actually left
+                    # unread. Peek at whether the file actually continues
+                    # past this line before deciding which one this is.
+                    return "unrecognised", False, next(f, None) is not None
     except OSError:
         return "unrecognised", True, False
     return "unrecognised", False, False
@@ -442,11 +453,13 @@ def sniff_file_envelope(path: str) -> str:
     see that function's docstring for why skipping is still sound.
 
     Returns "claude-code", "codex", or "unrecognised" -- the last one also
-    covering an unreadable or entirely-empty file, which offers no line to
-    sniff at all. Callers that need to tell "could not even open it" apart
-    from "opened it, found no known shape" -- #478 -- want
-    ``sniff_file_envelope_status()`` instead; this function's contract (a
-    single string, both causes collapsed) is kept unchanged for every
+    covering an unreadable file, an entirely-empty file (which offers no
+    line to sniff at all), and a scan that gave up at
+    ``sniff_file_envelope_status()``'s own cap (#543). Callers that need to
+    tell these apart -- "could not even open it" (#478) from "opened it,
+    found no known shape" from "gave up before exhausting it" (#556) --
+    want ``sniff_file_envelope_status()`` instead; this function's contract
+    (a single string, every cause collapsed) is kept unchanged for every
     existing caller.
     """
     return sniff_file_envelope_status(path)[0]

--- a/pipeline/extract.py
+++ b/pipeline/extract.py
@@ -361,23 +361,35 @@ def count_lines(path: str) -> int:
 # giving up and calling the file "unrecognised" -- generous enough for any
 # realistic run of bookkeeping lines, small enough that a genuinely foreign
 # file still fails fast rather than reading to the end of a huge transcript.
+# Hitting this cap is reported as its own ``capped`` fact (#556) rather than
+# folded into genuine exhaustion -- see ``sniff_file_envelope_status()``.
 _ENVELOPE_SNIFF_SCAN_CAP = 50
 
 
-def sniff_file_envelope_status(path: str) -> tuple[str, bool]:
+def sniff_file_envelope_status(path: str) -> tuple[str, bool, bool]:
     """Which host wrote this transcript, plus whether it could be OPENED at
-    all (#478).
+    all (#478), plus whether "unrecognised" means the scan gave up at its
+    cap rather than genuinely exhausting the file (#556).
 
     Same sniff as ``sniff_file_envelope()`` -- see that docstring -- but
-    returned alongside a second fact: "unrecognised" covers two different
-    causes, and this call tells them apart. ``unreadable=True`` means the
-    file could not even be opened (an ``OSError`` -- a permission error, a
-    bad mount, a file that vanished between listing and open); ``False``
-    means the file WAS opened and every parseable line was inspected -- to
-    genuine exhaustion, to an entirely-empty file, or up to
-    ``_ENVELOPE_SNIFF_SCAN_CAP`` unplaceable lines (#543, below) -- and none
-    of them named a known host shape. The envelope string itself is always
-    "unrecognised" in both cases, matching ``sniff_file_envelope()``
+    returned alongside two more facts: "unrecognised" covers three different
+    causes, and this call tells them apart.
+
+    * ``unreadable=True`` means the file could not even be opened (an
+      ``OSError`` -- a permission error, a bad mount, a file that vanished
+      between listing and open).
+    * ``capped=True`` means the file WAS opened, but the scan gave up after
+      ``_ENVELOPE_SNIFF_SCAN_CAP`` parseable-but-unplaceable lines without
+      ever resolving -- a genuinely foreign run of bookkeeping-shaped lines
+      long enough to hit the cap, or (in principle) a resolving line that
+      exists past it and was never reached.
+    * Both ``False`` means the file was opened and read to genuine
+      exhaustion (or found empty) -- every parseable line was inspected,
+      well within the cap, and none of them named a known host shape.
+
+    ``unreadable`` and ``capped`` are never both true: a file that could not
+    be opened at all never reaches the scan. The envelope string itself is
+    always "unrecognised" in every case, matching ``sniff_file_envelope()``
     exactly, so a caller that only wants the old behaviour is unaffected.
 
     A parseable line that ``_host.sniff_envelope()`` cannot place (#543 --
@@ -392,8 +404,8 @@ def sniff_file_envelope_status(path: str) -> tuple[str, bool]:
     because no unplaceable line is ever allowed to decide the verdict.
 
     Returns:
-        ``(envelope, unreadable)`` where ``envelope`` is "claude-code",
-        "codex", or "unrecognised".
+        ``(envelope, unreadable, capped)`` where ``envelope`` is
+        "claude-code", "codex", or "unrecognised".
     """
     try:
         with open(path, encoding="utf-8", errors="replace") as f:
@@ -408,13 +420,13 @@ def sniff_file_envelope_status(path: str) -> tuple[str, bool]:
                     continue
                 envelope = _host.sniff_envelope(obj)
                 if envelope != "unrecognised":
-                    return envelope, False
+                    return envelope, False, False
                 scanned += 1
                 if scanned >= _ENVELOPE_SNIFF_SCAN_CAP:
-                    break
+                    return "unrecognised", False, True
     except OSError:
-        return "unrecognised", True
-    return "unrecognised", False
+        return "unrecognised", True, False
+    return "unrecognised", False, False
 
 
 def sniff_file_envelope(path: str) -> str:
@@ -622,7 +634,7 @@ def extract_session(
     # prevent.
     actual_id = session_id or os.path.basename(path).replace(".jsonl", "")
     total_lines = count_lines(path)
-    envelope, envelope_unreadable = sniff_file_envelope_status(path)
+    envelope, envelope_unreadable, envelope_capped = sniff_file_envelope_status(path)
 
     used_skip_lines = 0
     unread_sidecar_unreadable = False
@@ -670,6 +682,7 @@ def extract_session(
         skip_lines=used_skip_lines,
         unread_sidecar_unreadable=unread_sidecar_unreadable,
         envelope_unreadable=envelope_unreadable,
+        envelope_capped=envelope_capped,
     )
 
 

--- a/pipeline/haiku.py
+++ b/pipeline/haiku.py
@@ -255,13 +255,26 @@ def _choose_summarizer_provider() -> str:
                 "back to 'claude', which may not be correct"
             )
         return "claude"
-    envelope = _extract.sniff_file_envelope(path)
+    envelope, envelope_unreadable, envelope_capped = _extract.sniff_file_envelope_status(path)
     if envelope == "codex":
         return "codex"
     if envelope == "unrecognised":
+        # #556: "unreadable or an unrecognised shape" used to be the whole
+        # story, but it collapsed a THIRD cause into "unrecognised shape" --
+        # the scan giving up at extract._ENVELOPE_SNIFF_SCAN_CAP without
+        # ever exhausting the file. sniff_file_envelope_status() (rather
+        # than the plain sniff_file_envelope() this used to call) is what
+        # makes the cap visible here, so the warning can name it instead of
+        # misfiling it under a shape genuinely never recognised.
+        if envelope_unreadable:
+            reason = "unreadable"
+        elif envelope_capped:
+            reason = "gave up after scanning too many unplaceable lines"
+        else:
+            reason = "an unrecognised shape"
         _warn(
             f"WARNING: could not identify the host from transcript {path!r} "
-            "(unreadable or an unrecognised shape) -- REMEMBER_SUMMARIZER=auto "
+            f"({reason}) -- REMEMBER_SUMMARIZER=auto "
             "is falling back to 'claude', which may not be correct"
         )
     return "claude"

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -133,6 +133,13 @@ def cmd_extract(session_id: str, project_dir: str) -> None:
     # every "unrecognised" case at the shape-sniffing function even when the
     # real answer is "the file could not be read at all".
     print(f"ENVELOPE_UNREADABLE={1 if r.envelope_unreadable else 0}")
+    # #556: ENVELOPE="unrecognised" with ENVELOPE_UNREADABLE=0 still collapses
+    # two different causes -- a file read to genuine exhaustion without ever
+    # naming a known host shape, and one that hit
+    # extract._ENVELOPE_SNIFF_SCAN_CAP and gave up before exhausting the
+    # file. Additive for the same reason as the two keys above: no current
+    # consumer reads this yet, but the distinction is on the bridge.
+    print(f"ENVELOPE_CAPPED={1 if r.envelope_capped else 0}")
 
 
 def cmd_build_prompt(

--- a/pipeline/shell.py
+++ b/pipeline/shell.py
@@ -85,7 +85,8 @@ def cmd_extract(session_id: str, project_dir: str) -> None:
     Prints:
         POSITION, HUMAN_COUNT, ASSISTANT_COUNT, EXCHANGE_COUNT,
         EXTRACT_FILE (path to temp file containing exchange text), ENVELOPE,
-        SKIP_LINES, UNREAD_SIDECAR_UNREADABLE, ENVELOPE_UNREADABLE.
+        SKIP_LINES, UNREAD_SIDECAR_UNREADABLE, ENVELOPE_UNREADABLE,
+        ENVELOPE_CAPPED.
     """
     import tempfile
     remember_dir = os.environ.get("REMEMBER_DIR") or None

--- a/pipeline/types.py
+++ b/pipeline/types.py
@@ -124,6 +124,16 @@ class ExtractResult:
             exhaustion (or found empty) and simply never contained a line
             naming a known host shape (#478). ``envelope`` is
             "unrecognised" in both cases; this is what tells them apart.
+        envelope_capped: True when ``envelope`` is "unrecognised" because
+            the scan gave up after ``extract._ENVELOPE_SNIFF_SCAN_CAP``
+            parseable-but-unplaceable lines, rather than because the file
+            was read to genuine exhaustion (or found empty) without ever
+            naming a known host shape (#556). Never true together with
+            ``envelope_unreadable`` -- a file that could not be opened
+            never reaches the scan -- and never true for a resolved
+            envelope. Lets a caller (``pipeline.haiku``'s fallback warning)
+            name the cap specifically instead of lumping it in with
+            "unrecognised shape".
     """
 
     exchanges: str = ""
@@ -135,6 +145,7 @@ class ExtractResult:
     skip_lines: int = 0
     unread_sidecar_unreadable: bool = False
     envelope_unreadable: bool = False
+    envelope_capped: bool = False
 
 
 @dataclass

--- a/pipeline/types.py
+++ b/pipeline/types.py
@@ -120,10 +120,12 @@ class ExtractResult:
         envelope_unreadable: True when the transcript file named by
             ``envelope`` could not even be OPENED (an ``OSError`` --
             permission error, bad mount, vanished between listing and
-            open) -- never true when the file was opened and read to
-            exhaustion (or found empty) and simply never contained a line
-            naming a known host shape (#478). ``envelope`` is
-            "unrecognised" in both cases; this is what tells them apart.
+            open) -- never true when the file was opened at all, whether
+            that read hit genuine exhaustion (or an empty file) or gave up
+            at the scan cap (``envelope_capped``, below), since neither of
+            those ever contained a line naming a known host shape (#478,
+            #556). ``envelope`` is "unrecognised" in every case; this is
+            what tells "could not open it" apart from the other two.
         envelope_capped: True when ``envelope`` is "unrecognised" because
             the scan gave up after ``extract._ENVELOPE_SNIFF_SCAN_CAP``
             parseable-but-unplaceable lines, rather than because the file

--- a/tests/test_sniff_envelope_capped_556.py
+++ b/tests/test_sniff_envelope_capped_556.py
@@ -1,0 +1,86 @@
+"""sniff_file_envelope_status() folds two different exhaustion causes into
+the same ``unreadable=False`` return (#556): a file whose scan hit
+``_ENVELOPE_SNIFF_SCAN_CAP`` unplaceable lines and gave up (#543's own cap),
+and a file that was read to genuine exhaustion (or found empty) and simply
+never named a known host shape. The caller-visible tuple could not tell
+these apart, so pipeline/haiku.py's fallback warning named only two causes
+("unreadable or an unrecognised shape") for a message that can also be
+produced by a third: the cap.
+
+This adds a third element to the returned tuple, ``capped``, true only when
+the scan gave up at the cap rather than genuinely exhausting the file.
+Every "must fire" case (the cap is actually hit) is paired with a "must not
+fire" control (a file that is genuinely exhausted, never capped) so the
+test cannot pass by reporting every unrecognised file as capped.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from pipeline.extract import _ENVELOPE_SNIFF_SCAN_CAP, sniff_file_envelope_status
+
+
+def test_scan_cap_is_reported_as_capped_not_exhausted(tmp_path):
+    """The defect itself: a file whose first _ENVELOPE_SNIFF_SCAN_CAP + 1
+    lines are all parseable-but-unplaceable must be distinguishable from a
+    genuinely exhausted file. Would still pass if the code did nothing
+    (capped stayed unreported) unless this asserts on the actual return
+    value distinguishing the two.
+    """
+    unplaceable = (
+        '{"type": "queue-operation", "operation": "enqueue"}\n' * (_ENVELOPE_SNIFF_SCAN_CAP + 1)
+    )
+    path = tmp_path / "past-the-cap.jsonl"
+    path.write_text(unplaceable, encoding="utf-8")
+
+    envelope, unreadable, capped = sniff_file_envelope_status(str(path))
+    assert envelope == "unrecognised"
+    assert unreadable is False
+    assert capped is True
+
+
+def test_genuine_exhaustion_is_not_reported_as_capped(tmp_path):
+    """MUST-FIRE control's pair: a file that is fully read -- every line
+    parseable and unplaceable, but fewer than the cap -- exhausts normally
+    and must report capped=False, not capped=True. Without this control,
+    a fix that reports every "unrecognised" result as capped=True would
+    also pass the test above.
+    """
+    unplaceable = (
+        '{"type": "queue-operation", "operation": "enqueue"}\n' * (_ENVELOPE_SNIFF_SCAN_CAP - 1)
+    )
+    path = tmp_path / "genuinely-exhausted.jsonl"
+    path.write_text(unplaceable, encoding="utf-8")
+
+    envelope, unreadable, capped = sniff_file_envelope_status(str(path))
+    assert envelope == "unrecognised"
+    assert unreadable is False
+    assert capped is False
+
+
+def test_an_empty_file_is_exhausted_not_capped(tmp_path):
+    """A second genuine-exhaustion shape: an entirely empty file offers no
+    line to scan at all, and must not be reported as capped.
+    """
+    path = tmp_path / "empty.jsonl"
+    path.write_text("", encoding="utf-8")
+
+    envelope, unreadable, capped = sniff_file_envelope_status(str(path))
+    assert envelope == "unrecognised"
+    assert unreadable is False
+    assert capped is False
+
+
+def test_unreadable_file_is_not_reported_as_capped(tmp_path):
+    """The OSError cause and the capped cause are distinct facts about the
+    same "unrecognised" verdict; an unopenable file must not be capped=True.
+    """
+    missing = str(tmp_path / "does-not-exist.jsonl")
+    envelope, unreadable, capped = sniff_file_envelope_status(missing)
+    assert envelope == "unrecognised"
+    assert unreadable is True
+    assert capped is False

--- a/tests/test_sniff_envelope_capped_556.py
+++ b/tests/test_sniff_envelope_capped_556.py
@@ -62,6 +62,27 @@ def test_genuine_exhaustion_is_not_reported_as_capped(tmp_path):
     assert capped is False
 
 
+def test_a_file_with_exactly_the_cap_and_nothing_more_is_not_capped(tmp_path):
+    """Boundary case (found in review): a file whose unplaceable-line count
+    lands EXACTLY on ``_ENVELOPE_SNIFF_SCAN_CAP`` and then ends is genuine
+    exhaustion, not "gave up with more file left" -- there is no unread
+    line hiding past the cap for a later build to ever find. Reporting
+    this as capped=True would tell #450's quarantine that a re-run of this
+    exact same file could someday resolve it, which is never true here:
+    the whole file has already been read. Without peeking past the cap
+    line, a naive `scanned >= cap` check reports this boundary case as
+    capped=True (the defect this test pins).
+    """
+    unplaceable = '{"type": "queue-operation", "operation": "enqueue"}\n' * _ENVELOPE_SNIFF_SCAN_CAP
+    path = tmp_path / "exactly-the-cap.jsonl"
+    path.write_text(unplaceable, encoding="utf-8")
+
+    envelope, unreadable, capped = sniff_file_envelope_status(str(path))
+    assert envelope == "unrecognised"
+    assert unreadable is False
+    assert capped is False
+
+
 def test_an_empty_file_is_exhausted_not_capped(tmp_path):
     """A second genuine-exhaustion shape: an entirely empty file offers no
     line to scan at all, and must not be reported as capped.

--- a/tests/test_sniff_envelope_scan_forward_543.py
+++ b/tests/test_sniff_envelope_scan_forward_543.py
@@ -50,9 +50,10 @@ def test_bookkeeping_lines_before_the_first_message_are_skipped(tmp_path):
         '{"type": "user", "message": {"role": "user", "content": "hi"}, "sessionId": "s"}\n',
         encoding="utf-8",
     )
-    envelope, unreadable = sniff_file_envelope_status(str(path))
+    envelope, unreadable, capped = sniff_file_envelope_status(str(path))
     assert envelope == "claude-code"
     assert unreadable is False
+    assert capped is False
     assert sniff_file_envelope(str(path)) == "claude-code"
 
 
@@ -68,9 +69,10 @@ def test_bookkeeping_lines_before_a_codex_payload_are_skipped(tmp_path):
         '{"type": "session_meta", "payload": {"id": "abc"}}\n',
         encoding="utf-8",
     )
-    envelope, unreadable = sniff_file_envelope_status(str(path))
+    envelope, unreadable, capped = sniff_file_envelope_status(str(path))
     assert envelope == "codex"
     assert unreadable is False
+    assert capped is False
 
 
 def test_scan_cap_gives_up_before_a_resolving_line_past_it(tmp_path):
@@ -89,9 +91,12 @@ def test_scan_cap_gives_up_before_a_resolving_line_past_it(tmp_path):
     path = tmp_path / "past-the-cap.jsonl"
     path.write_text(unplaceable + resolving, encoding="utf-8")
 
-    envelope, unreadable = sniff_file_envelope_status(str(path))
+    envelope, unreadable, capped = sniff_file_envelope_status(str(path))
     assert envelope == "unrecognised"
     assert unreadable is False
+    # #556: this scan-cap case is now distinguishable from genuine
+    # exhaustion -- it must report capped, not merely "unrecognised".
+    assert capped is True
 
 
 def test_blank_and_malformed_lines_do_not_count_against_the_scan_cap(tmp_path):
@@ -108,9 +113,10 @@ def test_blank_and_malformed_lines_do_not_count_against_the_scan_cap(tmp_path):
     path = tmp_path / "noisy-but-within-cap.jsonl"
     path.write_text(noise + resolving, encoding="utf-8")
 
-    envelope, unreadable = sniff_file_envelope_status(str(path))
+    envelope, unreadable, capped = sniff_file_envelope_status(str(path))
     assert envelope == "claude-code"
     assert unreadable is False
+    assert capped is False
 
 
 def test_a_genuinely_foreign_file_still_reads_unrecognised(tmp_path):
@@ -126,7 +132,8 @@ def test_a_genuinely_foreign_file_still_reads_unrecognised(tmp_path):
         '{"kind": "totally-unrelated-tool", "data": [1, 2, 3]}\n',
         encoding="utf-8",
     )
-    envelope, unreadable = sniff_file_envelope_status(str(path))
+    envelope, unreadable, capped = sniff_file_envelope_status(str(path))
     assert envelope == "unrecognised"
     assert unreadable is False
+    assert capped is False
     assert sniff_file_envelope(str(path)) == "unrecognised"

--- a/tests/test_sniff_envelope_unreadable_478.py
+++ b/tests/test_sniff_envelope_unreadable_478.py
@@ -38,9 +38,10 @@ def test_missing_file_is_unrecognised_and_flagged_unreadable(tmp_path):
     shape.
     """
     missing = str(tmp_path / "does-not-exist.jsonl")
-    envelope, unreadable = sniff_file_envelope_status(missing)
+    envelope, unreadable, capped = sniff_file_envelope_status(missing)
     assert envelope == "unrecognised"
     assert unreadable is True
+    assert capped is False
     # Old call site's contract is unchanged.
     assert sniff_file_envelope(missing) == "unrecognised"
 
@@ -56,9 +57,10 @@ def test_permission_denied_file_is_flagged_unreadable(tmp_path):
     path.write_text('{"type": "user"}\n', encoding="utf-8")
     path.chmod(0)
     try:
-        envelope, unreadable = sniff_file_envelope_status(str(path))
+        envelope, unreadable, capped = sniff_file_envelope_status(str(path))
         assert envelope == "unrecognised"
         assert unreadable is True
+        assert capped is False
     finally:
         path.chmod(stat.S_IWUSR | stat.S_IRUSR)
 
@@ -71,9 +73,10 @@ def test_a_readable_but_shapeless_file_is_not_flagged_unreadable(tmp_path):
     """
     path = tmp_path / "shapeless.jsonl"
     path.write_text('{"nothing": "recognisable"}\n', encoding="utf-8")
-    envelope, unreadable = sniff_file_envelope_status(str(path))
+    envelope, unreadable, capped = sniff_file_envelope_status(str(path))
     assert envelope == "unrecognised"
     assert unreadable is False
+    assert capped is False
 
 
 def test_an_empty_file_is_not_flagged_unreadable(tmp_path):
@@ -83,6 +86,7 @@ def test_an_empty_file_is_not_flagged_unreadable(tmp_path):
     """
     path = tmp_path / "empty.jsonl"
     path.write_text("", encoding="utf-8")
-    envelope, unreadable = sniff_file_envelope_status(str(path))
+    envelope, unreadable, capped = sniff_file_envelope_status(str(path))
     assert envelope == "unrecognised"
     assert unreadable is False
+    assert capped is False


### PR DESCRIPTION
Closes #556.

`sniff_file_envelope_status()` in `pipeline/extract.py` folded #543's 50-line scan cap into the same `unreadable=False` return that genuine exhaustion reaches, so a transcript whose scan gave up at the cap was indistinguishable from one that was fully read. `pipeline/haiku.py`'s fallback warning ("could not identify the host from transcript ... (unreadable or an unrecognised shape)") then enumerated two causes for a return value that could also be produced by a third.

## What changed

- `sniff_file_envelope_status()` now returns a 3-tuple `(envelope, unreadable, capped)` instead of `(envelope, unreadable)`. Every existing caller (`pipeline/extract.py:extract_session`, `pipeline/haiku.py:_choose_summarizer_provider`, and three test files) was updated to unpack all three values -- checked with a repo-wide grep, nothing else touches this tuple.
- `pipeline/types.py`'s `ExtractResult` gets a new `envelope_capped: bool = False` field, additive, following the same pattern as the existing `envelope_unreadable`/`unread_sidecar_unreadable` fields (no current consumer -- the signal is on the bridge for a future one, same shape as #458/#478 took).
- `pipeline/shell.py` prints a new additive `ENVELOPE_CAPPED=0|1` line, same convention as `ENVELOPE_UNREADABLE`.
- `pipeline/haiku.py`'s fallback warning now names the cap specifically ("gave up after scanning too many unplaceable lines") instead of lumping it under "an unrecognised shape".
- Docstrings on `sniff_file_envelope_status()`, `sniff_file_envelope()`, `ExtractResult.envelope_unreadable`, and `cmd_extract()`'s `Prints:` list were updated to describe the new 3-way split.
- New test file `tests/test_sniff_envelope_capped_556.py`, plus updates to `tests/test_sniff_envelope_scan_forward_543.py` and `tests/test_sniff_envelope_unreadable_478.py` for the new tuple arity.
- Changelog fragment `changelog.d/556.fixed.md`, checked against `.oss/assemble_changelog.py --check`.

## Self-review fix

The `Explore` reviewer caught a real off-by-one at the exact scan-cap boundary: a file whose unplaceable-line count landed *exactly* on `_ENVELOPE_SNIFF_SCAN_CAP` and then ended was reported `capped=True` even though the scan had genuinely exhausted the whole file -- no line was ever left unread. Fixed by peeking one line past the cap before deciding (`next(f, None) is not None`); a dedicated boundary test pins it, verified red before the fix and green after.

## Below-bar

`pipeline/shell.py`'s `ENVELOPE_UNREADABLE` print line (added under #478) has no dedicated shell-level test, and the new `ENVELOPE_CAPPED` line follows the identical pattern -- untested at that layer. This matches pre-existing convention rather than introducing a new gap, and neither key has a consumer yet, so it did not seem worth a new test file for one print statement in this PR. Flagging in case a maintainer disagrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)