### PR TITLE
Fix stale prose totals in docs/windows-skip-triage.md (#595)

### DIFF
--- a/changelog.d/595.fixed.md
+++ b/changelog.d/595.fixed.md
@@ -5,7 +5,13 @@
   against the live tree) had already grown to 102 modules / 82 `unclear`
   across #589 and #591 without those sentences being touched (#595). The doc
   now states 102/82, and a new guard,
-  `tests/test_windows_skip_triage_prose_totals_595.py`, ties each of the four
-  prose sentences to the table's own row count rather than to another
-  hardcoded number, so a future row added to the table without updating the
-  prose next to it fails a test instead of drifting silently again.
+  `tests/test_windows_skip_triage_prose_totals_595.py`, ties every one of
+  these prose sentences -- total, `unclear`, and (after self-review flagged
+  the same gap on the two other verdict counts) `convertible` and
+  `not-convertible` as well -- to the table's own row/verdict counts rather
+  than to another hardcoded number, so a future row added to the table
+  without updating the prose next to it fails a test instead of drifting
+  silently again. The table-row parsing itself now lives in one shared
+  `scripts.windows_skip_triage_497.parse_doc_table_rows` helper, used by both
+  this new guard and the existing #497 one, so the two cannot silently
+  disagree about what counts as a row.

--- a/changelog.d/595.fixed.md
+++ b/changelog.d/595.fixed.md
@@ -1,0 +1,11 @@
+- Fixed: `docs/windows-skip-triage.md` restated the total blanket win32-skip
+  module count and the `unclear` verdict count as fixed prose numbers -- "98"
+  and "78 modules" -- in four sentences that nothing recomputed, while the
+  table right below them (guarded by `tests/test_windows_skip_triage_497.py`
+  against the live tree) had already grown to 102 modules / 82 `unclear`
+  across #589 and #591 without those sentences being touched (#595). The doc
+  now states 102/82, and a new guard,
+  `tests/test_windows_skip_triage_prose_totals_595.py`, ties each of the four
+  prose sentences to the table's own row count rather than to another
+  hardcoded number, so a future row added to the table without updating the
+  prose next to it fails a test instead of drifting silently again.

--- a/docs/windows-skip-triage.md
+++ b/docs/windows-skip-triage.md
@@ -23,7 +23,7 @@ session -- #585, #588). A `.claude/jit-context` entry
 `supertool` write introduces the `pytestmark` pattern; `CONTRIBUTING.md` states it too,
 for a contributor not routing writes through `supertool`.
 
-## The count: 98, not 107 (and not the issue's original 92)
+## The count: 102, not 107 (and not the issue's original 92)
 
 The issue's own re-verified count -- `grep -rl "pytestmark = pytest.mark.skipif"
 tests | xargs grep -l "win32"` -- returns 107 on this tree. That command only
@@ -43,7 +43,7 @@ parses every test module with `ast`, and only counts a file that has an
 actual module-level `pytestmark = pytest.mark.skipif(<expr containing
 "win32">, reason=...)` assignment -- a bare call, or one arm of a
 list/tuple of marks (pytest ORs a list, so any one arm mentioning "win32"
-is a real blanket skip). That finds **98** modules on this tree at this
+is a real blanket skip). That finds **102** modules on this tree at this
 commit. `tests/test_windows_skip_triage_497.py` recomputes this same set
 on every run and diffs it against the table below, so this list cannot
 silently drift out of sync with the tree the way the issue itself describes
@@ -62,7 +62,7 @@ once already during review.
   path-format incompatibility. 12 modules.
 - **unclear** -- the reason string alone does not say enough to tell; reading
   it is not the same as reading the test body, and this list is deliberately
-  not that read. 78 modules.
+  not that read. 82 modules.
 
 **A blind spot in the scanner itself, caught once already.** An earlier
 version of `scripts/windows_skip_triage_497.py` only matched a bare
@@ -78,7 +78,7 @@ what the AST matcher was written to recognize, not by an exhaustive read of
 every skip expression in `tests/`.
 
 **The `unclear` majority is the honest result, not a shortcut.** The great
-bulk of these 98 reasons is one of a handful of near-identical templated
+bulk of these 102 reasons is one of a handful of near-identical templated
 strings -- `"bash subprocess + POSIX layout -- not portable to Windows
 runners"`, `"bash hook subprocess + POSIX semantics -- not portable to
 Windows runners"`, and near-variants -- that bundle the one thing

