### PR TITLE
docs: document Antigravity in the README, drop Gemini CLI (#572)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![License](https://img.shields.io/badge/license-Community-brightgreen)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-5A67D8)](https://github.com/Digital-Process-Tools/claude-marketplace)
 [![Codex](https://img.shields.io/badge/Codex-plugin-000000)](.agents/plugins/marketplace.json)
+[![Antigravity](https://img.shields.io/badge/Antigravity-plugin-4285F4)](docs/install-antigravity.md)
 [![Version](https://img.shields.io/badge/version-0.27.0-orange)](.claude-plugin/plugin.json)
 
 Your coding agent starts every session blank. It doesn't know what you worked on yesterday, what conventions your team follows, or what mistakes it already made. You re-explain everything, every time.
@@ -76,13 +77,15 @@ codex plugin install remember
 
 Observed working against `codex-cli 0.150.1`. What was found on the way: [docs/install-codex.md](docs/install-codex.md).
 
-**Gemini CLI**
+**Antigravity CLI (`agy`)**
 
 ```
-gemini extensions link <path-to-this-checkout>/.gemini
+python3 scripts/install_agy_hooks.py
 ```
 
-Manifests are checked in and tested for shape; no hook has been seen firing under a live Gemini CLI yet ([#532](https://github.com/Digital-Process-Tools/claude-remember/issues/532)). That is why Gemini CLI carries no host badge above, while Claude Code and Codex do: [docs/install-gemini-cli.md](docs/install-gemini-cli.md). On an individual Google account's free tier, the command above is refused outright (`IneligibleTierError: UNSUPPORTED_CLIENT`) after the OAuth token is accepted -- see that page for the detail and what has and hasn't been tested.
+Observed working against `agy` 1.1.27: capture was driven end to end against a real `agy` process, not reasoned from its docs. Antigravity has no per-plugin manifest -- `agy plugin install` copies a plugin's own `hooks.json`, counts it, marks the plugin enabled, and never loads it ([#553](https://github.com/Digital-Process-Tools/claude-remember/issues/553)) -- so the installer merges a `remember` entry into the shared `~/.gemini/config/hooks.json`, preserving every other plugin's entries already there.
+
+**One gap, before you choose this host:** of the four Antigravity events confirmed to fire, none is a process-exit signal, so there is no analogue of `SessionEnd` and no last-chance flush at the end of a conversation. `Stop` fires after every turn and is deliberately not wired to `session-end-hook.sh`. What that costs, the name-keyed schema whose parse failures are silent, and the three live defects found while porting: [docs/install-antigravity.md](docs/install-antigravity.md).
 
 ## Requirements
 
@@ -115,12 +118,14 @@ Run it when memory is not appearing and nothing says why. It prints resolved pat
 
 ### Hooks
 
-| Claude Code / Codex | Gemini CLI | Script | Purpose |
+| Claude Code / Codex | Antigravity | Script | Purpose |
 | --- | --- | --- | --- |
 | `SessionStart` | `SessionStart` | `session-start-hook.sh` | Loads memory into context, recovers missed sessions |
-| `UserPromptSubmit` | `BeforeAgent` | `user-prompt-hook.sh` | Stamps the current time into the prompt |
-| `PostToolUse` | `AfterTool` | `post-tool-hook.sh` | Saves the session when enough tool calls have accumulated |
-| `SessionEnd` | `SessionEnd` | `session-end-hook.sh` | Flushes whatever `PostToolUse` has not saved yet |
+| `UserPromptSubmit` | `PreInvocation` (per model invocation, not per prompt) | `user-prompt-hook.sh` | Stamps the current time into the prompt |
+| `PostToolUse` | not wired (`PostInvocation` fires, nothing here needs it) | `post-tool-hook.sh` | Saves the session when enough tool calls have accumulated |
+| `SessionEnd` | **no analogue found** | `session-end-hook.sh` | Flushes whatever `PostToolUse` has not saved yet |
+
+Antigravity's `Stop` is a turn boundary, not a teardown, so it is wired to its own adapter rather than to `session-end-hook.sh`; the row above is the gap that leaves.
 
 What each one skips and why, the `hooks.d/` listener contract, and why `SessionEnd` never writes a handoff: [docs/hooks.md](docs/hooks.md).
 
@@ -176,7 +181,7 @@ Everything that used to sit on this page and did not need to be read before inst
 
 - [Installing under Claude Code](docs/install-claude-code.md): updates, the official marketplace, manual install, checking your version
 - [Installing under Codex](docs/install-codex.md)
-- [Installing under Gemini CLI](docs/install-gemini-cli.md)
+- [Installing under Antigravity CLI](docs/install-antigravity.md)
 - [Windows](docs/windows.md)
 - [Hooks](docs/hooks.md)
 - [Diagnostics](docs/diagnostics.md)

--- a/changelog.d/572.changed.md
+++ b/changelog.d/572.changed.md
@@ -1,0 +1,16 @@
+- Changed: the README now documents Antigravity CLI (`agy`) as a supported host and no
+  longer documents Gemini CLI (#572). Antigravity gains a host badge, an install section built
+  around `scripts/install_agy_hooks.py`, its own column in the hooks table, and a docs-list
+  entry; the table column is separate rather than folded into an existing one because the
+  mapping genuinely differs -- `UserPromptSubmit` maps to `PreInvocation`, `PostToolUse` is
+  not wired, and `SessionEnd` has no analogue at all. That last row is stated in the README
+  itself rather than only in the install page: none of the four Antigravity events confirmed
+  to fire is a process-exit signal, so a short conversation can end with no final flush, and
+  a reader choosing a host should see that before installing rather than after.
+- Changed: the Gemini CLI install section, hooks-table column and docs-list link are removed
+  from the README. `gemini extensions link` is refused on a free-tier individual account with
+  working credentials (`IneligibleTierError: UNSUPPORTED_CLIENT`, #532), and Google's own
+  error text names the Antigravity suite as the migration. This is not a claim that Gemini CLI
+  was withdrawn upstream: paid tiers were never tested and nothing above
+  `@google/gemini-cli` 0.58.0 has been re-probed, so "refused on the tiers that could be
+  tested" is the whole observation. `.gemini/settings.json` and its shape tests are untouched.

--- a/tests/test_host_neutral_wording_562.py
+++ b/tests/test_host_neutral_wording_562.py
@@ -58,7 +58,7 @@ def test_readme_keeps_claude_code_where_the_sentence_is_claude_code_specific():
     assert "**Claude Code**\n" in README
     assert "Restart Claude Code afterwards; hooks are read at session start" in README
     assert "Claude Code kills a hook at 60s" not in README  # this sentence lives in docs/configuration.md, not README
-    assert "| Claude Code / Codex | Gemini CLI | Script | Purpose |" in README
+    assert "| Claude Code / Codex | Antigravity | Script | Purpose |" in README
 
 
 def test_readme_full_name_appears_once_then_short_name():


### PR DESCRIPTION
Closes #572

## What changed

`grep -niE 'antigravity|agy' README.md` returned nothing before this commit. The `agy` port shipped in #563/#566 with a full install page, observed live against `agy` 1.1.27, and the README never mentioned it once.

Worse, the README stated the rule for its own host badges -- "That is why Gemini CLI carries no host badge above, while Claude Code and Codex do" -- while being wrong about its own badge row under that same rule. Antigravity is an observed host: capture was driven end to end against a real `agy` process, not reasoned from its docs.

Antigravity now has a badge, an install section around `scripts/install_agy_hooks.py`, its own hooks-table column and a docs-list entry.

**The table column is separate rather than folded into `Claude Code / Codex`**, because the mapping genuinely differs and folding it would misreport three of four rows:

| Remember | Antigravity |
| --- | --- |
| `SessionStart` | `SessionStart` |
| `UserPromptSubmit` | `PreInvocation` (per model invocation, not per prompt) |
| `PostToolUse` | not wired (`PostInvocation` fires, nothing here needs it) |
| `SessionEnd` | **no analogue found** |

That last row is stated in the README itself rather than left to the install page. Of the four Antigravity events confirmed to fire, none is a process-exit signal, so a short conversation can end with no final flush. A reader choosing a host should meet that before installing, not after.

## Gemini CLI comes off the README

Its install section, hooks-table column and docs-list link are removed, at the maintainer's decision on #572 -- they report being unable to install Gemini CLI at all. #532 recorded the mechanism already: `gemini extensions link` with `@google/gemini-cli` 0.58.0 on a free-tier individual account answers `IneligibleTierError: UNSUPPORTED_CLIENT -- This client is no longer supported for Gemini Code Assist for individuals`, *after* the OAuth token is accepted. A tier rejection with working credentials, not an auth failure, and Google's own error text names the Antigravity suite as the migration.

**What this PR is careful not to claim.** Paid Gemini tiers were never tested. Nothing above 0.58.0 has been re-probed. "Refused on the tiers that could be tested" is the entire observation, and neither the README nor the changelog fragment says more than that -- in particular neither says Gemini CLI was withdrawn or deprecated upstream, because this repo has not observed that. `.gemini/settings.json` and `tests/test_gemini_manifest_456.py` are untouched by this PR.

## The one test change

`tests/test_host_neutral_wording_562.py:61` hard-asserted the old table header verbatim (`| Claude Code / Codex | Gemini CLI | Script | Purpose |`), so it moves with the table. The #562 guard it belongs to -- host-specific sentences survive host-neutral rewording -- is unchanged in intent; only the header string it pins moves.

Ran red first, by construction: the assertion failed against the edited README (`AssertionError: assert '| Claude Code / Codex | Gemini CLI | Script | Purpose |' in ...`) before being updated, which is what confirms the guard was actually reading the table rather than passing vacuously.

## Verification

- `tests/test_host_neutral_wording_562.py`, `test_readme_reference_move_505.py`, `test_gemini_manifest_456.py` -- 28 passed.
- `tests/test_install_agy_hooks_563.py`, `test_agy_hooks_malformed_payload_568.py` -- 20 passed.
- `python3 .oss/assemble_changelog.py --check` -- ok, 11 fragments.
- **Observed on macOS only.** No platform-specific code changes here (documentation plus one string in a test), so the cross-platform risk is judged nil rather than tested -- that judgement is REASONED, not observed.

## Known follow-on, deliberately not settled here

`docs/install-gemini-cli.md` is now linked from nowhere, while `.gemini/settings.json` stays checked in and its shape tests keep passing. The repo therefore ships and tests a manifest whose only documentation is unreachable -- which this repo's own bar ("a change nobody can discover is not shipped") counts as a defect. Either delete page and manifests together, or restore a single docs-list link. Left open in #572 for a maintainer decision rather than resolved unilaterally in a docs PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bv6BGZD2EdZ9EuJ7tPDTb7

[AI-generated]