### PR TITLE
Fix: quarantine a MIXED Antigravity span exactly like an all-unmapped one (#583)

### DIFF
--- a/changelog.d/583.fixed.md
+++ b/changelog.d/583.fixed.md
@@ -1,0 +1,17 @@
+- Fixed: a MIXED Antigravity read span -- at least one mapped exchange
+  (`USER_INPUT`/`PLANNER_RESPONSE`) alongside at least one unmapped step type in the
+  same span -- exited `scripts/save-session.sh` with `EXCHANGE_COUNT > 0` and was
+  never routed through the #450/#575 quarantine at all: the unmapped step's content
+  was silently dropped, and if a prior quarantine mark existed for that session it
+  was cleared, because the ordinary successful-save path passes any value other than
+  `"unrecognised"` to `cmd_save_position()`, which reads that as "whatever was
+  quarantined has now been read" (#583). `$ENVELOPE_HAS_UNMAPPED_STEP` was
+  previously only consulted inside the script's `EXCHANGE_COUNT -eq 0` branch; a new
+  `save_position_span()` helper now applies the same check at every other
+  `save-position` call site -- the give-up-after-repeated-failures path, the
+  reject-not-an-entry-header path, the model SKIP path, and the ordinary successful
+  append -- so a mixed span quarantines exactly like an all-unmapped one, whatever
+  its own mapped exchanges' fate was. This accepts the same re-extraction/duplicate-
+  summary risk on a future recovery that #575 already accepted for the all-unmapped
+  case, rather than building real per-step-range tracking, which the issue itself
+  left as a larger, separate design decision.

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -509,6 +509,33 @@ FAILURE_MARKER="${REMEMBER_DIR}/tmp/last-summary-failure"
 MAX_FAILURES=$(config ".thresholds.max_summary_failures" 3)
 case "$MAX_FAILURES" in ''|*[!0-9]*) MAX_FAILURES=3 ;; esac
 
