### PR TITLE
Record trap.d entry for #554: agy plugin validate ok over total absence

### DIFF
--- a/changelog.d/554.added.md
+++ b/changelog.d/554.added.md
@@ -1,0 +1,7 @@
+- Added: a `trap.d` entry for issue #554, recording that Antigravity CLI (`agy`)
+  1.1.26's `plugin validate` prints the same `[ok]` top-line verdict, exit code `0`,
+  whether it resolved every plugin component or all five came back
+  `skipped (not found)`. This is upstream behaviour in a third-party CLI, not a bug in
+  this repo -- nothing in the plugin itself changed -- so the entry exists to make sure
+  a future claim about Antigravity plugin support in this repo is checked against the
+  per-component detail lines rather than against the verdict or the exit code alone.

--- a/changelog.d/554.fixed.md
+++ b/changelog.d/554.fixed.md
@@ -1,0 +1,7 @@
+- Fixed: recorded a trap.d entry for issue #554 -- Antigravity CLI (`agy`) 1.1.26's
+  `plugin validate` prints the same `[ok]` top-line verdict, exit code `0`, whether it
+  resolved every plugin component or all five came back `skipped (not found)`. This is
+  upstream behaviour in a third-party CLI, not a bug in this repo, so nothing in the
+  plugin itself changed; the fragment exists so a future claim about Antigravity
+  plugin support in this repo is checked against the per-component detail lines
+  rather than against the verdict or the exit code alone.

--- a/changelog.d/554.fixed.md
+++ b/changelog.d/554.fixed.md
@@ -1,7 +1,0 @@
-- Fixed: recorded a trap.d entry for issue #554 -- Antigravity CLI (`agy`) 1.1.26's
-  `plugin validate` prints the same `[ok]` top-line verdict, exit code `0`, whether it
-  resolved every plugin component or all five came back `skipped (not found)`. This is
-  upstream behaviour in a third-party CLI, not a bug in this repo, so nothing in the
-  plugin itself changed; the fragment exists so a future claim about Antigravity
-  plugin support in this repo is checked against the per-component detail lines
-  rather than against the verdict or the exit code alone.

--- a/trap.d/554.agy-plugin-validate-ok-over-total-absence.md
+++ b/trap.d/554.agy-plugin-validate-ok-over-total-absence.md
@@ -1,0 +1,36 @@
+While probing Antigravity CLI (`agy`) 1.1.26 as a candidate host (#553), pointing
+`agy plugin validate` at this repo's `.claude-plugin/` directory -- which contains
+only `plugin.json`, no `skills/`, `agents/`, `commands/`, `mcpServers` config or
+`hooks/` -- produced:
+
+```
+$ agy plugin validate .claude-plugin
+  [ok]    .claude-plugin
+          - skills      : skipped (not found)
+          - agents      : skipped (not found)
+          - commands    : skipped (not found)
+          - mcpServers  : skipped (not found)
+          - hooks       : skipped (not found)
+```
+
+All five component types the tool checks for came back `skipped (not found)`, and the
+top-line verdict is `[ok]`, coloured green, exit code `0`. A directory that resolved
+zero components validates identically to one that resolved every component correctly
+-- the verdict carries no signal that anything was actually found, only that nothing
+checked came back an error.
+
+This is the same failure shape this project already treats as its worst case for its
+own memory capture -- something that ran and produced a clean result while saving
+nothing -- reproduced here in someone else's tool rather than this one. The
+generalizable rule: a validator's top-line verdict can be a claim about what it
+*checked* rather than about what it *found*. When a tool reports `skipped` counts
+sitting right next to an `[ok]`, the `skipped` count is the actual reading, and the
+verdict above it is not derived from them. Any future claim in this repo about
+Antigravity plugin support has to read the per-component detail lines -- never the
+top-line verdict, and never the exit code alone, since both render identically whether
+the plugin loaded five components or zero.
+
+Filed as issue #554. Not fixable in this repo -- `agy` is a third-party CLI -- and not
+reported upstream from here (no channel was looked for). Recorded so nobody in this
+project later cites a green `agy plugin validate` run, or its `0` exit code, as
+evidence that an Antigravity install actually loaded anything.


### PR DESCRIPTION
Adds a trap.d fragment documenting an upstream finding from #554: Antigravity CLI (`agy`) 1.1.26's `plugin validate` prints the same `[ok]` top-line verdict, exit code `0`, whether every plugin component resolved or all five came back `skipped (not found)`. This is upstream behaviour in a third-party CLI -- not fixable in this repo -- and #554 says so explicitly. Recorded as `trap.d/554.agy-plugin-validate-ok-over-total-absence.md`, quoting the issue's own transcript rather than re-running the probe (no `agy` install available or attempted here), and stating the generalizable rule: a validator's top-line verdict can be a claim about what it *checked*, not about what it *found* -- read the per-component detail lines, never the verdict or the exit code alone.

Also adds `changelog.d/554.added.md` per this repo's changelog-fragment convention.

## No code changed

Documentation-only: two new files under `trap.d/` and `changelog.d/`, nothing else touched. No test in this repo governs `trap.d/` structure or naming (`grep -rl 'trap.d' tests/ scripts/` found nothing), so there is no red/green TDD cycle to report for this change -- confirmed rather than assumed. `README.md` was checked and does not reference `trap.d/` or Antigravity anywhere, so no docs update was needed there.

## A judgment call worth naming: does this discharge #554

This PR files the trap.d entry #554's own body suggests as its next step, but #554 states two purposes for the finding: (1) recording the trap so future work reads the per-component detail lines instead of the top-line verdict, and (2) standing as a live caution ("so nobody in this project later cites a green `agy plugin validate` as evidence"). The first is a one-time deliverable this PR completes. The second is arguably a standing property of the repo's own future behaviour, not something a single commit discharges by existing. This PR deliberately does not use a closing keyword for #554 -- whether recording the trap fully accounts for what the issue asked for, or whether it should stay open as a live caution until something else references it (e.g. a jit-context rule via `/oss:curate`), is left as the maintainer's call at merge time. Referenced above as #554, no closing keyword bound.

## Self-review: one finding argued down, one fixed

Two reviewers ran against the committed diff (Explore + oss:auditor). The auditor returned `NO FINDINGS` across its full checklist (classified `no-findings` by `review_return.py`). Explore returned `FINDINGS: 2` (classified `states-findings`):

1. *Argued down* -- claimed this repo's convention is that a pure trap.d-only PR gets no changelog fragment at all, citing two prior trap.d-only commits (`fe45493` for #539, `51f38c6` for #543) that shipped without one. Checked both citations against their actual merge history: neither is a standalone trap-only PR -- both are sub-commits riding inside larger PRs (`#539`/`#542`, `#543`) that already carried their own changelog fragment for the real code change in that PR, under the "one file per pull request" rule. No genuine precedent for a standalone trap.d-only PR either way was found in this repo's history. This lane's own brief already explicitly weighed and decided this question ("the changelog is required regardless ... a trap.d addition is exactly the kind of change a reader of the changelog would want to see named"), so the fragment stays, argued down rather than fixed.

2. *Fixed* -- the changelog fragment was labelled `Fixed:` while its own body said "nothing in the plugin itself changed," a real self-contradiction. Renamed `changelog.d/554.fixed.md` to `changelog.d/554.added.md` and reworded to "Added: a `trap.d` entry ...", which matches the actual content. Re-verified with `python3 .oss/assemble_changelog.py --check` after the rename (passes, 3 fragments).

Full reviewer exchange and precedent-checking detail: see the session note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bv6BGZD2EdZ9EuJ7tPDTb7