### PR TITLE
Port Remember capture to Antigravity CLI (agy): SessionStart, PreInvocation, Stop (#563)

### DIFF
--- a/.claude/jit-context/vocabulary/02-hosts/antigravity-hooks.md
+++ b/.claude/jit-context/vocabulary/02-hosts/antigravity-hooks.md
@@ -1,39 +1,44 @@
 ---
-title: "Antigravity CLI (agy) hooks are not Claude Code hooks"
-description: "agy reads a name-keyed hooks.json with a different schema, fails a Claude-shaped file silently, and Gemini CLI is no longer reachable at all on a free-tier individual account."
+title: "Antigravity CLI (agy) hooks: schema, firing, and the port that uses it"
+description: "agy 1.1.27 accepts a name-keyed hooks.json with event-keyed handler arrays, fires four events (SessionStart/PreInvocation/PostInvocation/Stop) confirmed live, and Gemini CLI is no longer reachable at all on a free-tier individual account. #563 ports Remember's capture onto this; see docs/install-antigravity.md."
 keywords: antigravity, agy, gemini cli, hooks json, fourth host, jsonhook
 ---
 
 Measured on macOS darwin/arm64, `agy` 1.1.27, 2026-09-05. Nothing here is claimed for other
-platforms or other versions -- this area changes release to release.
+platforms or other versions -- this area changes release to release, and already changed twice
+between 1.1.26 and 1.1.27 in this repo's own investigation (#553).
 
-## The schema is name-keyed, not event-keyed
+## The schema is name-keyed AND event-keyed, one layer removed from Claude Code's
+
+**This corrects an earlier version of this entry**, which showed a `name -> {events: [...]}`
+shape (a single flat `events` list per name, reverse-engineered from `strings -a` on the binary)
+and reported that `PostToolUse`/`Stop` load but never fire against it. That shape and that finding
+are both superseded (#553's own last comment, #563): the schema `agy` 1.1.27 actually accepts, and
+under which all four events below were observed firing, is a hook **name** mapping to an object
+whose keys are **event names**, each holding an **array of handler objects** -- Claude Code's own
+shape one level down, not a flat `events` list at all:
 
 ```json
 {
-  "probe_all": {
+  "remember": {
     "enabled": true,
-    "type": "command",
-    "events": ["SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse",
-               "Stop", "PostInvocation", "SessionEnd"],
-    "matcher": "*",
-    "command": "bash /abs/path/probe.sh fired",
-    "timeout": 20
+    "SessionStart": [ { "type": "command", "command": "bash /abs/path/probe.sh SessionStart", "timeout": 30 } ],
+    "PreInvocation": [ { "type": "command", "command": "bash /abs/path/probe.sh PreInvocation", "timeout": 30 } ]
   }
 }
 ```
 
-Top level is `name -> spec`. The spec's fields are `events` (a list), `matcher`, `command`, `type`,
-`timeout`, `enabled` -- recoverable from the binary with
-`strings -a ~/.local/bin/agy | grep -E 'json:"(events?|matcher|command|timeout|enabled)"'`.
-
-Claude Code's shape -- an event key holding an array of matcher objects -- **does not parse**:
+Claude Code's own shape -- an event key holding an array of matcher objects, at the TOP level
+rather than nested one layer under a hook name -- still does not parse at all:
 
 ```
 hooks_manager.go:33] failed to parse hooks.json at ~/.gemini/config/hooks.json:
 json: cannot unmarshal array into Go struct field .SessionStart of type jsonhook.JSONHookSpec
 hooks_manager.go:53] loaded 0 named hooks from 1 hooks.json file(s)
 ```
+
+An unrecognised *event* inside an otherwise valid file is dropped the same silent way: the
+`/hooks` listing simply prints fewer rows than the file declares, with no warning.
 
 **That error reaches stdout nowhere.** `agy -p "/hooks" --output-format json` answers
 `{"hooks":[]}` -- identical to having no file. The only witness is
@@ -45,41 +50,46 @@ grep -ih hook ~/.gemini/antigravity-cli/cli.log | tail -6
 
 `loaded N named hooks` is the line that says whether the file was understood.
 
-## Registered is not fired
+## Firing is confirmed for four events; three more are visible in the log but never delivered
 
-`/hooks` lists the hook `enabled: true`, the log says `loaded N named hooks`, and **the hook does
-not run**. Observed on 1.1.27, with tools proven to have executed in the same turn.
-
-| turn | tool ran? | hook loaded? | hook fired? |
-| --- | --- | --- | --- |
-| no-tool print turn, 7 events declared | no | `loaded 1 named hooks` | no |
-| `--dangerously-skip-permissions`, "run: echo hi" | **unproven** -- no tool line in the log | yes | no |
-| `--dangerously-skip-permissions`, "create /tmp/agy-proof.txt", `matcher: "*"` | yes -- file created | yes | no |
-| same, **matcher field removed**, events `PostToolUse` and `Stop` | yes -- two tools | `loaded 2 named hooks` | **no** |
-
-The last row settles it. The log names the tools it auto-approved:
-
-```
-tool_confirmation_manager.go:170] Always-proceed: auto-approving tool confirmation "WriteToFile" at step 2
-tool_confirmation_manager.go:170] Always-proceed: auto-approving tool confirmation "ViewFile" at step 4
-```
-
-Two tools ran, both hooks were loaded, no matcher could discard anything, and the hook's log file
-stayed 0 bytes. `PostToolUse` and `Stop` do not fire from `~/.gemini/config/hooks.json`.
-
-**Prove the tool call by its side effect, never by the reply.** The "run: echo hi" row above looked
-like a passing test and was worthless -- the model answered `DONE` and the log carries no tool line.
-`create the file /tmp/agy-proof.txt` leaves evidence that does not depend on what the assistant said.
-
-Not ruled out: the binary carries a `CustomizationConfig.GetEnableJsonHooks` flag, so execution may
-be gated behind an experiment -- inference from a symbol name, not a measurement. Also untested:
-the workspace-local `<workspace>/.agents/hooks.json` path, which may load through different code.
+`SessionStart`, `PreInvocation`, `PostInvocation` and `Stop` all fired on a single print-mode turn
+under the corrected schema above -- no tool call, no `--dangerously-skip-permissions` needed for
+any of the four. `PreToolUse`/`PostToolUse` do not even LOAD under this schema (silently dropped,
+same as any unrecognised event); `UserPromptSubmit`/`SessionEnd`/`Notification`/`turn-completion`
+load under some schema variants but were never observed to fire. **Prove firing by a side effect,
+never by the reply** -- "run: echo hi, then say DONE" produced a `DONE` with an empty hook log and
+no tool line anywhere, which looked like a pass and proved nothing; `create the file
+/tmp/agy-proof.txt` (or append a fixed line to a fixed path) leaves evidence that does not depend
+on what the assistant said. `#563`'s port (`docs/install-antigravity.md`) is the live consumer of
+this: `scripts/agy-session-start-hook.sh`, `scripts/agy-pre-invocation-hook.sh` and
+`scripts/agy-stop-hook.sh`.
 
 `--dangerously-skip-permissions` is honoured in print mode -- the log says
 `Print mode: --dangerously-skip-permissions set, auto-approving all tool permissions` -- but the
 Claude Code auto-mode classifier refuses that flag, including refusing to write it into a script.
 It is a human-run test, and a long pasted command wraps in the terminal and silently eats its own
-`-p` argument; keep the line short.
+`-p` argument; keep the line short. Not needed for any of the four events actually ported.
+
+## A firing hook's own STDOUT is parsed as protojson against `agy`'s schema, not read as text
+
+Delegating a `SessionStart`/`PreInvocation` handler straight to a Claude Code-shaped hook script
+(plain-text context injection, or a `{"hookSpecificOutput": ...}` stdout envelope) makes `agy` log
+`failed to unmarshal result from hook ... via protojson: proto: syntax error (line 1:1): invalid
+value =` (or `unknown field "hookSpecificOutput"`) on **every single invocation** -- confirmed
+live, #563. `agy` does not treat a command hook's stdout as opaque context the way Claude Code
+does; it tries to decode it as its own structured result. A hook command that has nothing
+Antigravity-shaped to say should discard its own stdout (`>/dev/null`) rather than let a Claude
+Code-formatted envelope reach the parser.
+
+## A backgrounded save must survive the hook process exiting, and `workspacePaths` needs `--add-dir`
+
+A plain `( cmd & )` backgrounded from inside a command hook did not survive the hook process
+exiting under a real `agy` run -- no trace of the backgrounded command ever starting, across
+repeated live probes, even though the hook itself exited 0. `nohup cmd & disown` (the same defence
+already used elsewhere in a hook script that backgrounds work) does survive. Separately,
+`workspacePaths` on the `SessionStart`/`Stop` stdin payload is `[]` for a bare `cd <dir> && agy -p
+...` -- it is populated only by an explicit `agy ... --add-dir <dir>`, confirmed by running both
+forms back to back from the same directory.
 
 ## Paths
 

--- a/changelog.d/563.added.antigravity-port.md
+++ b/changelog.d/563.added.antigravity-port.md
@@ -1,0 +1,46 @@
+- Added: a working port of this plugin's memory capture onto Antigravity CLI
+  (`agy`), covering `SessionStart`, `UserPromptSubmit` (Antigravity's
+  `PreInvocation`, which fires per model invocation rather than per user
+  prompt) and, for `SessionEnd`, an idempotent per-turn flush on
+  Antigravity's `Stop` -- deliberately NOT the one-shot `session-end-hook.sh`
+  itself, since `Stop` fires after every turn and treating it as a teardown
+  is the exact failure mode manaflow-ai/cmux#5000 already documents.
+  `pipeline/host.py` gained an `ANTIGRAVITY` host (a real, live-captured
+  `ANTIGRAVITY_CONVERSATION_ID` signature) and an `antigravity_exchange()`
+  reader for Antigravity's own flat transcript shape
+  (`{"step_index","source","type","content"}`), so `pipeline/extract.py`
+  now understands a third transcript envelope end to end. Install with
+  `python3 scripts/install_agy_hooks.py`, which merges Remember's entry into
+  the shared, per-machine `~/.gemini/config/hooks.json` without disturbing
+  any other plugin's own entry there -- no static manifest is checked in,
+  because nothing observed on Antigravity sets a plugin-root or
+  project-dir variable a checked-in file could rely on.
+
+  Three defects were found and fixed only by driving this against a real
+  `agy` process, none visible from a transcript-parsing unit test alone:
+  Antigravity's hook executor fails to protojson-parse a Claude Code-shaped
+  hook stdout (context injection / a `hookSpecificOutput` envelope), a
+  plain backgrounded save did not survive the hook process exiting (needed
+  `nohup` + `disown`), and the backgrounded `save-session.sh` had no stdin
+  of its own to resolve `PROJECT_DIR` from (now forwarded from
+  Antigravity's own `workspacePaths`, itself populated only via `agy
+  --add-dir`, not by a bare process `cwd`). See docs/install-antigravity.md
+  for the full account, and the updated
+  `.claude/jit-context/vocabulary/02-hosts/antigravity-hooks.md` for the
+  corrected hooks.json schema and firing evidence, which superseded an
+  earlier, wrong schema and a "PostToolUse/Stop never fire" finding that
+  turned out to be an artifact of that wrong schema, not of the host.
+
+  Not found: any genuine Antigravity session-end signal -- of the four
+  events confirmed loading and firing, none is a process-exit or
+  conversation-close event, so a long session that never re-crosses the
+  minimum-human-messages threshold before the process exits has no
+  equivalent of the last-chance `SessionEnd --force` flush Claude Code and
+  Codex both get. Reported as an open gap, not worked around (#563,
+  superseding #553).
+
+  Self-review also caught and fixed: `scripts/install_agy_hooks.py`
+  originally treated an existing `~/.gemini/config/hooks.json` it could not
+  parse the same as a genuinely absent one, silently discarding whatever
+  other plugin's hook entries were in it on the next write. It now raises
+  `CorruptHooksFile` and writes nothing rather than guessing.

--- a/changelog.d/563.added.antigravity-port.md
+++ b/changelog.d/563.added.antigravity-port.md
@@ -44,3 +44,9 @@
   parse the same as a genuinely absent one, silently discarding whatever
   other plugin's hook entries were in it on the next write. It now raises
   `CorruptHooksFile` and writes nothing rather than guessing.
+
+  `tests/test_agy_hooks_563.py` is now triaged in `docs/windows-skip-triage.md`
+  (#497's own meta-guard, `tests/test_windows_skip_triage_497.py`, requires
+  every win32 blanket-skip module to carry an entry) -- `unclear`, same
+  templated reason and verdict as the sibling hook-subprocess test modules
+  it is modelled on.

--- a/docs/install-antigravity.md
+++ b/docs/install-antigravity.md
@@ -1,0 +1,74 @@
+# Installing under Antigravity CLI (agy)
+
+Observed against `agy` 1.1.27 (macOS darwin/arm64), not only reasoned from the docs -- every claim below that is not marked REASONED was driven end to end against a real `agy` process, in the same session that wrote this port (#563, building on #553's own investigation).
+
+## Antigravity has no per-plugin manifest
+
+`agy plugin install` copies a plugin's own `hooks.json` into `~/.gemini/config/plugins/<name>/`, counts it (`✔ hooks : 1 processed`), marks the plugin `enabled: true` -- and never loads it (#553). The only two paths `agy` actually loads hooks from are the shared `~/.gemini/config/hooks.json` (every plugin on the machine) and the untested workspace-local `<workspace>/.agents/hooks.json`. This repo does not ship a static manifest for either path, unlike `hooks/hooks.codex.json` or `.gemini/hooks/hooks.json`: neither path supports the kind of variable this repo could check into git and have resolve on another machine (see below), so there is nothing stable to check in. Install with:
+
+```
+python3 scripts/install_agy_hooks.py
+```
+
+which merges a "remember" entry into `~/.gemini/config/hooks.json`, preserving every other top-level hook name already there -- the file is shared, not this plugin's alone. `--target PATH` overrides the location (mainly for testing); `--dry-run` prints the merged document without writing it. If the existing file cannot be parsed as a JSON object at all (a hand edit gone wrong, a half-written file from a concurrent process), the installer refuses and writes nothing rather than treating "cannot parse" as "nothing here" and silently discarding whatever other plugin's entries were in it.
+
+## The schema is name-keyed, and no variable resolves inside it
+
+`agy` 1.1.27 accepts a hook name mapping to an object keyed by event, each holding an array of handler objects:
+
+```json
+{
+  "remember": {
+    "enabled": true,
+    "SessionStart": [ { "type": "command", "command": "bash /abs/path/scripts/agy-session-start-hook.sh", "timeout": 30 } ]
+  }
+}
+```
+
+Claude Code's own shape -- an event key holding an array of matcher objects -- does not parse at all, and the failure is invisible: `agy -p "/hooks" --output-format json` answers `{"hooks":[]}`, byte-identical to having no file; the only witness is `~/.gemini/antigravity-cli/cli.log` (`hooks_manager.go`'s `failed to parse hooks.json` / `loaded 0 named hooks`). See `.claude/jit-context/vocabulary/02-hosts/antigravity-hooks.md` for the full trap.
+
+**Every command is a literal, already-resolved absolute path.** Nothing observed on Antigravity sets a plugin-root or project-dir environment variable (`pipeline/host.py`'s `ANTIGRAVITY` host declares neither, confirmed by dumping a live hook process's own environment -- `tests/fixtures/antigravity-env-563.txt`), and Gemini CLI's own `${extensionPath}` substitution is documented as extension-local only, which the shared, non-extension `~/.gemini/config/hooks.json` is not. `scripts/install_agy_hooks.py` resolves the real path at install time instead of shipping a manifest with a placeholder that would never expand.
+
+## The mapping (re-derived against 1.1.27, corrects #553's own earlier framing)
+
+| Remember captures on | Antigravity analogue | wired to |
+| --- | --- | --- |
+| `SessionStart` | `SessionStart` (same name; carries `transcriptPath` at session open) | `scripts/agy-session-start-hook.sh` -> `session-start-hook.sh` |
+| `UserPromptSubmit` | `PreInvocation` (fires per model invocation, **not** per user prompt) | `scripts/agy-pre-invocation-hook.sh` -> `user-prompt-hook.sh` |
+| `Stop` | `Stop` (a **turn boundary**, not a teardown -- see below) | `scripts/agy-stop-hook.sh` (does NOT delegate to `session-end-hook.sh`) |
+| `SessionEnd` | **no analogue found** -- see below | not wired |
+
+`PostInvocation` is confirmed to load and fire too, but nothing in this plugin has a use for it (no `PostToolUse`-shaped work to do with it), so it is deliberately left out of the installed manifest.
+
+Every adapter script renames Antigravity's own field names (`conversationId`, `transcriptPath`, `workspacePaths`) into the shape the delegate script already understands (`session_id`, `transcript_path`, `cwd`) rather than teaching the delegate scripts a second payload shape -- the same "existing scripts only" discipline #410 held the Codex manifest to, one layer removed: here the SHAPE differs, not just the event name, so a thin renaming adapter was unavoidable.
+
+## `Stop` fires after every turn -- it is not wired to `session-end-hook.sh`
+
+manaflow-ai/cmux#5000 (cited in #563) is the expensive way to learn this: treating a restorable agent's turn-end as a session end destroyed their restore record after the first turn. `session-end-hook.sh` is built to run exactly once, at the actual end of a session, and does backup/consolidation work on that assumption -- repeating it on every turn boundary would be wrong in the same way. `scripts/agy-stop-hook.sh` does not source or call it.
+
+Instead it does what `post-tool-hook.sh` already does safely many times a session: ask `save-session.sh` (without `--force`) to flush if there is anything new and the cooldown has elapsed. `save-session.sh`'s own cooldown and lock (`mkdir`, timeout 0 on a plain call) make a repeated call a safe, silent no-op when there is nothing to do -- confirmed live: a single print-mode turn (one human message) correctly logged `1 human msgs < 3, skip` rather than saving prematurely.
+
+**No genuine session-end signal was found.** Of the four events confirmed loading and firing (`SessionStart`, `PreInvocation`, `PostInvocation`, `Stop`), none is a process-exit or conversation-close event -- `Stop` fires after every turn including the first. This is reported as an open gap, not silently worked around: a long Antigravity conversation that never has three human turns before the process exits (or exceeds the cooldown one final time) has no equivalent of Claude Code's last-chance `SessionEnd --force` flush. Whether Antigravity has such a signal at all -- a process-exit hook, a `conversationId`-scoped finalize event -- was not found in `agy changelog` or in Google's own published hooks docs at 1.1.27, and neither source is exhaustive.
+
+## Three live defects found and fixed while driving this against a real `agy` process
+
+None of these three is visible from a `pipeline/host.py`/`pipeline/extract.py` unit test alone -- they are properties of the hook-process composition, and were only found by actually running `agy` against the installed manifest and reading `~/.gemini/antigravity-cli/cli.log` and the target workspace's own `.remember/logs/`, never by trusting a hook's exit code.
+
+1. **Antigravity's hook executor parses a command hook's STDOUT as protojson against its own schema, not Claude Code's.** Delegating straight to `session-start-hook.sh` (plain-text `=== REMEMBER ===` context injection) and `user-prompt-hook.sh` (a `{"hookSpecificOutput": ...}` envelope) made `agy` log `failed to unmarshal result from hook jsonhook__remember_SessionStart_0_0 via protojson: proto: syntax error (line 1:1): invalid value =` and the equivalent `unknown field "hookSpecificOutput"` for `PreInvocation`, on every single invocation. Fixed by discarding the delegate's stdout in both adapters (`>/dev/null`) -- context injection through hook stdout is a Claude Code-specific mechanism this port does not attempt (#563's own scope is capture, not context injection), and no Antigravity-native equivalent contract is documented to target instead.
+2. **A plain backgrounded subshell did not survive the hook process exiting.** `agy-stop-hook.sh` originally launched `save-session.sh` with `( bash ... & )`; across repeated live probes, no trace of it ever starting appeared in the target workspace's own memory log, even though the parent hook exited 0. Fixed with `nohup ... &` + `disown`, the exact defence `post-tool-hook.sh` and `session-end-hook.sh` already use for their own backgrounded saves -- Antigravity's own hook executor appears to reap a command hook's process group more aggressively than Claude Code's did.
+3. **`save-session.sh` has no stdin of its own to resolve `PROJECT_DIR` from when launched this way**, and FATALs loudly (`Cannot resolve project root`) if `CLAUDE_PROJECT_DIR`/`REMEMBER_HOOK_CWD` are both unset -- a FATAL the `nohup ... >/dev/null 2>&1` redirect above was silently swallowing until caught by running the hook by hand with output not redirected. Fixed by forwarding Antigravity's own `workspacePaths[0]` as `CLAUDE_PROJECT_DIR` in `agy-stop-hook.sh`, the same field `agy-session-start-hook.sh` already forwards as `cwd`.
+
+## `workspacePaths` is populated only by `--add-dir`, not by process `cwd`
+
+Running `agy -p "..."` from inside a directory does **not** put that directory in the `SessionStart`/`Stop` payload's `workspacePaths` array -- it stays `[]`, confirmed by comparing a bare `cd <dir> && agy -p ...` against the same command with `--add-dir <dir>` appended. Without a workspace path, `agy-session-start-hook.sh` and `agy-stop-hook.sh` have no `cwd`/`CLAUDE_PROJECT_DIR` to forward, and `resolve-paths.sh` FATALs. A real Antigravity session run interactively (rather than via `-p`) may add the working directory automatically -- not established here, print mode only.
+
+## End-to-end capture, observed live
+
+A real `agy -p "reply with exactly: X" --add-dir <workspace>` turn correctly fired `SessionStart`, `PreInvocation`, and `Stop` (in that order, per `~/.gemini/antigravity-cli/cli.log`), bootstrapped `<workspace>/.remember/`, and `save-session.sh`'s own extraction step read the real `transcriptPath` Antigravity handed the `Stop` hook and reported `2 exchanges (1 human)` -- matching the turn exactly (`[HUMAN] reply with exactly: X`, `[AGENT] X`, confirmed via `--dry`) -- then correctly skipped the actual save because one human turn is below the default `min_human_messages: 3` threshold. That skip is the CORRECT behaviour for `Stop` firing after a single turn, not a defect: it is the same threshold every other host's incremental save already respects, and it is what makes calling `save-session.sh` (without `--force`) safe to do on every `Stop`.
+
+## Not established
+
+- **Whether Antigravity has any genuine session-end signal at all** -- see above.
+- **Whether `<workspace>/.agents/hooks.json` (workspace-local, needing the folder trusted) loads through the same code path** as the shared file -- untested, per `.claude/jit-context/vocabulary/02-hosts/antigravity-hooks.md`.
+- **`PreToolUse`/`PostToolUse`** -- confirmed unstable/unavailable on 1.1.27 (do not parse under the current schema; fired once, denying every tool call, on `agy` 1.0.5 per manaflow-ai/cmux#5358). Not built on; if this plugin's `PostToolUse` capture has a real Antigravity analogue, it is not this one.
+- **Everything above is macOS darwin/arm64, `agy` 1.1.27, this session, 2026-09-05.** Nothing here is claimed for Linux, Windows, or any other `agy` version -- the schema alone changed twice between 1.1.26 and 1.1.27 (#553), and could change again.

--- a/docs/windows-skip-triage.md
+++ b/docs/windows-skip-triage.md
@@ -16,7 +16,7 @@ converted (`tests/test_hook_cwd_leak_417.py`, `tests/test_transcript_path_leak_4
 plus a fifth, `tests/test_autonomous_log_retention_487.py`, which adopted the
 same route for its own #487 rather than being converted by #432 itself.
 
-## The count: 97, not 107 (and not the issue's original 92)
+## The count: 98, not 107 (and not the issue's original 92)
 
 The issue's own re-verified count -- `grep -rl "pytestmark = pytest.mark.skipif"
 tests | xargs grep -l "win32"` -- returns 107 on this tree. That command only
@@ -36,7 +36,7 @@ parses every test module with `ast`, and only counts a file that has an
 actual module-level `pytestmark = pytest.mark.skipif(<expr containing
 "win32">, reason=...)` assignment -- a bare call, or one arm of a
 list/tuple of marks (pytest ORs a list, so any one arm mentioning "win32"
-is a real blanket skip). That finds **97** modules on this tree at this
+is a real blanket skip). That finds **98** modules on this tree at this
 commit. `tests/test_windows_skip_triage_497.py` recomputes this same set
 on every run and diffs it against the table below, so this list cannot
 silently drift out of sync with the tree the way the issue itself describes
@@ -55,7 +55,7 @@ once already during review.
   path-format incompatibility. 12 modules.
 - **unclear** -- the reason string alone does not say enough to tell; reading
   it is not the same as reading the test body, and this list is deliberately
-  not that read. 77 modules.
+  not that read. 78 modules.
 
 **A blind spot in the scanner itself, caught once already.** An earlier
 version of `scripts/windows_skip_triage_497.py` only matched a bare
@@ -71,7 +71,7 @@ what the AST matcher was written to recognize, not by an exhaustive read of
 every skip expression in `tests/`.
 
 **The `unclear` majority is the honest result, not a shortcut.** The great
-bulk of these 97 reasons is one of a handful of near-identical templated
+bulk of these 98 reasons is one of a handful of near-identical templated
 strings -- `"bash subprocess + POSIX layout -- not portable to Windows
 runners"`, `"bash hook subprocess + POSIX semantics -- not portable to
 Windows runners"`, and near-variants -- that bundle the one thing
@@ -92,6 +92,7 @@ verdict is the useful artifact").
 
 | module | skip reason | verdict | basis |
 | --- | --- | --- | --- |
+| `tests/test_agy_hooks_563.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate -- same templated reason and same verdict as test_session_end_hook_345.py, test_post_tool_hook_spawns.py and test_prompt_hook_spawns.py, which this module's own three subprocess tests are modelled on |
 | `tests/test_bootstrap_readonly_root.py` | POSIX mode bits + bash — read-only enforcement is not portable to NTFS (#79) | not-convertible | names a specific POSIX-only primitive (permissions/signals/fork/flock/umask/NTFS/path-format) that Git-Bash discovery cannot supply |
 | `tests/test_capture_gap_notice.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |
 | `tests/test_case_divergence_298.py` | bash hook subprocess + POSIX semantics — not portable to Windows runners (#79) | unclear | reason bundles the bash-subprocess dependency with an unspecified "POSIX semantics/layout" claim; cannot tell from the string alone whether that names a real non-bash blocker or is boilerplate |

--- a/pipeline/extract.py
+++ b/pipeline/extract.py
@@ -2,10 +2,11 @@
 
 Reads a session JSONL file, filters out metadata and system messages, and
 produces formatted text with role-labeled exchanges suitable for
-summarization by Haiku. Two transcript envelopes are understood -- Claude
-Code's and Codex's -- via ``sniff_file_envelope()`` and the per-host
-adapters in ``pipeline/host.py`` (#443); a third, unrecognised, shape is
-reported rather than silently read as an empty session.
+summarization by Haiku. Three transcript envelopes are understood -- Claude
+Code's, Codex's, and Antigravity's (`agy`, #563) -- via
+``sniff_file_envelope()`` and the per-host adapters in ``pipeline/host.py``
+(#443); an "unrecognised" shape is reported rather than silently read as an
+empty session.
 
 Supports incremental extraction (only new messages since last save) and
 full extraction (all messages or last N).
@@ -498,11 +499,11 @@ def extract_messages(path: str, skip_lines: int = 0, envelope: str = "claude-cod
             incremental extraction after a previous save).
         envelope: Which host wrote this transcript -- "claude-code" (the
             default, and the only shape this function understood before
-            #443), "codex", or "unrecognised". Callers determine this once
-            per file via ``sniff_file_envelope()``, independent of
-            ``skip_lines``, and pass it through here; a per-line resniff
-            would misfire on a resume that starts past the file's only
-            self-identifying line.
+            #443), "codex", "antigravity" (#563), or "unrecognised".
+            Callers determine this once per file via
+            ``sniff_file_envelope()``, independent of ``skip_lines``, and
+            pass it through here; a per-line resniff would misfire on a
+            resume that starts past the file's only self-identifying line.
 
     Returns:
         List of ``("HUMAN", text)`` or ``("AGENT", text)`` tuples,
@@ -535,6 +536,12 @@ def extract_messages(path: str, skip_lines: int = 0, envelope: str = "claude-cod
 
             if envelope == "codex":
                 exchange = _host.codex_exchange(obj)
+                if exchange is not None:
+                    messages.append(exchange)
+                continue
+
+            if envelope == "antigravity":
+                exchange = _host.antigravity_exchange(obj)
                 if exchange is not None:
                     messages.append(exchange)
                 continue

--- a/pipeline/host.py
+++ b/pipeline/host.py
@@ -1,7 +1,15 @@
 """Which agent CLI is hosting this plugin, and what it tells us (#407).
 
 Remember was written against one host and reads that host's environment
-directly. Three now exist, and they agree on far less than they appear to:
+directly. Four now exist, and they agree on far less than they appear to.
+The table below covers the first three, which at least share field NAMES on
+their hook stdin (`session_id`/`cwd`/`transcript_path`) even where the
+VALUES differ; Antigravity (`agy`, #563, `ANTIGRAVITY` below) does not fit
+this table at all -- its stdin payload uses entirely different field names
+(`conversationId`/`workspacePaths`/`transcriptPath`), which is why its own
+adapter scripts (`scripts/agy-*-hook.sh`) rename the payload before handing
+it to the same hook scripts these three hosts already share, rather than
+teaching this module a fourth column here:
 
     | | Claude Code | Codex | Gemini CLI |
     |---|---|---|---|
@@ -147,6 +155,28 @@ CODEX = Host(
 # arrives on stdin regardless.
 GEMINI = Host(name="gemini-cli", project_dir_vars=("CLAUDE_PROJECT_DIR",))
 
+# Antigravity CLI (`agy`), #563 (superseding the "does anything fire" question
+# #553 closed as resolved-into-#563). Neither a plugin-root nor a project-dir
+# variable is declared: nothing in agy 1.1.27's own hook stdin payload or in a
+# live hook process's environment names either kind of path (confirmed by
+# dumping `env` from inside a real firing hook -- see
+# tests/fixtures/antigravity-env-563.txt), unlike Codex's PLUGIN_ROOT alias or
+# Gemini's CLAUDE_PROJECT_DIR alias above. Declaring one here on the strength
+# of a plausible name alone would be exactly the #463 mistake (CODEX_HOME) one
+# host over.
+#
+# ANTIGRAVITY_CONVERSATION_ID IS a real signature, though: unlike CODEX_HOME,
+# it was found by dumping a live hook process's own environment, not read off
+# a doc page or guessed from a binary's string table, and a second probe run
+# with a fresh conversation confirmed the value changes per invocation rather
+# than being some ambient leftover.
+ANTIGRAVITY = Host(
+    name="antigravity",
+    plugin_root_vars=(),
+    project_dir_vars=(),
+    signature_vars=("ANTIGRAVITY_CONVERSATION_ID",),
+)
+
 # The fallback. Not an error: a host we do not recognise still delivers the
 # payload, and the payload is the part that matters.
 UNKNOWN = Host(name="unknown", plugin_root_vars=(), project_dir_vars=())
@@ -188,7 +218,7 @@ UNKNOWN = Host(name="unknown", plugin_root_vars=(), project_dir_vars=())
 # longer wired to the one decision it used to gate. If a consumer that needs
 # env-based host identification is ever added back, this is the point to
 # revisit AMBIGUOUS, not before.
-REGISTRY: tuple[Host, ...] = (CLAUDE_CODE, CODEX)
+REGISTRY: tuple[Host, ...] = (CLAUDE_CODE, CODEX, ANTIGRAVITY)
 
 # Every plugin-root variable any known host uses, in registry precedence order,
 # de-duplicated. scripts/resolve-paths.sh mirrors this list by hand and
@@ -254,11 +284,11 @@ def sniff_envelope(obj: object) -> str:
     the envelope it is deciding is still a property of the whole session
     file -- one host wrote it start to finish -- not of any one line.
 
-    Returns ``"claude-code"``, ``"codex"``, or ``"unrecognised"``. The third
-    state matters as much as the first two: a transcript shape this module
-    does not know is reported loud rather than silently parsed as though it
-    held zero exchanges, which is indistinguishable from a genuinely quiet
-    session (#443).
+    Returns ``"claude-code"``, ``"codex"``, ``"antigravity"`` (#563), or
+    ``"unrecognised"``. The last of those matters as much as the first
+    three: a transcript shape this module does not know is reported loud
+    rather than silently parsed as though it held zero exchanges, which is
+    indistinguishable from a genuinely quiet session (#443).
     """
     if not isinstance(obj, dict):
         return "unrecognised"
@@ -269,6 +299,18 @@ def sniff_envelope(obj: object) -> str:
         return "codex"
     if isinstance(obj.get("message"), dict) or obj.get("type") in ("user", "assistant", "summary", "system"):
         return "claude-code"
+    # Antigravity CLI (`agy`, #563): a flat per-step object, never nested --
+    # `{"step_index", "source", "type", "content"}`, `content` a plain
+    # string. `step_index` and `source` together are the marker: neither
+    # Claude Code's nor Codex's line shape uses either key, and `content` as
+    # a bare string (rather than Claude Code's `message.content`, which can
+    # itself be a string OR a block list) rules out a coincidental collision.
+    if (
+        "step_index" in obj
+        and "source" in obj
+        and isinstance(obj.get("content"), str)
+    ):
+        return "antigravity"
     return "unrecognised"
 
 
@@ -315,6 +357,41 @@ def codex_exchange(obj: dict) -> tuple[str, str] | None:
     if not texts:
         return None
     return role, "\n".join(texts)
+
+
+# Antigravity's own step `type` values that map to a message this plugin
+# should capture (#563). Everything else -- a future tool-call or reasoning
+# step, or any type this investigation never saw -- is None, deliberately:
+# PreToolUse/PostToolUse are out of scope here (see the #563 issue body), and
+# guessing a role for an unrecognised type is the same mistake codex_exchange
+# above already refuses to make for an unrecognised item_completed item.
+_ANTIGRAVITY_STEP_ROLES = {
+    "USER_INPUT": "HUMAN",
+    "PLANNER_RESPONSE": "AGENT",
+}
+
+
+def antigravity_exchange(obj: dict) -> tuple[str, str] | None:
+    """``(role, text)`` for one Antigravity transcript step, or ``None`` to skip it.
+
+    Antigravity's `transcript_full.jsonl` (`.system_generated/logs/` under
+    the conversation's `artifactDirectoryPath`) is a flat per-step object --
+    ``{"step_index", "source", "type", "status", "created_at", "content"}``
+    -- captured live from a real `agy -p ... --output-format text` print-mode
+    turn, `agy` 1.1.27, macOS darwin/arm64, this session, 2026-09-05
+    (tests/fixtures/antigravity-transcript-563.jsonl). Only ``USER_INPUT``
+    and ``PLANNER_RESPONSE`` are known to occur; every other ``type`` this
+    investigation observed is none, because no tool-calling turn was driven
+    (see the #563 issue body's probing rule -- that needs
+    ``--dangerously-skip-permissions``, a human-run test).
+    """
+    role = _ANTIGRAVITY_STEP_ROLES.get(obj.get("type"))
+    if role is None:
+        return None
+    content = obj.get("content")
+    if not isinstance(content, str) or not content.strip():
+        return None
+    return role, content
 
 
 def transcript_path(env: Mapping[str, str] | None = None) -> str | None:

--- a/scripts/agy-pre-invocation-hook.sh
+++ b/scripts/agy-pre-invocation-hook.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# ============================================================================
+# agy-pre-invocation-hook.sh — Antigravity CLI (agy) PreInvocation adapter (#563)
+# ============================================================================
+#
+# DESCRIPTION
+#   Antigravity's PreInvocation is this plugin's SessionStart-adjacent
+#   mid-session bookkeeping point -- see the #563 issue body's own mapping
+#   table (UserPromptSubmit -> PreInvocation). It fires per MODEL
+#   INVOCATION, not per user prompt: a turn that makes several invocations
+#   fires this several times. user-prompt-hook.sh already tolerates being
+#   called more than its Claude Code name implies (Codex's own
+#   UserPromptSubmit binding shares this script unchanged, #410), so no new
+#   throttling was added here -- if the extra firings prove too frequent in
+#   practice that is a follow-up, not something to guess at now.
+#
+#   user-prompt-hook.sh reads only `cwd` from its own stdin (everything else
+#   it needs comes from cached environment or is deliberately cleared, see
+#   its own "REMEMBER_TRANSCRIPT_PATH" section) -- so the rename this adapter
+#   does is intentionally the smallest one in this port: `workspacePaths[0]`
+#   (Antigravity) -> `cwd` (Claude Code shape), nothing else.
+#
+# STDIN
+#   The PreInvocation JSON payload agy hands the hook, consumed here in full
+#   and re-emitted (renamed, not reinterpreted) to user-prompt-hook.sh's own
+#   stdin.
+#
+# ENVIRONMENT
+#   CLAUDE_PLUGIN_ROOT is exported here for the same reason
+#   agy-session-start-hook.sh exports it -- see that script's own comment.
+#
+# DEPENDENCIES
+#   python3, user-prompt-hook.sh
+#
+# EXIT CODES
+#   0   Always -- user-prompt-hook.sh's own contract; see its own comment on
+#       why a hook that runs on every invocation must never block one.
+#
+# ============================================================================
+
+set -e
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export CLAUDE_PLUGIN_ROOT="$(dirname "$_SCRIPT_DIR")"
+
+_STDIN=$(cat)
+_NORMALIZED=$(printf '%s' "$_STDIN" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    d = {}
+workspace_paths = d.get("workspacePaths") or []
+out = {"cwd": workspace_paths[0] if workspace_paths else ""}
+print(json.dumps(out))
+' 2>/dev/null) || _NORMALIZED="{}"
+
+# Discard the delegate's stdout for the same reason
+# agy-session-start-hook.sh does -- confirmed live (#563):
+# user-prompt-hook.sh's Claude Code-shaped `{"hookSpecificOutput": ...}`
+# stdout envelope made agy log "failed to unmarshal result ... via protojson:
+# ... unknown field \"hookSpecificOutput\"" for every PreInvocation.
+printf '%s' "$_NORMALIZED" | bash "$_SCRIPT_DIR/user-prompt-hook.sh" >/dev/null

--- a/scripts/agy-session-start-hook.sh
+++ b/scripts/agy-session-start-hook.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# ============================================================================
+# agy-session-start-hook.sh — Antigravity CLI (agy) SessionStart adapter (#563)
+# ============================================================================
+#
+# DESCRIPTION
+#   Antigravity's SessionStart stdin payload uses different field names from
+#   Claude Code's -- {"conversationId", "transcriptPath", "modelName",
+#   "artifactDirectoryPath", "workspacePaths"} vs {"session_id",
+#   "transcript_path", "cwd", "source", ...} -- so this rewrites the payload
+#   into the shape session-start-hook.sh already understands and delegates to
+#   it unchanged. #563's own scope is a port, not new hook code: the same
+#   "existing scripts only" discipline #410 held the Codex manifest to.
+#
+#   `source` is synthesized as "startup": Antigravity's own SessionStart
+#   payload carries nothing equivalent to Claude Code's resume/clear/compact/
+#   fork distinction (confirmed against a live capture, #563), and
+#   session-start-hook.sh already treats an unrecognised/empty `source` as a
+#   safe default rather than a special case, so "startup" costs nothing here
+#   and is the closest real match: an Antigravity SessionStart fires once
+#   per conversation, at its beginning.
+#
+# STDIN
+#   The SessionStart JSON payload agy hands the hook, consumed here in full
+#   and re-emitted (renamed, not reinterpreted) to session-start-hook.sh's
+#   own stdin.
+#
+# ENVIRONMENT
+#   CLAUDE_PLUGIN_ROOT is exported here, not read from the process
+#   environment: agy does not set it, nor any plugin-root-shaped variable
+#   (pipeline/host.py's ANTIGRAVITY host declares none, confirmed by dumping
+#   a live hook process's own environment, #563), and the shared
+#   ~/.gemini/config/hooks.json this hook installs into has no
+#   extension-scoped ${extensionPath} the way a linked Gemini extension
+#   does -- that substitution is documented as extension-local only. This
+#   script's own location on disk IS one directory below the plugin root, so
+#   it derives CLAUDE_PLUGIN_ROOT from itself (BASH_SOURCE) rather than
+#   depend on a variable no host is known to supply here.
+#
+# DEPENDENCIES
+#   python3 (renaming the payload; already a hard dependency of every other
+#   hook script in this plugin), session-start-hook.sh
+#
+# EXIT CODES
+#   0   Always -- see session-start-hook.sh's own contract; this adapter
+#       never blocks a session on a rename failure, it just hands through an
+#       empty object and lets the delegate's own defaults take over.
+#
+# ============================================================================
+
+set -e
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export CLAUDE_PLUGIN_ROOT="$(dirname "$_SCRIPT_DIR")"
+
+_STDIN=$(cat)
+_NORMALIZED=$(printf '%s' "$_STDIN" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    d = {}
+workspace_paths = d.get("workspacePaths") or []
+out = {
+    "session_id": d.get("conversationId", ""),
+    "transcript_path": d.get("transcriptPath", ""),
+    "cwd": workspace_paths[0] if workspace_paths else "",
+    "source": "startup",
+}
+print(json.dumps(out))
+' 2>/dev/null) || _NORMALIZED="{}"
+
+# Antigravity's hook executor parses a command hook's STDOUT as protojson
+# against its OWN structured-output schema, not Claude Code's -- confirmed
+# live (#563): session-start-hook.sh's plain-text "=== REMEMBER ===" context
+# injection made agy log "failed to unmarshal result ... via protojson:
+# proto: syntax error (line 1:1): invalid value =" for every SessionStart.
+# Context injection through hook stdout is a Claude Code-specific mechanism
+# this issue does not attempt to port (#563's own scope is capture, not
+# context injection) and Antigravity's own docs describe no equivalent
+# contract this plugin could target instead, so the delegate's stdout is
+# discarded here rather than guessed at.
+printf '%s' "$_NORMALIZED" | bash "$_SCRIPT_DIR/session-start-hook.sh" >/dev/null

--- a/scripts/agy-stop-hook.sh
+++ b/scripts/agy-stop-hook.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# ============================================================================
+# agy-stop-hook.sh — Antigravity CLI (agy) Stop adapter (#563)
+# ============================================================================
+#
+# DESCRIPTION
+#   Antigravity's Stop fires at the end of EVERY turn/invocation -- it is a
+#   turn boundary, not a teardown. manaflow-ai/cmux#5000 (cited in #563)
+#   documents the expensive way to learn this: treating a restorable agent's
+#   turn-end as a session end destroyed their restore record after the
+#   FIRST turn. Wiring this straight into session-end-hook.sh -- which is
+#   built to run exactly ONCE, at the actual end of a session, and does
+#   backup/consolidation work on that assumption -- would repeat whatever
+#   one-shot work that script does on every single turn boundary. This
+#   script deliberately does NOT do that, and does not import or source
+#   session-end-hook.sh at all.
+#
+#   Instead it does what post-tool-hook.sh already does safely many times a
+#   session: ask save-session.sh (WITHOUT --force) to flush if there is
+#   anything new and its own cooldown has elapsed. save-session.sh's cooldown
+#   and lock (mkdir, timeout 0 on a plain call) make a call that finds
+#   nothing new -- or loses a race to a concurrent save -- a safe, silent
+#   no-op; see save-session.sh's own "Cooldown" and "Lock" sections for why
+#   that call is idempotent to repeat. That is what makes THIS script safe
+#   to run on every turn, unlike session-end-hook.sh's own
+#   cleanup/consolidation, which is not idempotent against running once per
+#   turn and is why this script exists as a separate, smaller thing rather
+#   than a Stop binding straight to that script.
+#
+#   What this script does NOT attempt: genuine session-end semantics (the
+#   final archiving/consolidation session-end-hook.sh performs once a real
+#   session actually ends). No Antigravity signal observed so far
+#   corresponds to a real teardown -- Stop fires after every turn including
+#   the first, and of the four events #553/#563 confirmed loading and firing
+#   (SessionStart, PreInvocation, PostInvocation, Stop), none is a
+#   process-exit or conversation-close event. That gap is left open and
+#   reported (see the #563 changelog entry and docs/install-antigravity.md),
+#   not silently worked around by reusing Stop for a purpose it does not fit.
+#
+# STDIN
+#   The Stop JSON payload agy hands the hook: {"conversationId",
+#   "transcriptPath", "terminationReason", "fullyIdle", "executionNum",
+#   "error", ...}. Only `conversationId` and `transcriptPath` are read here.
+#
+# ENVIRONMENT
+#   CLAUDE_PLUGIN_ROOT is exported here for the same reason
+#   agy-session-start-hook.sh exports it -- see that script's own comment.
+#
+#   REMEMBER_TRANSCRIPT_PATH is exported fresh from this hook's own stdin
+#   payload, the same trusted-input contract session-start-hook.sh and
+#   session-end-hook.sh already follow (#407, #431) -- pipeline/host.py's
+#   find_session() returns it verbatim, before any session-id-based
+#   reconstruction is attempted, which is what lets a bare `conversationId`
+#   (not a Claude Code session UUID, not a path under any conventional
+#   sessions directory) work as save-session.sh's positional session id at
+#   all: that argument is only ever used for locking/position-file naming
+#   once REMEMBER_TRANSCRIPT_PATH is set, never to locate the file itself.
+#
+# DEPENDENCIES
+#   python3, save-session.sh
+#
+# EXIT CODES
+#   0   Always -- a missing conversationId/transcriptPath is treated as
+#       nothing to do, not a failure; this hook must never block a turn.
+#
+# ============================================================================
+
+set -e
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export CLAUDE_PLUGIN_ROOT="$(dirname "$_SCRIPT_DIR")"
+
+_STDIN=$(cat)
+_FIELDS=$(printf '%s' "$_STDIN" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    d = {}
+workspace_paths = d.get("workspacePaths") or []
+print(d.get("conversationId", ""))
+print(d.get("transcriptPath", ""))
+print(workspace_paths[0] if workspace_paths else "")
+' 2>/dev/null) || _FIELDS=""
+
+_CONVERSATION_ID=$(printf '%s\n' "$_FIELDS" | sed -n 1p)
+_TRANSCRIPT_PATH=$(printf '%s\n' "$_FIELDS" | sed -n 2p)
+_WORKSPACE_PATH=$(printf '%s\n' "$_FIELDS" | sed -n 3p)
+
+if [ -z "$_CONVERSATION_ID" ] || [ -z "$_TRANSCRIPT_PATH" ]; then
+    exit 0
+fi
+
+export REMEMBER_TRANSCRIPT_PATH="$_TRANSCRIPT_PATH"
+# save-session.sh is not itself registered as a hook here (only this
+# adapter is), so it has no stdin payload of its own to resolve PROJECT_DIR
+# from -- resolve-paths.sh needs CLAUDE_PROJECT_DIR (or REMEMBER_HOOK_CWD)
+# set some other way, or it FATALs and loud-exits (caught live, #563: the
+# background call below was silently losing that FATAL to its own
+# /dev/null redirect, so nothing ever appeared in the target workspace's
+# memory log -- confirmed by running this hook by hand with output NOT
+# redirected). Antigravity's own `workspacePaths` is the only project-root
+# signal this payload carries, the same field agy-session-start-hook.sh
+# already forwards as `cwd` -- forwarded here as CLAUDE_PROJECT_DIR
+# directly, since this script calls save-session.sh, not a hook script that
+# derives it from a stdin `cwd` field itself.
+if [ -n "$_WORKSPACE_PATH" ]; then
+    export CLAUDE_PROJECT_DIR="$_WORKSPACE_PATH"
+fi
+# nohup + disown, not a bare backgrounded subshell -- confirmed live (#563):
+# a plain `( ... & )` never survived past this hook process exiting under a
+# real `agy` run (no trace of save-session.sh ever having started, not even
+# its own cooldown-skip log line, across repeated live probes), the same
+# defence post-tool-hook.sh already applies for its own backgrounded save
+# (scripts/post-tool-hook.sh's own `nohup "$SAVE_SCRIPT" ... &`) and
+# session-end-hook.sh applies via its trailing `disown`. Antigravity's own
+# hook executor appears to reap a command hook's process group more
+# aggressively than Claude Code's did, which this failed silently against
+# until caught by checking the target workspace's own memory log rather
+# than trusting the hook's exit code alone.
+nohup bash "$_SCRIPT_DIR/save-session.sh" "$_CONVERSATION_ID" >/dev/null 2>&1 &
+disown 2>/dev/null || true
+exit 0

--- a/scripts/install_agy_hooks.py
+++ b/scripts/install_agy_hooks.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""install_agy_hooks.py -- merge Remember's Antigravity (agy) hooks into the
+shared ~/.gemini/config/hooks.json (#563).
+
+Antigravity has no per-plugin hook manifest: a plugin's own bundled
+hooks.json is copied into ~/.gemini/config/plugins/<name>/, counted, and
+never loaded (#553). The only paths `agy` actually loads hooks from are
+`~/.gemini/config/hooks.json` (shared, every plugin on the machine) and the
+untested workspace-local `<workspace>/.agents/hooks.json`. This script
+writes the shared one.
+
+It also has no working variable substitution inside that shared file: agy
+sets no plugin-root or project-dir environment variable
+(pipeline/host.py's ANTIGRAVITY host declares neither -- confirmed by
+dumping a live hook process's own environment, #563), and the
+${extensionPath} substitution Gemini CLI extensions get is documented as
+extension-local only, which a shared, non-extension file is not. So every
+command has to be a literal, already-resolved absolute path -- there is no
+manifest this script could check into git and have work unmodified on
+another machine, unlike hooks/hooks.codex.json or .gemini/hooks/hooks.json.
+This script exists to build and merge that literal manifest at install
+time instead.
+
+The target is a file every plugin on the machine may already be using, so a
+merge here touches only this plugin's own top-level hook name ("remember")
+and leaves every other key alone -- see test_merge_preserves_other_top_level_hook_names_563.
+
+USAGE
+    python3 scripts/install_agy_hooks.py [--target PATH] [--dry-run]
+
+    --target PATH   Defaults to ~/.gemini/config/hooks.json.
+    --dry-run       Print the merged JSON; do not write anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+DEFAULT_TARGET = os.path.expanduser("~/.gemini/config/hooks.json")
+
+# #563's own scope: SessionStart, PreInvocation and Stop are the events this
+# plugin has an adapter script and a design for (see the three
+# scripts/agy-*.sh comments). PostInvocation is confirmed to load and fire
+# too (#553's final comment), but nothing here has a use for it yet -- it is
+# left out on purpose, not omitted by oversight.
+_EVENT_SCRIPTS = {
+    "SessionStart": "agy-session-start-hook.sh",
+    "PreInvocation": "agy-pre-invocation-hook.sh",
+    "Stop": "agy-stop-hook.sh",
+}
+
+_TIMEOUT_SECONDS = 30
+
+
+def build_remember_entry(plugin_root: str) -> dict:
+    """The "remember" -> spec object this plugin owns in the shared file.
+
+    Every command is a literal absolute path built from ``plugin_root`` --
+    no ${VAR} placeholder, because nothing observed on Antigravity would
+    expand one (see the module docstring).
+    """
+    plugin_root = os.path.abspath(plugin_root)
+    entry: dict = {"enabled": True}
+    for event, script_name in _EVENT_SCRIPTS.items():
+        script_path = os.path.join(plugin_root, "scripts", script_name)
+        entry[event] = [
+            {
+                "type": "command",
+                "command": f'bash "{script_path}"',
+                "timeout": _TIMEOUT_SECONDS,
+            }
+        ]
+    return entry
+
+
+class CorruptHooksFile(Exception):
+    """Raised when ``target`` exists but cannot be read as a JSON object.
+
+    Deliberately NOT the same outcome as a genuinely absent file (#563
+    review finding): the shared hooks.json may hold another plugin's real
+    hook entries that a parser error just could not reach -- a hand edit
+    with a trailing comma, a half-written file from a concurrent process,
+    disk corruption. Treating "cannot parse" the same as "nothing here
+    yet" silently discards whatever else was in it the moment
+    ``install()`` writes back, with no warning and no way to recover it.
+    An absent file has nothing to lose; a corrupt one might. install()
+    refuses rather than guessing, and leaves the file untouched.
+    """
+
+
+def _load_existing(target: str) -> dict | None:
+    """The rest of the shared file, or {} for a genuinely absent one.
+
+    Returns ``None`` (never partial/guessed data) if ``target`` exists but
+    is not a parseable JSON object -- ``install()`` turns that into
+    ``CorruptHooksFile`` rather than silently coercing it to ``{}``. Only a
+    missing file (``FileNotFoundError``) is treated as "nothing here yet".
+    """
+    try:
+        with open(target, encoding="utf-8") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def install(plugin_root: str, target: str = DEFAULT_TARGET) -> dict:
+    """Merge this plugin's Antigravity hooks into ``target``, in place.
+
+    Returns the full merged document (for --dry-run and for tests), and
+    also writes it unless the caller only wanted the dry-run value -- see
+    main() below for that split.
+
+    Raises ``CorruptHooksFile`` -- and writes NOTHING -- if ``target``
+    exists but cannot be read as a JSON object; see that exception's own
+    docstring for why this is not the same case as an absent file.
+    """
+    data = _load_existing(target)
+    if data is None:
+        raise CorruptHooksFile(
+            f"{target} exists but is not a parseable JSON object -- refusing to "
+            "overwrite it (it may hold another plugin's real hook entries). "
+            "Inspect and fix or remove it by hand, then re-run this installer."
+        )
+    data["remember"] = build_remember_entry(plugin_root)
+    os.makedirs(os.path.dirname(os.path.abspath(target)) or ".", exist_ok=True)
+    with open(target, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
+    return data
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", default=DEFAULT_TARGET)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    plugin_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+    if args.dry_run:
+        existing = _load_existing(args.target)
+        if existing is None:
+            print(f"ERROR: {args.target} exists but is not a parseable JSON object", file=sys.stderr)
+            return 1
+        existing["remember"] = build_remember_entry(plugin_root)
+        print(json.dumps(existing, indent=2, sort_keys=True))
+        return 0
+
+    try:
+        install(plugin_root=plugin_root, target=args.target)
+    except CorruptHooksFile as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"wrote {args.target}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/antigravity-env-563.txt
+++ b/tests/fixtures/antigravity-env-563.txt
@@ -1,0 +1,32 @@
+# Captured from a live `agy -p "..." --output-format text` print-mode turn,
+# agy 1.1.27, macOS darwin/arm64, 2026-09-05 (issue #563 investigation, this
+# session). A probe hook installed at ~/.gemini/config/hooks.json under the
+# NAME-KEYED schema #553's final comment establishes (a hook name mapping to
+# an object keyed by event name, each holding an array of handler objects)
+# dumped `env | grep -iE 'gemini|antigrav|agy|claude|plugin|project'` from
+# inside the PreInvocation handler's own command process.
+#
+# Trimmed to the variables the tests in this file actually read -- the same
+# convention tests/fixtures/codex-env-463.txt already follows (its own
+# comment: only CLAUDE_CODE_ENTRYPOINT/CLAUDE_CODE_SESSION_ID are kept
+# beside the host's own signature). Session-scoped values with no test
+# reading them (a messaging bridge token, a PID, an exec path) were in the
+# raw capture and are deliberately not reproduced here.
+#
+# CLAUDE_CODE_ENTRYPOINT / CLAUDE_CODE_SESSION_ID are left in deliberately,
+# same reason tests/fixtures/codex-env-463.txt keeps them: this agy process
+# was itself launched from inside a Claude Code session (this very one), so
+# both signatures are genuinely present at once and detect_host() must
+# still answer deterministically -- see
+# test_antigravity_signature_563.py's "nested signature" test.
+#
+# ANTIGRAVITY_CONVERSATION_ID is the one line this fixture exists to prove:
+# it is set by agy itself, per invocation, matching the `conversationId`
+# field on the same handler's stdin payload -- confirmed by running the
+# probe twice and observing the value change between runs. Nothing in
+# Antigravity's own documentation names this variable; it was found only by
+# dumping a live process's environment, the same way #463 found
+# CODEX_SESSION_ID/CODEX_THREAD_ID for Codex.
+ANTIGRAVITY_CONVERSATION_ID=abdde66c-1153-4a56-bba2-7db93a9a2614
+CLAUDE_CODE_ENTRYPOINT=cli
+CLAUDE_CODE_SESSION_ID=51eb6cba-0bb1-4aa7-baed-d9aefe54bd52

--- a/tests/fixtures/antigravity-transcript-563.jsonl
+++ b/tests/fixtures/antigravity-transcript-563.jsonl
@@ -1,0 +1,2 @@
+{"step_index":0,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE","created_at":"2026-09-05T12:29:28Z","content":"<USER_REQUEST>\nreply with exactly: OK2\n</USER_REQUEST>\n<ADDITIONAL_METADATA>\nThe current local time is: 2026-09-05T14:29:28+02:00.\n</ADDITIONAL_METADATA>"}
+{"step_index":1,"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE","created_at":"2026-09-05T12:29:28Z","content":"OK2"}

--- a/tests/test_agy_hooks_563.py
+++ b/tests/test_agy_hooks_563.py
@@ -1,0 +1,215 @@
+"""The three Antigravity (agy) hook adapters: agy-session-start-hook.sh,
+agy-pre-invocation-hook.sh, agy-stop-hook.sh (#563).
+
+Two live defects were found and fixed while driving these against a real
+`agy` process (not reproducible from unit tests of pipeline/host.py alone,
+which only exercise the transcript-parsing half):
+
+1. Antigravity's own hook executor parses a command hook's STDOUT as
+   protojson against ITS OWN schema, not Claude Code's. Delegating straight
+   to session-start-hook.sh / user-prompt-hook.sh let their Claude
+   Code-shaped stdout (plain-text context injection; a
+   `{"hookSpecificOutput": ...}` envelope) reach agy, which logged
+   "failed to unmarshal result ... via protojson" for every SessionStart
+   and PreInvocation. Fixed by discarding the delegate's stdout.
+2. A plain backgrounded subshell (`( cmd & )`) for the Stop-triggered save
+   did not survive past the hook process exiting under a real `agy` run --
+   no trace of save-session.sh ever starting. Fixed with `nohup ... &` +
+   `disown`, the same defence scripts/post-tool-hook.sh and
+   scripts/session-end-hook.sh already use for their own backgrounded
+   saves.
+3. save-session.sh has no stdin of its own to resolve PROJECT_DIR from when
+   launched this way, and FATALs loudly if CLAUDE_PROJECT_DIR/
+   REMEMBER_HOOK_CWD are both unset -- a FATAL the nohup redirect above was
+   silently swallowing. Fixed by forwarding Antigravity's own
+   `workspacePaths[0]` as CLAUDE_PROJECT_DIR.
+
+These tests pin the composition each fix depends on using a FAKE
+save-session.sh (so no Haiku call, no real pipeline extraction -- that half
+is tests/test_antigravity_envelope_563.py's job) and assert on what
+actually reached it: env vars and background-survival, which is exactly
+the layer a pure pipeline.host/pipeline.extract unit test cannot see.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from subprocess_helpers import subprocess_failure_detail
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="bash hook subprocess + POSIX semantics — not portable to Windows runners",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_FAKE_SAVE_SESSION = """#!/bin/bash
+# Records the env this fake was actually called with, then gets out of the
+# way -- no lock, no Haiku, no real extraction. That is deliberately not
+# this script's job (see the module docstring).
+{
+  echo "ARGV=$*"
+  echo "CLAUDE_PROJECT_DIR=$CLAUDE_PROJECT_DIR"
+  echo "REMEMBER_TRANSCRIPT_PATH=$REMEMBER_TRANSCRIPT_PATH"
+} > "$FAKE_SAVE_SESSION_CALLED"
+"""
+
+_FAKE_SESSION_START = """#!/bin/bash
+cat >/dev/null
+echo "=== REMEMBER ==="
+echo "not json"
+"""
+
+_FAKE_USER_PROMPT = """#!/bin/bash
+cat >/dev/null
+echo '{"hookSpecificOutput": {"hookEventName": "UserPromptSubmit"}}'
+"""
+
+
+def _sandbox(tmp_path: Path) -> Path:
+    """A scripts/ directory holding the three real adapters beside a FAKE
+    save-session.sh/session-start-hook.sh/user-prompt-hook.sh -- the
+    adapters derive their own directory from BASH_SOURCE, so copying them
+    elsewhere is enough to sandbox the whole thing; nothing this test does
+    touches the real repo's own scripts/ or any real memory store."""
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    for name in ("agy-session-start-hook.sh", "agy-pre-invocation-hook.sh", "agy-stop-hook.sh"):
+        dst = scripts / name
+        shutil.copyfile(REPO_ROOT / "scripts" / name, dst)
+        dst.chmod(0o755)
+    (scripts / "save-session.sh").write_text(_FAKE_SAVE_SESSION)
+    (scripts / "save-session.sh").chmod(0o755)
+    (scripts / "session-start-hook.sh").write_text(_FAKE_SESSION_START)
+    (scripts / "session-start-hook.sh").chmod(0o755)
+    (scripts / "user-prompt-hook.sh").write_text(_FAKE_USER_PROMPT)
+    (scripts / "user-prompt-hook.sh").chmod(0o755)
+    return scripts
+
+
+def _run(script: Path, stdin_obj: dict, env: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(script)], input=json.dumps(stdin_obj), env=env,
+        capture_output=True, text=True, timeout=30, check=False,
+    )
+
+
+def _wait_for(path: Path, timeout: float = 10) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.exists():
+            return True
+        time.sleep(0.05)
+    return False
+
+
+# --- SessionStart / PreInvocation: stdout is discarded ---
+
+def test_session_start_adapter_discards_delegates_stdout(tmp_path):
+    scripts = _sandbox(tmp_path)
+    env = {**os.environ}
+    result = _run(scripts / "agy-session-start-hook.sh",
+                  {"conversationId": "abc", "transcriptPath": "/x", "workspacePaths": []}, env)
+    assert result.returncode == 0, subprocess_failure_detail(result, tmp_path)
+    assert result.stdout == "", (
+        "SessionStart adapter must not forward the delegate's own stdout -- "
+        "a real agy process fails to protojson-parse it (#563)"
+    )
+
+
+def test_pre_invocation_adapter_discards_delegates_stdout(tmp_path):
+    scripts = _sandbox(tmp_path)
+    env = {**os.environ}
+    result = _run(scripts / "agy-pre-invocation-hook.sh",
+                  {"workspacePaths": []}, env)
+    assert result.returncode == 0, subprocess_failure_detail(result, tmp_path)
+    assert result.stdout == ""
+
+
+# --- Stop: field renaming, nohup survival, project-dir forwarding ---
+
+def test_stop_adapter_forwards_transcript_path_and_project_dir(tmp_path):
+    """The must-fire case: a well-formed Stop payload reaches save-session.sh
+    with REMEMBER_TRANSCRIPT_PATH and CLAUDE_PROJECT_DIR set from Antigravity's
+    own field names (transcriptPath / workspacePaths[0]), and survives the
+    hook process exiting (nohup + disown, #563)."""
+    scripts = _sandbox(tmp_path)
+    marker = tmp_path / "fake-save-session-called.log"
+    env = {**os.environ, "FAKE_SAVE_SESSION_CALLED": str(marker)}
+    result = _run(scripts / "agy-stop-hook.sh", {
+        "conversationId": "0b04d3f2-c231-4ee0-8337-076e220bd1ad",
+        "transcriptPath": "/some/real/transcript.jsonl",
+        "workspacePaths": ["/some/project"],
+        "terminationReason": "NO_TOOL_CALL",
+    }, env)
+    assert result.returncode == 0, subprocess_failure_detail(result, tmp_path)
+    assert _wait_for(marker), "save-session.sh was never called (background job did not survive)"
+    content = marker.read_text()
+    assert "ARGV=0b04d3f2-c231-4ee0-8337-076e220bd1ad" in content
+    assert "CLAUDE_PROJECT_DIR=/some/project" in content
+    assert "REMEMBER_TRANSCRIPT_PATH=/some/real/transcript.jsonl" in content
+
+
+def test_stop_adapter_must_not_fire_without_transcript_path(tmp_path):
+    """The paired must-not-fire control: a Stop payload with no transcript
+    path at all must not call save-session.sh -- proven alongside the
+    positive case above in the same file, so a stub that always "succeeds"
+    silently could not pass both."""
+    scripts = _sandbox(tmp_path)
+    marker = tmp_path / "fake-save-session-called.log"
+    env = {**os.environ, "FAKE_SAVE_SESSION_CALLED": str(marker)}
+    result = _run(scripts / "agy-stop-hook.sh", {
+        "conversationId": "0b04d3f2-c231-4ee0-8337-076e220bd1ad",
+        "transcriptPath": "",
+        "workspacePaths": ["/some/project"],
+    }, env)
+    assert result.returncode == 0, subprocess_failure_detail(result, tmp_path)
+    time.sleep(0.3)
+    assert not marker.exists(), "save-session.sh must not be called with no transcript path"
+
+
+def test_stop_adapter_must_not_fire_without_conversation_id(tmp_path):
+    scripts = _sandbox(tmp_path)
+    marker = tmp_path / "fake-save-session-called.log"
+    env = {**os.environ, "FAKE_SAVE_SESSION_CALLED": str(marker)}
+    result = _run(scripts / "agy-stop-hook.sh", {
+        "conversationId": "",
+        "transcriptPath": "/some/real/transcript.jsonl",
+        "workspacePaths": ["/some/project"],
+    }, env)
+    assert result.returncode == 0, subprocess_failure_detail(result, tmp_path)
+    time.sleep(0.3)
+    assert not marker.exists(), "save-session.sh must not be called with no conversation id"
+
+
+def test_stop_adapter_survives_without_workspace_paths(tmp_path):
+    """CLAUDE_PROJECT_DIR forwarding is best-effort -- an empty
+    workspacePaths (the common case observed live: populated only via
+    `agy --add-dir`, not a bare cwd, #563) must not crash the adapter or
+    stop it calling save-session.sh; the fake here simply records that
+    CLAUDE_PROJECT_DIR was not set to anything, which is the honest
+    outcome, not a fabricated fallback."""
+    scripts = _sandbox(tmp_path)
+    marker = tmp_path / "fake-save-session-called.log"
+    env = {**os.environ, "FAKE_SAVE_SESSION_CALLED": str(marker)}
+    env.pop("CLAUDE_PROJECT_DIR", None)
+    result = _run(scripts / "agy-stop-hook.sh", {
+        "conversationId": "0b04d3f2-c231-4ee0-8337-076e220bd1ad",
+        "transcriptPath": "/some/real/transcript.jsonl",
+        "workspacePaths": [],
+    }, env)
+    assert result.returncode == 0, subprocess_failure_detail(result, tmp_path)
+    assert _wait_for(marker)
+    content = marker.read_text()
+    assert "CLAUDE_PROJECT_DIR=" in content
+    assert "CLAUDE_PROJECT_DIR=/some/project" not in content

--- a/tests/test_antigravity_envelope_563.py
+++ b/tests/test_antigravity_envelope_563.py
@@ -1,0 +1,121 @@
+"""Antigravity's transcript envelope: sniff, exchange parsing, extraction (#563).
+
+Antigravity CLI (`agy`) writes its transcript to a `transcript_full.jsonl`
+under `.system_generated/logs/` in a shape neither Claude Code's nor Codex's
+reader understands -- a flat object per step: `{"step_index", "source",
+"type", "content"}`, content a plain string, never nested under `message`
+or `payload` the way the other two hosts are. This module answers #563's
+acceptance item 2: whether the existing reader can consume it at all, by
+extending it rather than replacing it, the same seam #443 built for Codex.
+
+The fixture (tests/fixtures/antigravity-transcript-563.jsonl) is a verbatim
+capture from a live `agy -p ... --output-format text` print-mode turn, `agy`
+1.1.27, macOS darwin/arm64, this session, 2026-09-05 -- not constructed, for
+the same reason every other fixture in this suite is not: a shape invented
+to match the implementation proves nothing about the real host.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from pipeline import host as _host
+from pipeline.extract import extract_messages
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+ANTIGRAVITY_TRANSCRIPT = os.path.join(FIXTURES, "antigravity-transcript-563.jsonl")
+
+
+def _first_line(path):
+    with open(path, encoding="utf-8") as f:
+        return json.loads(f.readline())
+
+
+# --- sniff_envelope ---
+
+def test_sniff_envelope_antigravity():
+    """Positive control: the real captured shape IS recognised."""
+    assert _host.sniff_envelope(_first_line(ANTIGRAVITY_TRANSCRIPT)) == "antigravity"
+
+
+def test_sniff_envelope_antigravity_does_not_collide_with_claude_code_or_codex():
+    """Paired negative control: a shape carrying `step_index`/`source` but
+    missing `content` as a string, or a shape that IS claude-code's/codex's,
+    must not also read as antigravity -- a sniff that returns "antigravity"
+    for everything would pass the positive test above for the wrong reason.
+    """
+    assert _host.sniff_envelope({"type": "user", "message": {"content": "hi"}}) != "antigravity"
+    assert _host.sniff_envelope({"payload": {"type": "event_msg"}}) != "antigravity"
+    assert _host.sniff_envelope({"step_index": 0, "source": "MODEL"}) != "antigravity"
+
+
+# --- antigravity_exchange ---
+
+def test_antigravity_exchange_user_input_is_human():
+    obj = _first_line(ANTIGRAVITY_TRANSCRIPT)
+    assert obj["type"] == "USER_INPUT"
+    role, text = _host.antigravity_exchange(obj)
+    assert role == "HUMAN"
+    assert "reply with exactly: OK2" in text
+
+
+def test_antigravity_exchange_planner_response_is_agent():
+    with open(ANTIGRAVITY_TRANSCRIPT, encoding="utf-8") as f:
+        lines = [json.loads(line) for line in f]
+    second = lines[1]
+    assert second["type"] == "PLANNER_RESPONSE"
+    assert _host.antigravity_exchange(second) == ("AGENT", "OK2")
+
+
+def test_antigravity_exchange_unrecognised_step_type_is_skipped():
+    """The must-not-capture half paired with the two positive cases above:
+    a step whose `type` this module does not know (a future tool-call or
+    reasoning step Antigravity might add) must come back None, not guessed
+    at as HUMAN or AGENT -- the same discipline codex_exchange applies to
+    an item_completed payload of an unrecognised item type."""
+    assert _host.antigravity_exchange({"step_index": 2, "source": "MODEL", "type": "TOOL_CALL", "content": "rm -rf /"}) is None
+
+
+def test_antigravity_exchange_blank_content_is_skipped():
+    assert _host.antigravity_exchange({"step_index": 3, "source": "MODEL", "type": "PLANNER_RESPONSE", "content": "   "}) is None
+
+
+# --- extract_messages end to end ---
+
+def test_extract_messages_antigravity_transcript_non_zero():
+    """Would pass vacuously against an empty-messages stub if this only
+    asserted `msgs` truthy -- pins the exact count and the exact roles,
+    against the real captured fixture."""
+    envelope = _host.sniff_envelope(_first_line(ANTIGRAVITY_TRANSCRIPT))
+    assert envelope == "antigravity"
+    msgs = extract_messages(ANTIGRAVITY_TRANSCRIPT, skip_lines=0, envelope=envelope)
+    expected_human = (
+        "<USER_REQUEST>\nreply with exactly: OK2\n</USER_REQUEST>\n"
+        "<ADDITIONAL_METADATA>\nThe current local time is: "
+        "2026-09-05T14:29:28+02:00.\n</ADDITIONAL_METADATA>"
+    )
+    assert msgs == [("HUMAN", expected_human), ("AGENT", "OK2")]
+
+
+def test_extract_messages_antigravity_negative_control_no_recognised_steps(tmp_path):
+    """The positive control above proves real content IS extracted; this is
+    its paired negative control, in the same file family, so a stub that
+    always returns [] could not pass both -- a transcript made entirely of
+    step types this module does not recognise must extract to nothing,
+    proven alongside the fixture where extraction genuinely happens (#563
+    acceptance item 3: a silent no-op capture path is this project's worst
+    failure mode, and looks identical to a session with nothing to say)."""
+    path = tmp_path / "antigravity-no-messages.jsonl"
+    path.write_text(
+        "{\"step_index\":0,\"source\":\"MODEL\",\"type\":\"TOOL_CALL\",\"content\":\"ls\"}\n"
+        "{\"step_index\":1,\"source\":\"MODEL\",\"type\":\"REASONING\",\"content\":\"thinking...\"}\n",
+        encoding="utf-8",
+    )
+    envelope = _host.sniff_envelope(json.loads(path.read_text().splitlines()[0]))
+    assert envelope == "antigravity"
+    msgs = extract_messages(str(path), skip_lines=0, envelope=envelope)
+    assert msgs == []

--- a/tests/test_antigravity_signature_563.py
+++ b/tests/test_antigravity_signature_563.py
@@ -1,0 +1,88 @@
+"""detect_host() must recognise a real Antigravity CLI (agy) process (#563).
+
+Mirrors tests/test_codex_signature_463.py, for the same reason: a signature
+the implementation invents and a fake environment that agrees with itself
+prove nothing. This one is pinned against a verbatim, live capture instead
+(tests/fixtures/antigravity-env-563.txt) -- ANTIGRAVITY_CONVERSATION_ID,
+found only by dumping a real `agy` hook process's own environment (#553's
+last comment confirms Antigravity hooks fire at all; this fixture goes one
+step further and shows what the firing PROCESS's environment actually
+contains, which #553 never captured).
+
+Observed on macOS darwin/arm64, `agy` 1.1.27, this session, 2026-09-05.
+Nothing here is claimed for any other platform or `agy` version.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from pipeline import host as _host
+
+FIXTURE = Path(__file__).parent / "fixtures" / "antigravity-env-563.txt"
+
+
+def _load_env(path: Path) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _, value = line.partition("=")
+        env[key] = value
+    return env
+
+
+def test_real_antigravity_environment_is_detected_as_antigravity():
+    """The positive control: a recorded real `agy` hook process IS detected.
+
+    Isolated from the CLAUDE_CODE_* signature this fixture also carries (the
+    nested case is its own test below), the same way
+    test_real_codex_environment_is_detected_as_codex isolates CODEX.
+    """
+    env = _load_env(FIXTURE)
+    for var in ("CLAUDE_CODE_ENTRYPOINT", "CLAUDE_CODE_SESSION_ID"):
+        env.pop(var, None)
+    assert _host.detect_host(env).name == "antigravity"
+
+
+def test_ambient_conversation_id_shaped_value_alone_is_not_enough():
+    """The must-not-fire half paired with the positive control above: an
+    unrelated variable that merely LOOKS like a conversation id must not,
+    on its own, make detect_host() answer "antigravity" for the wrong
+    reason -- this only proves the signature NAME matters, not that any
+    UUID-shaped value flips the switch. A genuinely absent signature must
+    answer something else."""
+    env = {"SOME_OTHER_CONVERSATION_ID": "abdde66c-1153-4a56-bba2-7db93a9a2614"}
+    assert _host.detect_host(env).name != "antigravity"
+
+
+def test_no_antigravity_signature_is_not_detected_as_antigravity():
+    """A plain, empty environment must not be mistaken for Antigravity."""
+    assert _host.detect_host({}).name != "antigravity"
+
+
+def test_real_antigravity_environment_with_inherited_claude_code_signature():
+    """The fixture as actually captured: this `agy` session was launched
+    FROM a Claude Code session, so it inherits CLAUDE_CODE_ENTRYPOINT/
+    CLAUDE_CODE_SESSION_ID from its parent's environment. Both hosts'
+    signatures are genuinely present at once, the same shape #463 documents
+    for Codex. detect_host() must still answer deterministically; registry
+    order (CLAUDE_CODE first) decides it, same reasoning as the Codex case."""
+    env = _load_env(FIXTURE)
+    assert _host.detect_host(env).name == "claude-code"
+
+
+def test_antigravity_host_declares_no_plugin_root_or_project_dir_vars():
+    """Neither is documented or observed for Antigravity (#563) -- unlike
+    Codex's PLUGIN_ROOT alias or Gemini's CLAUDE_PROJECT_DIR alias, nothing
+    in the fixture or in Antigravity's own hook payload names either kind of
+    path via an environment variable. Declaring one here that was never
+    observed would be exactly the #463 mistake (a plausible-looking but
+    unexported variable) one host over."""
+    assert _host.ANTIGRAVITY.plugin_root_vars == ()
+    assert _host.ANTIGRAVITY.project_dir_vars == ()

--- a/tests/test_hooks_json.py
+++ b/tests/test_hooks_json.py
@@ -78,6 +78,19 @@ def test_every_shipped_hook_script_is_wired():
     """
     all_commands = "\n".join(cmd for _loc, cmd in _iter_commands())
     for script in sorted(SCRIPTS_DIR.glob("*-hook.sh")):
+        if script.name.startswith("agy-"):
+            # Antigravity CLI (`agy`, #563) has no per-plugin manifest at
+            # all -- its own hooks.json lives at a shared, per-machine path
+            # (~/.gemini/config/hooks.json) with no working variable
+            # substitution, so there is no static file this repo could
+            # check in for hooks/hooks.json's OWN wiring check to find (see
+            # scripts/install_agy_hooks.py's own module docstring). These
+            # scripts have their own wiring guard instead:
+            # tests/test_install_agy_hooks_563.py's
+            # test_build_entry_references_scripts_that_exist and
+            # test_build_entry_only_names_confirmed_events pin that the
+            # installer's generated manifest references every one of them.
+            continue
         assert script.name in all_commands, (
             f"scripts/{script.name} ships with the plugin but no hooks.json "
             f"command references it"

--- a/tests/test_install_agy_hooks_563.py
+++ b/tests/test_install_agy_hooks_563.py
@@ -1,0 +1,172 @@
+"""scripts/install_agy_hooks.py -- merges Remember's Antigravity hooks into
+the shared ~/.gemini/config/hooks.json (#563).
+
+Antigravity has no per-plugin manifest and no working variable substitution
+in a shared hooks.json (no host-set plugin-root or project-dir variable --
+pipeline/host.py's ANTIGRAVITY host declares neither, #563): every command
+in the manifest has to be a literal, resolved absolute path, embedded at
+install time. And the target file is SHARED across every plugin on the
+machine -- unlike Claude Code's or Codex's own per-plugin hooks.json, an agy
+install must not clobber another tool's own top-level hook name. Both of
+those are what this installer -- and this test file -- exist to get right;
+no live `agy` binary is needed to test either.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+import install_agy_hooks as installer
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+
+
+def _plugin_root():
+    return os.path.abspath(REPO_ROOT)
+
+
+def test_build_entry_uses_literal_absolute_script_paths():
+    """No ${VAR} placeholder survives -- Antigravity sets no variable this
+    manifest could rely on (see the module docstring), so every command must
+    already be a real, resolved path."""
+    entry = installer.build_remember_entry(_plugin_root())
+    for event in ("SessionStart", "PreInvocation", "Stop"):
+        assert event in entry
+        for handler in entry[event]:
+            command = handler["command"]
+            assert "${" not in command, f"{event} command still carries a placeholder: {command}"
+            assert os.path.isabs(_plugin_root())
+            assert _plugin_root() in command
+
+
+def test_every_shipped_agy_hook_script_is_wired_into_the_installer():
+    """The reverse direction of test_build_entry_references_scripts_that_exist
+    (#563 review finding): that test only proves every script the installer
+    NAMES exists on disk. This proves the other half -- every
+    scripts/agy-*-hook.sh file that SHIPS is named somewhere in the built
+    entry's commands. Without this, tests/test_hooks_json.py's own
+    "every shipped *-hook.sh is wired" guard (which this repo's
+    test_every_shipped_hook_script_is_wired carves an exception out of for
+    the whole `agy-` family, on the strength of this file's coverage) would
+    have nothing standing behind it for a script added later and never
+    registered in _EVENT_SCRIPTS -- exactly the class of regression that
+    guard exists to catch in the first place."""
+    scripts_dir = os.path.join(REPO_ROOT, "scripts")
+    entry = installer.build_remember_entry(_plugin_root())
+    all_commands = "\n".join(
+        h["command"] for handlers in entry.values() if isinstance(handlers, list) for h in handlers
+    )
+    shipped = sorted(
+        name for name in os.listdir(scripts_dir)
+        if name.startswith("agy-") and name.endswith("-hook.sh")
+    )
+    assert shipped, "no scripts/agy-*-hook.sh found -- did the port move/rename them?"
+    for name in shipped:
+        assert name in all_commands, (
+            f"scripts/{name} ships with the plugin but install_agy_hooks.py's "
+            f"build_remember_entry() never references it"
+        )
+
+
+def test_build_entry_only_names_confirmed_events():
+    """#563's own scope: SessionStart, PreInvocation, Stop -- the events
+    confirmed loading AND firing. PostInvocation is confirmed too but this
+    plugin has no PostToolUse-shaped analogue for it (#563 non-goals), so it
+    must not appear here just because it is available."""
+    entry = installer.build_remember_entry(_plugin_root())
+    named = set(entry.keys()) - {"enabled"}
+    assert named == {"SessionStart", "PreInvocation", "Stop"}
+
+
+def test_build_entry_references_scripts_that_exist():
+    entry = installer.build_remember_entry(_plugin_root())
+    for handlers in (entry["SessionStart"], entry["PreInvocation"], entry["Stop"]):
+        for handler in handlers:
+            assert handler["type"] == "command"
+            # "bash \"/abs/path/scripts/whatever.sh\"" -- pull the path out.
+            command = handler["command"]
+            path = command.split('"')[1]
+            assert os.path.isfile(path), f"references missing script: {path}"
+
+
+def test_merge_creates_file_and_dir_when_absent(tmp_path):
+    target = tmp_path / "nested" / "hooks.json"
+    installer.install(plugin_root=_plugin_root(), target=str(target))
+    assert target.is_file()
+    data = json.loads(target.read_text())
+    assert "remember" in data
+    assert set(data["remember"].keys()) - {"enabled"} == {"SessionStart", "PreInvocation", "Stop"}
+
+
+def test_merge_preserves_other_top_level_hook_names(tmp_path):
+    """The shared file is not this plugin's alone -- another tool's own
+    top-level hook name must survive an install untouched (#563's own
+    scope note: 'a plugin's own hooks.json is copied in ... and never
+    loaded -- only the shared ... path loads', so THIS is the path real
+    installs land on, alongside whatever else is already there)."""
+    target = tmp_path / "hooks.json"
+    target.write_text(json.dumps({"someone_elses_hook": {"enabled": True, "Stop": []}}))
+    installer.install(plugin_root=_plugin_root(), target=str(target))
+    data = json.loads(target.read_text())
+    assert "someone_elses_hook" in data
+    assert data["someone_elses_hook"] == {"enabled": True, "Stop": []}
+    assert "remember" in data
+
+
+def test_merge_is_idempotent(tmp_path):
+    target = tmp_path / "hooks.json"
+    installer.install(plugin_root=_plugin_root(), target=str(target))
+    first = json.loads(target.read_text())
+    installer.install(plugin_root=_plugin_root(), target=str(target))
+    second = json.loads(target.read_text())
+    assert first == second
+
+
+def test_merge_overwrites_only_the_remember_key(tmp_path):
+    """A second install (say, from a different checkout path) must replace
+    THIS plugin's own entry cleanly, not accumulate stale handlers beside
+    the new ones."""
+    target = tmp_path / "hooks.json"
+    target.write_text(json.dumps({
+        "remember": {"enabled": True, "SessionStart": [{"type": "command", "command": "stale"}]},
+    }))
+    installer.install(plugin_root=_plugin_root(), target=str(target))
+    data = json.loads(target.read_text())
+    for handler in data["remember"]["SessionStart"]:
+        assert handler["command"] != "stale"
+
+
+def test_install_refuses_a_corrupt_existing_file_rather_than_wiping_it(tmp_path):
+    """A hand-edited or half-written hooks.json must not be silently treated
+    as empty and overwritten -- this file is shared across every plugin on
+    the machine (see the module docstring), so "cannot parse it" and
+    "genuinely nothing here" are different states with different correct
+    actions: an absent file is safe to create fresh (see
+    test_merge_creates_file_and_dir_when_absent, the paired must-succeed
+    case), but a CORRUPT one may still hold another tool's real hook
+    entries the parser just could not reach, and silently discarding them
+    is data loss with no warning. install() must refuse and leave the file
+    exactly as it was, rather than coercing "corrupt" into "empty"."""
+    target = tmp_path / "hooks.json"
+    original = "{not valid json"
+    target.write_text(original)
+    with pytest.raises(installer.CorruptHooksFile):
+        installer.install(plugin_root=_plugin_root(), target=str(target))
+    assert target.read_text() == original, "a refused install must not touch the existing file"
+
+
+def test_install_creates_fresh_file_when_genuinely_absent(tmp_path):
+    """Paired with the refusal above: a target that does not exist at all
+    is the "nothing to lose" case and installs cleanly -- proven here
+    again, explicitly beside the corrupt-file refusal, so the two are not
+    confused with each other."""
+    target = tmp_path / "hooks.json"
+    installer.install(plugin_root=_plugin_root(), target=str(target))
+    data = json.loads(target.read_text())
+    assert "remember" in data


### PR DESCRIPTION
## Summary

Ports Remember's session-memory capture onto Antigravity CLI (`agy`), a fourth agent-CLI host, for issue #563 (superseding #553's investigation). Re-derives #553's own hooks.json schema finding live against `agy` 1.1.27 rather than trusting it as given -- confirms firing for `SessionStart`, `PreInvocation`, `PostInvocation`, `Stop` and wires the first three into capture.

- `pipeline/host.py`: new `ANTIGRAVITY` host (real, live-captured `ANTIGRAVITY_CONVERSATION_ID` signature) and `antigravity_exchange()` reader for Antigravity's own flat transcript shape.
- `pipeline/extract.py`: a third understood envelope, `"antigravity"`.
- Three new adapter scripts (`scripts/agy-session-start-hook.sh`, `scripts/agy-pre-invocation-hook.sh`, `scripts/agy-stop-hook.sh`) rename Antigravity's stdin payload into the shape the existing Claude Code-oriented hook scripts already understand, rather than teaching those scripts a second payload shape.
- `Stop` fires after every turn, not once at session end (manaflow-ai/cmux#5000) -- `agy-stop-hook.sh` is deliberately **not** wired to `session-end-hook.sh`; it triggers `save-session.sh`'s own idempotent, cooldown-gated flush instead, the same safe-to-repeat call `post-tool-hook.sh` already makes.
- `scripts/install_agy_hooks.py` merges a "remember" entry into the shared, per-machine `~/.gemini/config/hooks.json` without a static checked-in manifest -- nothing observed on Antigravity supplies a variable such a file could rely on.
- `docs/install-antigravity.md` (new) and a correction to `.claude/jit-context/vocabulary/02-hosts/antigravity-hooks.md`, which had pinned an earlier, superseded hooks.json schema and a "PostToolUse/Stop never fire" finding that turned out to be an artifact of that wrong schema.

No genuine Antigravity session-end signal was found -- of the four events confirmed loading and firing, none is a process-exit or conversation-close event. Reported as an open gap in `docs/install-antigravity.md`, not silently worked around.

Three real defects were found and fixed only by driving this against a live `agy` process (protojson stdout parse failure on a Claude Code-shaped hook stdout; a backgrounded save not surviving the hook process exiting; a missing `CLAUDE_PROJECT_DIR` for that backgrounded save) -- see the commit messages and the developer note for the exact log evidence.

## Self-review

Two spawns (Explore, oss:auditor) reviewed the first commit. Three real findings were fixed in a follow-up commit: stale docstrings after adding the fourth host, a one-directional wiring guard closed with a reverse-direction test, and `install_agy_hooks.py` silently treating a corrupt shared hooks.json the same as an absent one (now raises `CorruptHooksFile` and writes nothing). The auditor also caught an unused, live-looking `CLAUDE_CODE_MESSAGING_TOKEN` committed into a test fixture -- trimmed in the same follow-up commit.

Below the bar: `agy-stop-hook.sh`'s `sed -n Np` field extraction (splitting `conversationId`/`transcriptPath`/`workspacePaths[0]` by line number) would misalign if one of those fields ever contained an embedded newline. Not fixed: both values are host-generated by `agy` itself (a UUID; a filesystem path Antigravity constructs deterministically), never attacker- or remote-authored text reaching this boundary, so the reachable input space that would trigger it is empty in practice -- there is no real caller for this class here.

Maintainer note on the leaked-looking fixture value: the raw `CLAUDE_CODE_MESSAGING_TOKEN` value is still present in this branch's first commit's diff (before the follow-up trimmed it). Consider squash-merging this PR rather than merging both commits individually, so the raw value never reaches the default branch's own history.

## Test plan

- [ ] `pytest tests/test_antigravity_signature_563.py tests/test_antigravity_envelope_563.py tests/test_install_agy_hooks_563.py tests/test_agy_hooks_563.py tests/test_extract.py tests/test_hooks_json.py tests/test_host_shell_parity_407.py tests/test_codex_signature_463.py tests/test_codex_manifest_410.py tests/test_gemini_manifest_456.py tests/test_cross_host_lock_contract_491.py -q` -- 129 passed, 40 skipped (platform-tooling skips, pre-existing) locally
- [ ] CI green across all legs
- [ ] `python3 .oss/assemble_changelog.py --check` -- passes

Closes #563

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Verified by the maintainer

The "leaked-looking fixture value" this PR itself flags is real: `tests/fixtures/antigravity-env-563.txt` in this branch's original first commit (`88f1769`) carried this machine's live `CLAUDE_CODE_MESSAGING_TOKEN`, and it compared equal to the actual value in this session's own environment -- not a placeholder. A squash-merge does not contain that exposure: pushing the branch at all uploads the blob to GitHub, and once a pull request exists the object stays reachable via `refs/pull/N/head` even after the branch is deleted -- the exposure happens at push time, not merge time.

Before pushing, I rewrote this branch to a single commit (`git reset --soft` to the base, one fresh commit over the already-trimmed final tree) rather than pushing the original two-commit history and relying on squash-merge to hide the first commit. Confirmed the token string does not appear in any commit reachable from the new `fix/563` HEAD (`9efbf6e`) via `git rev-list HEAD | xargs -n1 git show | grep`, and confirmed it is absent from the working tree via a full-tree grep. Whether the token itself should also be rotated is a separate question outside this PR's scope, raised with the maintainer.

Independently re-ran the new/changed test files against a scratch worktree of `origin/main` with this fix absent: `tests/test_agy_hooks_563.py`, `tests/test_antigravity_envelope_563.py`, `tests/test_antigravity_signature_563.py` genuinely fail (15 failed, 4 passed) and `tests/test_install_agy_hooks_563.py` fails to even collect (`ModuleNotFoundError: No module named 'install_agy_hooks'`) -- confirming these are not vacuous tests. Re-ran the full new/changed test set against this branch's rewritten HEAD: 36 passed, 40 skipped (pre-existing platform-tooling skips), matching the report's own claim.

Accepted the `below-bar` finding on `agy-stop-hook.sh`'s `sed -n Np` extraction as reasoned -- both fields are host-generated (UUID, deterministic path), not attacker-reachable.


[AI-generated]