+# #583: every save-position call site below this point runs only once
+# EXCHANGE_COUNT -gt 0 (the EXCHANGE_COUNT -eq 0 branch above already
+# quarantines a wholly-unmapped span per #575) -- a give-up, a reject, a
+# SKIP, or an ordinary successful append. None of those verdicts says
+# anything about an unmapped step that rode along in the SAME span: the
+# extract text handed to every one of those paths never included it, so
+# whatever the verdict was, the step's content is not in it. $ENVELOPE,
+# $ENVELOPE_HAS_UNMAPPED_STEP and $SKIP_LINES are all set once by the
+# extract step (:275ish) and never reassigned afterwards -- call-haiku
+# prints HAIKU_TEXT_FILE/IS_SKIP/IS_REJECTED/PROVIDER/TK_*, none of which
+# collide with these names -- so this generalizes unchanged to every site
+# below, mixed span or not: a mapped-only span passes $ENVELOPE straight
+# through exactly as before, and a span carrying an unmapped step is routed
+# through the identical #450 quarantine mechanism the all-unmapped case
+# uses, accepting the same re-extraction/duplicate-summary risk on a future
+# recovery that #575 already accepted for that case (see #583's own "what
+# would settle it" section for the alternative this deliberately does not
+# build: real per-step-range tracking).
+save_position_span() {
+    if [ "$ENVELOPE" != "unrecognised" ] && [ "$ENVELOPE_HAS_UNMAPPED_STEP" = "1" ]; then
+        log "extract" "$ENVELOPE envelope with an unmapped step type, skip -- position -> $POSITION (span quarantined from line $SKIP_LINES for a future build)"
+        cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell save-position "$LAST_SAVE_FILE" "$SESSION_ID" "$POSITION" "unrecognised" "$SKIP_LINES"
+    else
+        cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell save-position "$LAST_SAVE_FILE" "$SESSION_ID" "$POSITION" "$ENVELOPE"
+    fi
+}
+
 record_summary_failure() {
     [ "$MAX_FAILURES" -eq 0 ] && return 0
     _prev_key=""
@@ -528,7 +555,7 @@ record_summary_failure() {
 
     if [ "$_count" -ge "$MAX_FAILURES" ]; then
         log "haiku" "WARNING: ${_count} consecutive failures on this span -- dropping it unsummarized and advancing position -> $POSITION (see thresholds.max_summary_failures)"
-        cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell save-position "$LAST_SAVE_FILE" "$SESSION_ID" "$POSITION" "$ENVELOPE"
+        save_position_span
         rm -f "$FAILURE_MARKER"
     else
         echo "$_key $_count" > "$FAILURE_MARKER"
@@ -618,7 +645,7 @@ if [ "$IS_SKIP" != "true" ]; then
         # does, or this span would be re-summarized on every run forever.
         log "validate" "REJECTED (not an entry header): $(echo "$FIRST_LINE" | head -c 80)"
         keep_rejected_text "$HAIKU_TEXT_FILE" "validate"
-        cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell save-position "$LAST_SAVE_FILE" "$SESSION_ID" "$POSITION" "$ENVELOPE"
+        save_position_span
         log "validate" "position -> $POSITION"
         rm -f "$FAILURE_MARKER"
         exit 0
@@ -673,7 +700,7 @@ if [ "$IS_SKIP" = "true" ]; then
     # reconstruction, the exact failure mode #443's envelope field exists to
     # avoid. This is the value the call itself reported using.
     log "haiku" "SKIP (provider: ${PROVIDER:-claude}) -- position -> $POSITION"
-    cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell save-position "$LAST_SAVE_FILE" "$SESSION_ID" "$POSITION" "$ENVELOPE"
+    save_position_span
     # A SKIP is a successful summarization (the model judged the span not worth
     # recording) and it advances the position, so it must clear the failure
     # count too — otherwise a stale count survives and a later single failure
@@ -759,7 +786,7 @@ APPEND_ERR=$({ printf '\n' && cat "$HAIKU_TEXT_FILE"; } 2>&1 >> "$APPEND_TMP") \
 APPEND_ERR=$(mv "$APPEND_TMP" "$MEMORY_FILE" 2>&1) \
     || append_failed "commit failed: ${APPEND_ERR:-unknown error}"
 log "write" "appended (provider: ${PROVIDER:-claude}): $(head -1 "$HAIKU_TEXT_FILE" | cut -c1-80)"
-cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell save-position "$LAST_SAVE_FILE" "$SESSION_ID" "$POSITION" "$ENVELOPE"
+save_position_span
 log "write" "position -> $POSITION"
 rm -f "$FAILURE_MARKER"
 

--- a/tests/test_save_session_gates.py
+++ b/tests/test_save_session_gates.py
@@ -704,3 +704,148 @@ class TestNoWorkSkipRule:
 
         header = (project / ".remember" / "now.md").read_text().strip().splitlines()[0]
         assert header.endswith("| feature/a|b"), f"branch truncated: {header!r}"
+
+
+class TestMixedSpanQuarantine583:
+    """#583: a MIXED read span -- some exchanges the pipeline COULD map, plus
+    at least one step type it could not -- must be quarantined exactly like
+    an all-unmapped span (#575), at every save-position call site, not just
+    the EXCHANGE_COUNT==0 one this file already covers above. exchanges=3
+    here stands in for "3 mapped exchanges alongside 1 unmapped step in the
+    same span" -- EXCHANGE_COUNT>0 is exactly what routes the #575 branch
+    around every one of the four sites below today."""
+
+    def test_ordinary_successful_save_quarantines_a_mixed_span(self, tmp_path):
+        """The everyday path: Haiku summarized the mapped exchanges and the
+        result was appended to now.md. That summary is real, but it does not
+        cover the unmapped step -- so this must still quarantine, or the
+        step's content is gone the moment the position advances and any
+        earlier quarantine mark is cleared."""
+        env, project, plugin, calls, sid = _make_env(
+            tmp_path, exchanges=3, humans=3, position=42,
+            envelope="antigravity", envelope_has_unmapped_step=True,
+        )
+        env["STUB_HAIKU_TEXT"] = "## 10:00 | main\n\n- did some mapped work\n"
+        env["STUB_SKIP_LINES"] = "17"
+        _suppress_ndc(project)
+
+        result = _run(plugin, env, sid)
+
+        assert result.returncode == 0, subprocess_failure_detail(result, project / ".remember")
+        save_position_calls = [
+            line for line in calls.read_text().splitlines() if line.startswith("save-position")
+        ]
+        assert len(save_position_calls) == 1
+        assert "unrecognised" in save_position_calls[0], (
+            "a mixed span (3 mapped exchanges + 1 unmapped step) must be quarantined "
+            f"the same way an all-unmapped span is, not saved clean: {save_position_calls[0]!r}"
+        )
+        assert "17" in save_position_calls[0], (
+            "skip_lines must ride along so the quarantine points at the still-unread "
+            f"part of the span, not just the new position: {save_position_calls[0]!r}"
+        )
+        assert _saved_position(project) == 42
+
+    def test_ordinary_successful_save_of_a_fully_mapped_span_is_not_quarantined(self, tmp_path):
+        """Paired negative control: a mixed-shaped span that in fact had NO
+        unmapped step must save clean -- proving the assertion above means
+        "an unmapped step was actually seen", not "any antigravity span with
+        EXCHANGE_COUNT>0", which a stub that always quarantines would also
+        pass the positive test with."""
+        env, project, plugin, calls, sid = _make_env(
+            tmp_path, exchanges=3, humans=3, position=42,
+            envelope="antigravity", envelope_has_unmapped_step=False,
+        )
+        env["STUB_HAIKU_TEXT"] = "## 10:00 | main\n\n- did some mapped work\n"
+        _suppress_ndc(project)
+
+        result = _run(plugin, env, sid)
+
+        assert result.returncode == 0, subprocess_failure_detail(result, project / ".remember")
+        save_position_calls = [
+            line for line in calls.read_text().splitlines() if line.startswith("save-position")
+        ]
+        assert len(save_position_calls) == 1
+        assert "unrecognised" not in save_position_calls[0]
+        assert _saved_position(project) == 42
+
+    def test_skip_path_quarantines_a_mixed_span(self, tmp_path):
+        """The model judged the mapped exchanges not worth recording (SKIP).
+        That verdict says nothing about the unmapped step it never saw --
+        the extract text handed to Haiku never included it -- so this must
+        still quarantine."""
+        env, project, plugin, calls, sid = _make_env(
+            tmp_path, exchanges=3, humans=3, position=55,
+            envelope="antigravity", envelope_has_unmapped_step=True,
+        )
+        env["STUB_SKIP_LINES"] = "9"
+
+        result = _run(plugin, env, sid)
+
+        assert result.returncode == 0, subprocess_failure_detail(result, project / ".remember")
+        save_position_calls = [
+            line for line in calls.read_text().splitlines() if line.startswith("save-position")
+        ]
+        assert len(save_position_calls) == 1
+        assert "unrecognised" in save_position_calls[0], save_position_calls[0]
+        assert _saved_position(project) == 55
+
+    def test_skip_path_of_fully_mapped_span_is_not_quarantined(self, tmp_path):
+        """Paired negative control for the SKIP path."""
+        env, project, plugin, calls, sid = _make_env(
+            tmp_path, exchanges=3, humans=3, position=55,
+            envelope="antigravity", envelope_has_unmapped_step=False,
+        )
+
+        result = _run(plugin, env, sid)
+
+        assert result.returncode == 0, subprocess_failure_detail(result, project / ".remember")
+        save_position_calls = [
+            line for line in calls.read_text().splitlines() if line.startswith("save-position")
+        ]
+        assert len(save_position_calls) == 1
+        assert "unrecognised" not in save_position_calls[0]
+        assert _saved_position(project) == 55
+
+    def test_reject_gate_quarantines_a_mixed_span(self, tmp_path):
+        """Haiku's reply for the mapped exchanges was not an entry header, so
+        it is discarded by the reject gate -- that discard is about the
+        mapped content, not the unmapped step, which must still quarantine."""
+        env, project, plugin, calls, sid = _make_env(
+            tmp_path, exchanges=3, humans=3, position=63,
+            envelope="antigravity", envelope_has_unmapped_step=True,
+        )
+        env["STUB_HAIKU_TEXT"] = "Shall I proceed with that?\n"
+        env["STUB_SKIP_LINES"] = "4"
+
+        result = _run(plugin, env, sid)
+
+        assert result.returncode == 0, subprocess_failure_detail(result, project / ".remember")
+        save_position_calls = [
+            line for line in calls.read_text().splitlines() if line.startswith("save-position")
+        ]
+        assert len(save_position_calls) == 1
+        assert "unrecognised" in save_position_calls[0], save_position_calls[0]
+        assert _saved_position(project) == 63
+
+    def test_give_up_after_max_failures_quarantines_a_mixed_span(self, tmp_path):
+        """The span is dropped unsummarized after repeated Haiku failures --
+        that give-up is about the summarizer, not about the unmapped step,
+        which must still quarantine rather than being silently dropped along
+        with the rest."""
+        env, project, plugin, calls, sid = _make_env(
+            tmp_path, exchanges=3, humans=3, position=71,
+            envelope="antigravity", envelope_has_unmapped_step=True,
+        )
+        env["STUB_HAIKU_FAIL"] = "1"
+        env["STUB_SKIP_LINES"] = "6"
+
+        for _ in range(3):
+            _run(plugin, env, sid)
+
+        save_position_calls = [
+            line for line in calls.read_text().splitlines() if line.startswith("save-position")
+        ]
+        assert len(save_position_calls) == 1, save_position_calls
+        assert "unrecognised" in save_position_calls[0], save_position_calls[0]
+        assert _saved_position(project) == 71


### PR DESCRIPTION
A read span with at least one mapped exchange (`USER_INPUT`/`PLANNER_RESPONSE`) alongside at least one unmapped step type exited `scripts/save-session.sh` with `EXCHANGE_COUNT > 0`, so it never entered the `EXCHANGE_COUNT -eq 0` branch that consults `$ENVELOPE_HAS_UNMAPPED_STEP` (added by #575). The unmapped step's content was silently dropped, and any prior #450 quarantine mark for that session was cleared -- cmd_save_position()'s own contract is: any envelope value other than "unrecognised" clears the quarantine.

`$ENVELOPE`, `$ENVELOPE_HAS_UNMAPPED_STEP` and `$SKIP_LINES` are all set exactly once by the extract step and never reassigned by anything between it and the script's other 4 `save-position` call sites -- confirmed by reading every `print(f"...")` in `pipeline/shell.py`'s `cmd_extract`/`cmd_call_haiku`, not assumed. A new `save_position_span()` helper applies the same #575 check unchanged at those 4 sites (give-up-after-repeated-failures, reject-not-an-entry-header, model SKIP, ordinary successful append), so a mixed span quarantines exactly like an all-unmapped one, whatever its own mapped exchanges' fate was.

This accepts the same re-extraction/duplicate-summary risk on a future recovery that #575 already accepted for the all-unmapped case, rather than building real per-step-range tracking -- the larger alternative the issue itself left open as a separate design decision.

## Testing

- New `TestMixedSpanQuarantine583` (6 tests) in `tests/test_save_session_gates.py`, one per call site plus 2 paired negative controls (a mixed-shaped span with no actual unmapped step must save clean).
- Red before the fix: 4 of 6 new tests failed against the parent commit.
- Green after: 31 passed (25 pre-existing + 6 new).
- `python3 .oss/assemble_changelog.py --check` passed.
- Self-reviewed by two independent spawns (Explore + oss:auditor) against the committed diff -- both returned no findings, independently re-verified the variable-scoping claim, and confirmed no new shellcheck warnings vs the parent commit.

Closes #583

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-generated]