--- a/scripts/windows_skip_triage_497.py
+++ b/scripts/windows_skip_triage_497.py
@@ -36,6 +36,32 @@ from __future__ import annotations
 import ast
 import glob
 import os
+import re
+
+# Every row in docs/windows-skip-triage.md's table opens with a path cell in
+# backticks, followed by a reason cell and a verdict cell -- the same three
+# leading columns regardless of how many trailing columns (e.g. "basis")
+# follow. `tests/test_windows_skip_triage_497.py` (which only needs the path
+# column, to diff the row set against the live tree) and
+# `tests/test_windows_skip_triage_prose_totals_595.py` (which also needs the
+# verdict column, to check the doc's prose totals against the table's own
+# counts) both parse this same table. A second, independently-written copy of
+# this regex in the newer file was flagged in #595's own self-review: nothing
+# ties two separate patterns together, so a future change to the table's
+# column layout could satisfy one guard's row model while silently breaking
+# the other's. Parsing through this one shared function instead means both
+# guards see the same rows or fail the same way.
+_TABLE_ROW_RE = re.compile(r"^\|\s*`(tests/[^`]+\.py)`\s*\|([^|]*)\|([^|]*)\|", re.MULTILINE)
+
+
+def parse_doc_table_rows(doc_text: str) -> list[tuple[str, str, str]]:
+    """Return (path, reason, verdict) for every row in the doc's table,
+    trimmed of surrounding whitespace. `doc_text` is the full text of
+    docs/windows-skip-triage.md (or a fixture built to look like it)."""
+    return [
+        (path, reason.strip(), verdict.strip())
+        for path, reason, verdict in _TABLE_ROW_RE.findall(doc_text)
+    ]
 
 
 def find_blanket_skip_modules(tests_dir: str) -> dict[str, str | None]:

--- a/tests/test_windows_skip_triage_497.py
+++ b/tests/test_windows_skip_triage_497.py
@@ -31,7 +31,10 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from scripts.windows_skip_triage_497 import find_blanket_skip_modules, parse_doc_table_rows  # noqa: I001
+from scripts.windows_skip_triage_497 import (
+    find_blanket_skip_modules,
+    parse_doc_table_rows,
+)
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TESTS_DIR = os.path.join(REPO_ROOT, "tests")

--- a/tests/test_windows_skip_triage_497.py
+++ b/tests/test_windows_skip_triage_497.py
@@ -16,30 +16,30 @@ positive control"), the real doc's "must match" case is paired with a "must
 fire" case: a deliberately wrong fixture list is asserted to fail the same
 comparison, so the test cannot pass merely because comparison logic never
 runs.
