### PR TITLE
Fix: declare a SessionEnd timeout so Claude Code does not cancel the flush before it forks

### DIFF
--- a/changelog.d/560.fixed.md
+++ b/changelog.d/560.fixed.md
@@ -1,0 +1,16 @@
+- Fixed: `hooks/hooks.json`'s `SessionEnd` entry now declares `"timeout": 10`
+  -- Claude Code's SessionEnd budget defaults to 1.5 seconds shared across
+  every hook registered for that event, and `session-end-hook.sh`'s own
+  synchronous preamble (path resolution, tool detection, directory
+  bootstrap) was measured at roughly 3.4 seconds on a slow Windows/Git-Bash
+  machine, well past that budget -- Claude Code logged `Hook cancelled` and
+  the session's flush never ran, leaving `logs/autonomous/` with no
+  `session-end-*.log` for that session (#560). The hook body itself is
+  unchanged: it already forks the real flush into the background and
+  returns as soon as it has forked. Declaring `timeout` is the correct
+  thing to do, but Claude Code's own hooks reference is explicit that
+  timeouts declared on a plugin-provided hook (this one) do not raise that
+  shared SessionEnd budget the way a timeout declared in a settings file
+  does -- see [docs/hooks.md](docs/hooks.md) for the documented workaround
+  (`CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS`) if `Hook cancelled` still
+  appears after this change.

--- a/changelog.d/560.fixed.md
+++ b/changelog.d/560.fixed.md
@@ -13,4 +13,10 @@
   shared SessionEnd budget the way a timeout declared in a settings file
   does -- see [docs/hooks.md](docs/hooks.md) for the documented workaround
   (`CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS`) if `Hook cancelled` still
-  appears after this change.
+  appears after this change. The manual-install `.claude/settings.json`
+  snippet in [docs/install-claude-code.md](docs/install-claude-code.md) also
+  now declares `"timeout": 10` on its `SessionEnd` entry -- unlike a
+  plugin-provided hook, a timeout declared in a settings file *does* raise
+  the shared budget per the same reference, so that install route is fully
+  fixed by this change with no workaround needed (self-review finding,
+  #560).

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -59,3 +59,5 @@ export CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS=10000
 
 (10 seconds, matching the `timeout` this hook declares; the reference caps the SessionEnd budget at 60000 regardless of what any hook or this variable asks for.) Making this hook's own preamble fast enough to finish inside the *default* 1.5s budget — rather than asking for a longer one — is a larger change (it touches the shared detection/resolution scripts every hook sources, not just this one) and is tracked separately rather than folded into this fix.
 
+A manual install (registering these hooks yourself in your project's `.claude/settings.json`, per [docs/install-claude-code.md](docs/install-claude-code.md)) is not subject to the plugin carve-out above: that snippet's `SessionEnd` entry declares `"timeout": 10` too, and a timeout declared in a settings file *is* one Claude Code's own reference says raises the shared budget. That is the one install route where declaring `timeout` is a complete fix on its own, with no `CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS` fallback needed.
+

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -49,3 +49,13 @@ A flush failure (missing `python3`, a Haiku call that errors, or — since [#369
 
 A store that could never be created at all (a read-only or otherwise unwritable project root) is a narrower case than a flush failure — there is no `hook-errors.log` to write to, because the directory that would hold it is the one that failed. That one warning goes to this hook's own stderr instead ([#372](https://github.com/Digital-Process-Tools/claude-remember/issues/372)); it will not show up in `/remember:doctor`.
 
+**`SessionEnd` shares a 1.5-second budget across every hook registered for that event, and this hook can miss it before it ever reaches the fork ([#560](https://github.com/Digital-Process-Tools/claude-remember/issues/560)).** The Claude Code hooks reference (checked 2026-09, "SessionEnd" / "Timeouts") documents that budget, and one reporter measured this hook's own synchronous preamble — `lib-clock.sh`, `resolve-paths.sh`, `detect-tools.sh`'s python/jq detection, `bootstrap-dirs.sh`, `log.sh` — at roughly 3.4 seconds on a slow Windows/Git-Bash machine, well past 1.5s, with Claude Code logging `Hook cancelled` and no `session-end-*.log` ever appearing. `hooks/hooks.json` now declares `"timeout": 10` on this hook, which is the correct, harmless thing to declare — but the same reference is explicit that **"Timeouts set on plugin-provided hooks don't raise the budget."** This hook ships as `hooks/hooks.json` inside a plugin, exactly the location that clause names, so on an install where Claude Code enforces that carve-out, declaring `timeout` here does not, by itself, raise the effective 1.5s ceiling.
+
+If your own `session-end-*.log` files are still missing and your terminal still shows `Hook cancelled` after upgrading past this fix, the plugin genuinely cannot raise the SessionEnd budget on your behalf — set it yourself with the environment variable the same reference documents:
+
+```bash
+export CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS=10000
+```
+
+(10 seconds, matching the `timeout` this hook declares; the reference caps the SessionEnd budget at 60000 regardless of what any hook or this variable asks for.) Making this hook's own preamble fast enough to finish inside the *default* 1.5s budget — rather than asking for a longer one — is a larger change (it touches the shared detection/resolution scripts every hook sources, not just this one) and is tracked separately rather than folded into this fix.
+

--- a/docs/install-claude-code.md
+++ b/docs/install-claude-code.md
@@ -81,7 +81,8 @@ The first command decodes the whole catalogue and filters it down to this plugin
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/remember/scripts/session-end-hook.sh"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/remember/scripts/session-end-hook.sh",
+            "timeout": 10
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -35,7 +35,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/session-end-hook.sh\""
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/session-end-hook.sh\"",
+            "timeout": 10
           }
         ]
       }

--- a/tests/test_session_end_timeout_560.py
+++ b/tests/test_session_end_timeout_560.py
@@ -1,0 +1,89 @@
+"""SessionEnd hook must declare a per-hook `timeout` in hooks/hooks.json (#560).
+
+Claude Code's SessionEnd budget defaults to 1.5 seconds, shared across every
+hook registered for that event (Claude Code hooks reference, "Timeouts",
+checked 2026-09). session-end-hook.sh forks its real flush into the
+background and returns immediately once it has forked -- but the synchronous
+preamble before that fork (lib-clock.sh, resolve-paths.sh, detect-tools.sh's
+python/jq detection, bootstrap-dirs.sh, log.sh) was measured at ~3.4s on a
+reporter's Windows/Git-Bash machine (#560), well past the 1.5s budget, so
+Claude Code cancelled the hook before it ever reached the fork. Declaring a
+`timeout` on the hook *asks* Claude Code to raise that shared budget to match.
+
+IMPORTANT CAVEAT the fix does not fully resolve (documented in the pull
+request and the docs update, not re-litigated in this test): the same
+reference states "Timeouts set on plugin-provided hooks don't raise the
+budget" -- and this hook ships as `hooks/hooks.json` inside a plugin, exactly
+the location that clause names. Declaring `timeout` here is still correct
+practice (it is honored by settings-file-registered copies of this hook, and
+does no harm here even where the plugin-budget carve-out applies), but it is
+not, by itself, a load-bearing fix for a plugin install -- see the docs
+update and the changelog fragment for the actionable remedy
+(CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS). This test only pins the one thing
+this diff can enforce mechanically: the manifest declares a timeout.
+
+The bar: would this test still pass if hooks.json were left unchanged? No --
+today's manifest has no `timeout` key anywhere, so this fails for the right
+reason (KeyError / missing field) before the fix, and passes once
+`"timeout": 10` is added to the SessionEnd entry.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOKS_JSON = REPO_ROOT / "hooks" / "hooks.json"
+
+
+def _session_end_hooks():
+    data = json.loads(HOOKS_JSON.read_text())
+    groups = data["hooks"]["SessionEnd"]
+    for group in groups:
+        yield from group.get("hooks", [])
+
+
+def test_session_end_hook_declares_a_sane_timeout():
+    """Every SessionEnd command hook must declare a numeric `timeout` field.
+
+    Sane window: more than the reporter's measured ~3.4s (so it is not a
+    no-op) and no more than 60s (the documented ceiling Claude Code will
+    ever raise the SessionEnd budget to, per the same reference).
+    """
+    hooks = list(_session_end_hooks())
+    assert hooks, "no SessionEnd command hooks found -- test/manifest drifted"
+    for hook in hooks:
+        assert "timeout" in hook, (
+            f"SessionEnd hook {hook.get('command')!r} declares no `timeout` -- "
+            f"Claude Code cancels SessionEnd hooks at a 1.5s default budget "
+            f"(#560), and this hook's own preamble was measured well past "
+            f"that on a slow Windows/Git-Bash machine"
+        )
+        timeout = hook["timeout"]
+        assert isinstance(timeout, (int, float)) and not isinstance(timeout, bool), (
+            f"SessionEnd hook timeout must be numeric, got {timeout!r}"
+        )
+        assert 3.4 < timeout <= 60, (
+            f"SessionEnd hook timeout={timeout!r} is not in the sane window "
+            f"(>3.4s measured preamble cost, <=60s documented ceiling)"
+        )
+
+
+def test_only_session_end_declares_a_timeout():
+    """Other hook events already get a 600s (or 30s for UserPromptSubmit)
+    default per the same reference -- a `timeout` field only belongs on the
+    one event whose shared default (1.5s) is too tight for this plugin's own
+    hook to reliably fork its background flush inside.
+    """
+    data = json.loads(HOOKS_JSON.read_text())
+    for event, groups in data["hooks"].items():
+        if event == "SessionEnd":
+            continue
+        for group in groups:
+            for hook in group.get("hooks", []):
+                assert "timeout" not in hook, (
+                    f"{event} hook {hook.get('command')!r} declares a "
+                    f"`timeout` -- that event does not share SessionEnd's "
+                    f"tight 1.5s default and does not need one"
+                )


### PR DESCRIPTION
Closes #560

Claude Code's SessionEnd hook budget defaults to 1.5 seconds, shared across every hook registered for that event. `session-end-hook.sh` already forks its real flush (`save-session.sh --force`) into the background and returns as soon as it has forked, but its synchronous preamble -- `lib-clock.sh`, `resolve-paths.sh`, `detect-tools.sh`'s python/jq detection, `bootstrap-dirs.sh`, `log.sh` -- was measured at roughly 3.4 seconds on a reporter's slow Windows/Git-Bash machine, well past that budget. Claude Code cancelled the hook (`Hook cancelled`) before it ever reached the fork, and no `session-end-*.log` was ever written for that session.

`hooks/hooks.json`'s `SessionEnd` entry now declares `"timeout": 10`. A new test, `tests/test_session_end_timeout_560.py`, pins that the manifest declares a sane numeric timeout on `SessionEnd`, and only `SessionEnd` -- the other three events (`SessionStart`, `UserPromptSubmit`, `PostToolUse`) already default to a 600s (30s for `UserPromptSubmit`) budget per Claude Code's own hooks reference and do not need one.

**A real caveat, verified against Claude Code's current hooks reference (checked 2026-09) rather than taken on faith from the issue:** the reference states outright that "Timeouts set on plugin-provided hooks don't raise the budget," and this hook ships as `hooks/hooks.json` inside a plugin -- exactly the location that clause names, distinct from `~/.claude/settings.json` / `.claude/settings.json` / `.claude/settings.local.json`, which the same reference calls "settings files." Declaring `timeout` here is still correct practice and harmless, but on an install where Claude Code enforces that carve-out it will not, by itself, raise the effective 1.5s ceiling for a plugin install. `docs/hooks.md` documents this plainly and gives the actual working remedy for that case: set `CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS` yourself, since a plugin cannot set it on your behalf.

Self-review (an `Explore` reviewer and `oss:auditor`, spawned against the first commit) caught that `docs/install-claude-code.md`'s manual-install `.claude/settings.json` snippet -- the one install route where a declared timeout genuinely *does* raise the shared budget, per the same reference -- had not been updated. A follow-up commit adds `"timeout": 10` there too, so that route is now completely fixed with no workaround needed. **Below the intake bar, recorded here rather than filed:** the reviewer separately flagged that labelling this `Fixed:` in the changelog might overclaim for plugin installs specifically, since the plugin-provided declaration may be a no-op there; I judged the label correct because the hedge is stated in the very next sentence of both the changelog fragment and docs/hooks.md, and a real defect (the missing declaration) really is fixed as far as a plugin manifest can fix it.

Making `session-end-hook.sh`'s own preamble fast enough to finish inside the *default* 1.5s budget -- rather than asking Claude Code for a longer one -- is a larger change touching the shared detection/resolution scripts every hook in this plugin sources, and is intentionally left out of this fix rather than folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)