### PR TITLE
Write session summary entries in the same language as the conversation

### DIFF
--- a/changelog.d/593.added.md
+++ b/changelog.d/593.added.md
@@ -1,0 +1,1 @@
+- Session summary entries now follow the language of the conversation being summarized (issue #593).

--- a/prompts/save-session.prompt.txt
+++ b/prompts/save-session.prompt.txt
@@ -8,6 +8,7 @@ Read the conversation extract below and write ONE memory entry in this exact for
 Rules:
 - The first line MUST be exactly `## {{TIME}} | {{BRANCH}}` — these are concrete values already computed by the script (the time is the wall-clock time of this save). Copy them verbatim. Do NOT invent your own header (e.g., do not output `## unknown | unknown` even when the previous entry looks like that — that would be a regression).
 - ONE sentence only. Short and specific.
+- Write the entry in the SAME language as the conversation being summarized (e.g. Chinese conversation -> Chinese entry). Keep file names, identifiers, and technical terms in their original form.
 - Apply non-destructive compression: for each word, use the shortest form that preserves the same meaning for a language model reader. Keep all facts, all refs, all specifics — just fewer tokens. Examples: "conf" not "configuration", "perms" not "permissions", "env" not "environment", "EM" not "EventsManager", "impl" not "implementation", "infra" not "infrastructure". Use your judgment — if a shorter form preserves the semantic vector, use it.
 - Blocking, pending, or "not yet live" status is a fact, not filler — never drop it. If work that was done still requires a manual/human step (missing key, manual upload/migration, approval, etc.) before it actually works or is visible, that must survive compression even if the sentence gets longer. Never turn "done, but blocked on X" into just "done."
 - Drop filler: "in order to", "that handle", "for proper", "successfully"


### PR DESCRIPTION
## What

Adds one rule to `prompts/save-session.prompt.txt` so the daily-memory summarizer writes each entry in the same language as the conversation being summarized, keeping file names, identifiers, and technical terms in their original form.

## Why

The template contained English-only instructions and never asked the summarizer to follow the conversation language, so non-English sessions produced English log entries (observed with Chinese conversations).

## How verified

Applied the rule to a local template and re-ran a save over a Chinese conversation: the resulting entry was Chinese while file names and technical terms stayed unchanged. `compress-ndc.prompt.txt` intentionally needs no change — its non-destructive compression contract (zero information loss) already preserves the source language.

Closes #593