+
+The doc's table is parsed via `scripts.windows_skip_triage_497.parse_doc_table_rows`
+-- the same shared parser `tests/test_windows_skip_triage_prose_totals_595.py`
+uses for its own row/verdict counts -- rather than a second, independently
+written row regex here, so the two guards cannot silently disagree about what
+counts as a row (#595's own self-review).
 """
 
 from __future__ import annotations
 
 import os
-import re
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from scripts.windows_skip_triage_497 import find_blanket_skip_modules
+from scripts.windows_skip_triage_497 import find_blanket_skip_modules, parse_doc_table_rows  # noqa: I001
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TESTS_DIR = os.path.join(REPO_ROOT, "tests")
 DOC_PATH = os.path.join(REPO_ROOT, "docs", "windows-skip-triage.md")
 
-# Every row in the doc's table opens with a path cell in backticks, e.g.
-# "| `tests/test_foo.py` | ... |". This is the same shape for every row
-# regardless of verdict, so it does not need to know the verdict vocabulary.
-_ROW_PATH_RE = re.compile(r"^\|\s*`(tests/[^`]+\.py)`\s*\|", re.MULTILINE)
-
 
 def _doc_listed_paths(doc_text: str) -> set[str]:
-    return set(_ROW_PATH_RE.findall(doc_text))
+    return {path for path, _reason, _verdict in parse_doc_table_rows(doc_text)}
 
 
 def test_doc_lists_exactly_the_live_blanket_skip_modules():

--- a/tests/test_windows_skip_triage_prose_totals_595.py
+++ b/tests/test_windows_skip_triage_prose_totals_595.py
@@ -1,0 +1,111 @@
+"""docs/windows-skip-triage.md's prose totals must track the live table, not a
+frozen snapshot (#595).
+
+`tests/test_windows_skip_triage_497.py` already guards the *table*: it recomputes
+the live set of win32 blanket-skip modules via
+`scripts.windows_skip_triage_497.find_blanket_skip_modules` and diffs it against
+every row the table lists, so the table itself cannot silently drift. It says
+nothing about the doc's own prose, though, which restates the same two counts --
+the total module count and the `unclear` verdict count -- in four sentences the
+table-diff test never looks at. #589/#591 added two new rows to the table (in
+sync, per that test) without touching those four sentences, and the doc has
+said "98" and "78 modules" ever since, while the live tree (and the table
+itself) now has 102 modules and 82 of them `unclear`.
+
+Rather than hardcoding the current live numbers here (which would just move the
+staleness one file over -- this test would go stale the next time a row is
+added), this test ties the prose to the table's *own* row count: whatever the
+table says is the ground truth (that is what the #497 test guards), and the
+prose is stale exactly when it disagrees with the table it is standing next to.
+That also means this test does not need to recompute anything from `tests/`
+itself -- it reads `docs/windows-skip-triage.md` once, counts its own table
+rows and verdicts, and checks the four prose sentences against that count.
+
+Per this repo's CLAUDE.md ("a negative assertion needs a positive control"),
+the real "prose matches table" case is paired with a "must fire" case: fixture
+doc text with the table left alone but one prose number wrong is asserted to
+fail the same comparison, so this test cannot pass merely because the
+extraction regexes never match anything.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DOC_PATH = os.path.join(REPO_ROOT, "docs", "windows-skip-triage.md")
+
+_ROW_PATH_RE = re.compile(r"^\|\s*`(tests/[^`]+\.py)`\s*\|([^|]*)\|([^|]*)\|", re.MULTILINE)
+
+# The four sentences in docs/windows-skip-triage.md that restate a count the
+# table itself already carries. Each capture group is the digit run that must
+# equal either the live total row count ("total") or the live `unclear` row
+# count ("unclear").
+_PROSE_PATTERNS = [
+    (re.compile(r"## The count: (\d+), not \d+"), "total"),
+    (re.compile(r"finds \*\*(\d+)\*\* modules on this tree"), "total"),
+    (re.compile(r"not that read\. (\d+) modules\."), "unclear"),
+    (re.compile(r"bulk of these (\d+) reasons"), "total"),
+]
+
+
+def _table_counts(doc_text: str) -> dict[str, int]:
+    rows = _ROW_PATH_RE.findall(doc_text)
+    total = len(rows)
+    unclear = sum(1 for _path, _reason, verdict in rows if verdict.strip() == "unclear")
+    return {"total": total, "unclear": unclear}
+
+
+def _prose_mismatches(doc_text: str) -> list[str]:
+    counts = _table_counts(doc_text)
+    mismatches = []
+    for pattern, kind in _PROSE_PATTERNS:
+        match = pattern.search(doc_text)
+        if match is None:
+            mismatches.append(f"pattern {pattern.pattern!r} not found in doc")
+            continue
+        stated = int(match.group(1))
+        expected = counts[kind]
+        if stated != expected:
+            mismatches.append(
+                f"pattern {pattern.pattern!r} states {stated}, but the table's "
+                f"own {kind} row count is {expected}"
+            )
+    return mismatches
+
+
+def test_prose_totals_match_the_live_table():
+    with open(DOC_PATH, encoding="utf-8") as fh:
+        doc_text = fh.read()
+
+    counts = _table_counts(doc_text)
+    assert counts["total"] > 0, "sanity: the table must have at least one row"
+
+    mismatches = _prose_mismatches(doc_text)
+    assert not mismatches, (
+        "docs/windows-skip-triage.md's prose totals disagree with its own "
+        "table (#595): " + "; ".join(mismatches)
+    )
+
+
+def test_positive_control_fires_on_a_stale_prose_number():
+    # MUST fire: a positive control for the assertion above. Without this, a
+    # broken pattern (e.g. one that never matches) would make the real test
+    # pass whether or not the prose actually agrees with the table.
+    with open(DOC_PATH, encoding="utf-8") as fh:
+        doc_text = fh.read()
+
+    counts = _table_counts(doc_text)
+    wrong_total = counts["total"] + 1
+    stale_doc = doc_text.replace(
+        f"## The count: {counts['total']}, not 107",
+        f"## The count: {wrong_total}, not 107",
+    )
+    assert stale_doc != doc_text, "fixture setup: replacement did not match live doc text"
+
+    mismatches = _prose_mismatches(stale_doc)
+    assert mismatches, (
+        "positive control failed to fire: a deliberately wrong prose number "
+        "should have produced a nonempty mismatch list"
+    )

--- a/tests/test_windows_skip_triage_prose_totals_595.py
+++ b/tests/test_windows_skip_triage_prose_totals_595.py
@@ -129,10 +129,10 @@ def test_positive_control_fires_on_a_stale_prose_number():
 
 
 def test_positive_control_fires_on_a_stale_convertible_count():
-    # MUST fire: same as above, but for the convertible/not-convertible
-    # patterns added after self-review -- without this, a broken pattern for
-    # either one would make the real test pass whether or not the prose
-    # actually agrees with the table on those two counts specifically.
+    # MUST fire: same as above, but for the convertible pattern added after
+    # self-review -- without this, a broken pattern for it would make the
+    # real test pass whether or not the prose actually agrees with the table
+    # on that count specifically.
     with open(DOC_PATH, encoding="utf-8") as fh:
         doc_text = fh.read()
 
@@ -147,5 +147,51 @@ def test_positive_control_fires_on_a_stale_convertible_count():
     mismatches = _prose_mismatches(stale_doc)
     assert mismatches, (
         "positive control failed to fire: a deliberately wrong convertible "
+        "count should have produced a nonempty mismatch list"
+    )
+
+
+def test_positive_control_fires_on_a_stale_not_convertible_count():
+    # MUST fire: same as above, for the not-convertible pattern. A second
+    # audit round on #595 flagged that the first version of this file added
+    # a dedicated fire-test for `convertible` but not for `not-convertible`
+    # or `unclear` -- the identical gap the commit's own message claimed to
+    # have closed for "both new counts." This closes it for not-convertible.
+    with open(DOC_PATH, encoding="utf-8") as fh:
+        doc_text = fh.read()
+
+    counts = _table_counts(doc_text)
+    wrong_not_convertible = counts.get("not-convertible", 0) + 1
+    stale_doc = doc_text.replace(
+        f"path-format incompatibility. {counts.get('not-convertible', 0)} modules.",
+        f"path-format incompatibility. {wrong_not_convertible} modules.",
+    )
+    assert stale_doc != doc_text, "fixture setup: replacement did not match live doc text"
+
+    mismatches = _prose_mismatches(stale_doc)
+    assert mismatches, (
+        "positive control failed to fire: a deliberately wrong not-convertible "
+        "count should have produced a nonempty mismatch list"
+    )
+
+
+def test_positive_control_fires_on_a_stale_unclear_count():
+    # MUST fire: same as above, for the unclear pattern -- the fourth of the
+    # four counts this guard checks, and the other one the second audit round
+    # found had no dedicated fire-test of its own.
+    with open(DOC_PATH, encoding="utf-8") as fh:
+        doc_text = fh.read()
+
+    counts = _table_counts(doc_text)
+    wrong_unclear = counts.get("unclear", 0) + 1
+    stale_doc = doc_text.replace(
+        f"not that read. {counts.get('unclear', 0)} modules.",
+        f"not that read. {wrong_unclear} modules.",
+    )
+    assert stale_doc != doc_text, "fixture setup: replacement did not match live doc text"
+
+    mismatches = _prose_mismatches(stale_doc)
+    assert mismatches, (
+        "positive control failed to fire: a deliberately wrong unclear "
         "count should have produced a nonempty mismatch list"
     )

--- a/tests/test_windows_skip_triage_prose_totals_595.py
+++ b/tests/test_windows_skip_triage_prose_totals_595.py
@@ -5,21 +5,32 @@ frozen snapshot (#595).
 the live set of win32 blanket-skip modules via
 `scripts.windows_skip_triage_497.find_blanket_skip_modules` and diffs it against
 every row the table lists, so the table itself cannot silently drift. It says
-nothing about the doc's own prose, though, which restates the same two counts --
-the total module count and the `unclear` verdict count -- in four sentences the
-table-diff test never looks at. #589/#591 added two new rows to the table (in
-sync, per that test) without touching those four sentences, and the doc has
-said "98" and "78 modules" ever since, while the live tree (and the table
-itself) now has 102 modules and 82 of them `unclear`.
+nothing about the doc's own prose, though, which restates four of the table's
+own counts in five sentences the table-diff test never looks at: the total
+module count (three sentences), and the `unclear`, `convertible` and
+`not-convertible` verdict counts (one sentence each). #589/#591 added two new
+rows to the table (in sync, per that test) without touching the prose, and the
+doc said "98" and "78 modules" for a while, while the live tree (and the table
+itself) had already grown to 102 modules / 82 `unclear`.
 
 Rather than hardcoding the current live numbers here (which would just move the
 staleness one file over -- this test would go stale the next time a row is
-added), this test ties the prose to the table's *own* row count: whatever the
-table says is the ground truth (that is what the #497 test guards), and the
-prose is stale exactly when it disagrees with the table it is standing next to.
-That also means this test does not need to recompute anything from `tests/`
-itself -- it reads `docs/windows-skip-triage.md` once, counts its own table
-rows and verdicts, and checks the four prose sentences against that count.
+added), this test ties the prose to the table's *own* row/verdict counts:
+whatever the table says is the ground truth (that is what the #497 test
+guards), and the prose is stale exactly when it disagrees with the table it is
+standing next to. That also means this test does not need to recompute
+anything from `tests/` itself -- it reads `docs/windows-skip-triage.md` once,
+counts its own table rows and verdicts (via the same
+`scripts.windows_skip_triage_497.parse_doc_table_rows` helper
+`tests/test_windows_skip_triage_497.py` uses, so the two guards cannot
+silently disagree about what counts as a row), and checks the five prose
+sentences against that count.
+
+This test's own first version (#595's initial commit) only covered the total
+and `unclear` counts; a self-review reviewer flagged that the doc separately
+states "8 modules" (convertible) and "12 modules" (not-convertible) right next
+to the same table, uncovered by anything, and that this is the identical
+staleness risk left half-fixed. The two missing patterns below close that.
 
 Per this repo's CLAUDE.md ("a negative assertion needs a positive control"),
 the real "prose matches table" case is paired with a "must fire" case: fixture
@@ -32,29 +43,35 @@ from __future__ import annotations
 
 import os
 import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts.windows_skip_triage_497 import parse_doc_table_rows
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DOC_PATH = os.path.join(REPO_ROOT, "docs", "windows-skip-triage.md")
 
-_ROW_PATH_RE = re.compile(r"^\|\s*`(tests/[^`]+\.py)`\s*\|([^|]*)\|([^|]*)\|", re.MULTILINE)
-
-# The four sentences in docs/windows-skip-triage.md that restate a count the
+# The five sentences in docs/windows-skip-triage.md that restate a count the
 # table itself already carries. Each capture group is the digit run that must
-# equal either the live total row count ("total") or the live `unclear` row
-# count ("unclear").
+# equal the live row count for that "kind" ("total" = every row, or one of
+# the three verdict strings the table's own third column uses).
 _PROSE_PATTERNS = [
     (re.compile(r"## The count: (\d+), not \d+"), "total"),
     (re.compile(r"finds \*\*(\d+)\*\* modules on this tree"), "total"),
+    (re.compile(r"supply on a Windows runner via Git Bash\. (\d+) modules\."), "convertible"),
+    (re.compile(r"path-format incompatibility\. (\d+) modules\."), "not-convertible"),
     (re.compile(r"not that read\. (\d+) modules\."), "unclear"),
     (re.compile(r"bulk of these (\d+) reasons"), "total"),
 ]
 
 
 def _table_counts(doc_text: str) -> dict[str, int]:
-    rows = _ROW_PATH_RE.findall(doc_text)
-    total = len(rows)
-    unclear = sum(1 for _path, _reason, verdict in rows if verdict.strip() == "unclear")
-    return {"total": total, "unclear": unclear}
+    rows = parse_doc_table_rows(doc_text)
+    counts: dict[str, int] = {"total": len(rows)}
+    for _path, _reason, verdict in rows:
+        counts[verdict] = counts.get(verdict, 0) + 1
+    return counts
 
 
 def _prose_mismatches(doc_text: str) -> list[str]:
@@ -66,11 +83,11 @@ def _prose_mismatches(doc_text: str) -> list[str]:
             mismatches.append(f"pattern {pattern.pattern!r} not found in doc")
             continue
         stated = int(match.group(1))
-        expected = counts[kind]
+        expected = counts.get(kind, 0)
         if stated != expected:
             mismatches.append(
                 f"pattern {pattern.pattern!r} states {stated}, but the table's "
-                f"own {kind} row count is {expected}"
+                f"own {kind!r} row count is {expected}"
             )
     return mismatches
 
@@ -108,4 +125,27 @@ def test_positive_control_fires_on_a_stale_prose_number():
     assert mismatches, (
         "positive control failed to fire: a deliberately wrong prose number "
         "should have produced a nonempty mismatch list"
+    )
+
+
+def test_positive_control_fires_on_a_stale_convertible_count():
+    # MUST fire: same as above, but for the convertible/not-convertible
+    # patterns added after self-review -- without this, a broken pattern for
+    # either one would make the real test pass whether or not the prose
+    # actually agrees with the table on those two counts specifically.
+    with open(DOC_PATH, encoding="utf-8") as fh:
+        doc_text = fh.read()
+
+    counts = _table_counts(doc_text)
+    wrong_convertible = counts.get("convertible", 0) + 1
+    stale_doc = doc_text.replace(
+        f"supply on a Windows runner via Git Bash. {counts.get('convertible', 0)} modules.",
+        f"supply on a Windows runner via Git Bash. {wrong_convertible} modules.",
+    )
+    assert stale_doc != doc_text, "fixture setup: replacement did not match live doc text"
+
+    mismatches = _prose_mismatches(stale_doc)
+    assert mismatches, (
+        "positive control failed to fire: a deliberately wrong convertible "
+        "count should have produced a nonempty mismatch list"
     )


### PR DESCRIPTION
## What

docs/windows-skip-triage.md's table (guarded against the live tree by
tests/test_windows_skip_triage_497.py) grew to 102 modules / 82 unclear across
#589/#591, but four prose sentences next to the table still said 98/78 --
nothing recomputed them when the table grew.

