### PR TITLE
chore: declare the lane label vocabulary in .oss.json

### DIFF
--- a/.oss.json
+++ b/.oss.json
@@ -20,7 +20,15 @@
       "priority:low",
       "priority:medium"
     ],
-    "lanes": [],
+    "lanes": [
+      "lane-capture",
+      "lane-consolidation",
+      "lane-diagnostics",
+      "lane-hosts",
+      "lane-other",
+      "lane-paths",
+      "lane-storage"
+    ],
     "filed_by_loop": "filed-by-loop"
   },
   "milestones": [],


### PR DESCRIPTION
## What

The repo had no lane axis at all. `.oss.json` carried `"lanes": []` and the tracker had no
`lane-` label, so the triager had nothing to assign and all six open issues read identically
on the board — same cohort, same author, no subsystem.

Seven lanes now exist on the forge; this commit names them in `.oss.json` so the triager reads
them. Six are subsystems derived from the tree and the open issues; `lane-other` is the escape
hatch, so an unlabelled issue means *untriaged* rather than *nothing matched*.

| Lane | Area |
| --- | --- |
| `lane-hosts` | host adapters — Antigravity, Codex, Gemini, Claude Code; `host.py`, `agy-*` scripts, `hooks.*.json` |
| `lane-capture` | in-session hooks and the summarizer — post-tool, prompt, session-start/end, `haiku.py`, `prompts/` |
| `lane-consolidation` | NDC daily fold and its locks — `consolidate.py`, staging lock, rotation. SERIAL: races live here |
| `lane-paths` | slug and path resolution incl. the Windows band — `slug.py`, `lib-slug.sh`, `resolve-paths.sh` |
| `lane-storage` | where memory lives — external storage mode, git backup/restore, data files, memory dir |
| `lane-diagnostics` | doctor and the test harness — `doctor.sh`, `commands/doctor.md`, `conftest.py`, `run-tests.sh` |
| `lane-other` | fits none of the above |

The set is deliberately coarser than claude-supertool's seven subsystem lanes: this repo is
smaller, and a lane nobody can fill is a label that rots.

## Also done, outside this diff

Labels are forge state, not files, so they have nowhere to land in a PR:

- The seven `lane-*` labels were created on the tracker.
- The six open issues were labelled: #595 `lane-diagnostics`, #596 `lane-hosts`,
  #599 `lane-capture`, #600 `lane-capture`, #601 `lane-diagnostics`, #602 `lane-diagnostics`.
  #601 and #602 are test-quality defects rather than defects in the subsystem under test,
  which is why they sit in `lane-diagnostics` and not in `lane-paths` / `lane-hosts`.

## Verification

- **Observed:** `/oss:doctor` reports `.oss.json parsed and validated (14 keys)` with the new
  list in place.
- **Observed:** the diff is 9 insertions and 1 deletion — no other key was reformatted.
- **Not observed:** nothing here exercises the triager against the new vocabulary. The first
  `/oss:triage` run is what tests it.

## Changelog

Repo-internal config — no user-visible change, so `no-changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WPyTxGMEeCFajcZfaBiiZo

[AI-generated]