## Contents

- Update the prose to 102/82.
- Add tests/test_windows_skip_triage_prose_totals_595.py, tying each prose
  sentence to the table's own row count rather than to another hardcoded
  number -- so a future table change cannot leave the prose stale again.
- Second audit round: widen the guard to also cover the doc's separate
  "8 modules" (convertible) / "12 modules" (not-convertible) mentions next to
  the same table -- the identical staleness risk, left half-fixed by the
  first version. Factor the row-parsing regex, previously duplicated between
  the guard and tests/test_windows_skip_triage_497.py, into a shared
  scripts.windows_skip_triage_497.parse_doc_table_rows helper.
- Add the missing positive-control (must-fire) tests for the not-convertible
  and unclear prose patterns, alongside the existing must-not-fire cases.
- Reformat a noqa-suppressed import in tests/test_windows_skip_triage_497.py
  into ruff's own multi-line form instead of silencing the rule.

## Verification

- **Observed:** new tests fail red against the stale prose/hardcoded pattern
  and pass green against the fix (self-review: Explore + oss:auditor per the
  commit history).

## Changelog

changelog.d/595.fixed.md added.

Closes #595

This PR was assembled by a maintainer tick from three already-committed and
pushed commits (a developer lane dispatched in a prior tick whose handback
never opened the pull request) -- the commit messages above are that
developer's own record of the work and its self-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9WexZb39yUjQgJ53Zmf1c

[AI-generated]