### PR TITLE
Fix: sanitize embedded control bytes in log() (#599)

### DIFF
--- a/changelog.d/599.fixed.md
+++ b/changelog.d/599.fixed.md
@@ -1,0 +1,14 @@
+- Fixed: `log()` (`scripts/log.sh`) wrote its message argument verbatim into the
+  daily log file, with no newline handling. Several call sites in
+  `scripts/save-session.sh` embed the first 80 bytes of a model's reply straight
+  into a log line (e.g. the NDC and header-validation rejection paths) -- text
+  that is untrusted since #593, because it is model-authored from the
+  conversation's own content rather than controlled by this codebase. A raw
+  newline or carriage return embedded in that text landed at column 0 of the log
+  file and read as a second, forged log entry to anything parsing the log -- a
+  person skimming it, or a script (#599). `log()` now flattens every control byte
+  in the message to a plain space (`tr '[:cntrl:]' ' '`, the same remedy
+  `scripts/doctor.sh`'s `_json_escape` already uses for the identical reason)
+  before writing the line, once inside `log()` itself rather than at each of the
+  (at least three) call sites that embed such text, so the class is closed
+  everywhere `log()` is used rather than only at the newest call site.

--- a/changelog.d/599.fixed.md
+++ b/changelog.d/599.fixed.md
@@ -7,8 +7,18 @@
   newline or carriage return embedded in that text landed at column 0 of the log
   file and read as a second, forged log entry to anything parsing the log -- a
   person skimming it, or a script (#599). `log()` now flattens every control byte
-  in the message to a plain space (`tr '[:cntrl:]' ' '`, the same remedy
+  in the message to a plain space (`LC_ALL=C tr '[:cntrl:]' ' '`, the same remedy
   `scripts/doctor.sh`'s `_json_escape` already uses for the identical reason)
   before writing the line, once inside `log()` itself rather than at each of the
   (at least three) call sites that embed such text, so the class is closed
   everywhere `log()` is used rather than only at the newest call site.
+  `LC_ALL=C` is load-bearing rather than decoration: those call sites cut the
+  model's reply with `head -c 80`, a byte-count cut with no regard for UTF-8
+  character boundaries, and under the caller's own UTF-8 locale a cut landing
+  mid-multibyte-character makes `tr` print "Illegal byte sequence", exit
+  nonzero, and truncate its own output at the bad byte -- silently dropping
+  everything logged after it, and, because `save-session.sh` runs under `set
+  -e`, aborting the whole script on the `message=$(...)` assignment whose exit
+  status is `tr`'s. Forcing the C locale makes `tr` classify every byte 0-255
+  on its own, identically on GNU and BSD, so a non-ASCII byte that is not
+  itself a control code passes through untouched instead of erroring.

--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -496,11 +496,26 @@ MEMORY_LOG_FILE="${REMEMBER_LOG_DIR}/memory-${MEMORY_LOG_DATE}.log"
 # Output:
 #   Appends "HH:MM:SS [component] message" to daily log file.
 #   Falls back to stderr if log file is unwritable.
+#
+# Several callers (save-session.sh's NDC and header-validation paths, since
+# #593) embed the first bytes of a model's reply straight into $2. That text
+# is untrusted -- not controlled by this codebase -- and a raw newline or
+# carriage return inside it would land at column 0 of the log file, reading
+# as a second, forged log entry to anything parsing the log (a person
+# skimming it, or a script). Flattened here, once, rather than at each of the
+# (at least three) call sites that embed such text, so the class is closed
+# everywhere log() is used, not just at the newest one (#599). Same remedy
+# doctor.sh's _json_escape already uses for the identical reason: `tr
+# '[:cntrl:]'` is a POSIX bracket expression, identical on GNU and BSD tr,
+# and it operates on the whole byte stream so an embedded newline is caught
+# even though `message` is a single shell variable, not a stream `sed` would
+# see as two records.
 log() {
     local component="$1"
     local message="$2"
     local timestamp
     timestamp=$(_remember_date +%H:%M:%S)
+    message="$(printf '%s' "$message" | tr '[:cntrl:]' ' ')"
     echo "${timestamp} [${component}] ${message}" >> "$MEMORY_LOG_FILE" 2>/dev/null \
         || echo "${timestamp} [${component}] ${message}" >&2
 }

--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -498,24 +498,34 @@ MEMORY_LOG_FILE="${REMEMBER_LOG_DIR}/memory-${MEMORY_LOG_DATE}.log"
 #   Falls back to stderr if log file is unwritable.
 #
 # Several callers (save-session.sh's NDC and header-validation paths, since
-# #593) embed the first bytes of a model's reply straight into $2. That text
-# is untrusted -- not controlled by this codebase -- and a raw newline or
-# carriage return inside it would land at column 0 of the log file, reading
-# as a second, forged log entry to anything parsing the log (a person
-# skimming it, or a script). Flattened here, once, rather than at each of the
-# (at least three) call sites that embed such text, so the class is closed
-# everywhere log() is used, not just at the newest one (#599). Same remedy
-# doctor.sh's _json_escape already uses for the identical reason: `tr
-# '[:cntrl:]'` is a POSIX bracket expression, identical on GNU and BSD tr,
-# and it operates on the whole byte stream so an embedded newline is caught
-# even though `message` is a single shell variable, not a stream `sed` would
-# see as two records.
+# #593) embed the first bytes of a model's reply straight into $2 via `head
+# -c 80`, a byte-count cut with no regard for UTF-8 character boundaries.
+# That text is untrusted -- not controlled by this codebase -- and a raw
+# newline or carriage return inside it would land at column 0 of the log
+# file, reading as a second, forged log entry to anything parsing the log (a
+# person skimming it, or a script). Flattened here, once, rather than at each
+# of the (at least three) call sites that embed such text, so the class is
+# closed everywhere log() is used, not just at the newest one (#599).
+#
+# LC_ALL=C is not decoration: under the caller's own UTF-8 locale, a `head
+# -c 80` cut landing mid-multibyte-character hands tr a malformed sequence,
+# and BOTH GNU and BSD tr respond to that by printing "tr: Illegal byte
+# sequence" to stderr, exiting nonzero, and truncating their output at the
+# bad byte -- silently dropping everything after it inside this
+# already-unchecked $(...) (self-review, #599). Forcing the C locale makes
+# tr classify every byte 0-255 on its own, the same on GNU and BSD, so a
+# byte that is part of a multibyte character but is not itself one of the
+# ASCII control codes (0-31, 127) passes through untouched rather than
+# erroring -- the class this function exists to close (an embedded literal
+# newline/CR/tab, always single-byte in UTF-8) is still caught, and the
+# malformed tail from an unrelated truncation is preserved instead of
+# silently vanishing.
 log() {
     local component="$1"
     local message="$2"
     local timestamp
     timestamp=$(_remember_date +%H:%M:%S)
-    message="$(printf '%s' "$message" | tr '[:cntrl:]' ' ')"
+    message="$(printf '%s' "$message" | LC_ALL=C tr '[:cntrl:]' ' ')"
     echo "${timestamp} [${component}] ${message}" >> "$MEMORY_LOG_FILE" 2>/dev/null \
         || echo "${timestamp} [${component}] ${message}" >&2
 }

--- a/tests/test_log_newline_sanitization_599.py
+++ b/tests/test_log_newline_sanitization_599.py
@@ -48,7 +48,14 @@ def _make_project(tmp_path):
 
 def _run(script, project_dir):
     env = {**os.environ, "PROJECT_DIR": _bash_path(project_dir)}
-    result = subprocess.run([_BASH, "-c", script], env=env, capture_output=True, text=True)
+    # errors="replace": one test deliberately writes a truncated multibyte
+    # UTF-8 sequence into the logged message (#599 self-review) -- log()
+    # must survive that at the shell level, but Python's own default strict
+    # decode would raise on the same malformed byte while just reading the
+    # subprocess's stdout back, before either assertion below ever runs.
+    result = subprocess.run(
+        [_BASH, "-c", script], env=env, capture_output=True, text=True, errors="replace"
+    )
     assert result.returncode == 0, f"script failed: {result.stderr}"
     return result
 
@@ -84,3 +91,42 @@ def test_ordinary_multifield_message_still_logs_fully(tmp_path):
     assert len(log_lines) == 1
     assert "[extract]" in log_lines[0]
     assert "42 exchanges (7 human), position -> 1234, span quarantined" in log_lines[0]
+
+
+def test_truncated_multibyte_reply_does_not_abort_or_lose_the_tail(tmp_path):
+    """Self-review finding (#599): save-session.sh's actual call sites cut a
+    model reply with `head -c 80`, a byte-count cut with no regard for UTF-8
+    character boundaries. Under the caller's own UTF-8 locale, handing tr a
+    sequence truncated mid-multibyte-character makes tr print "Illegal byte
+    sequence", exit nonzero, and truncate its own output at the bad byte --
+    silently dropping anything logged after it, and, because save-session.sh
+    runs under `set -e`, aborting the whole script on a `message=$(...)`
+    assignment whose exit status is tr's. A plain non-English model reply
+    (legitimate since #593) can trigger this on nothing more exotic than an
+    unlucky byte offset. `log()` must run to completion and keep whatever
+    text follows the malformed byte, not vanish it or die.
+    """
+    project = _make_project(tmp_path)
+    src = project / "badmb.txt"
+    # A snowman (U+2603, e2 98 83) cut after its first byte -- exactly what
+    # `head -c 80` does whenever the 80-byte offset lands inside a multibyte
+    # character in the model's reply.
+    src.write_bytes(b"abc" + b"\xe2" + b"def-tail-content")
+    script = f"""
+    set -e
+    export PROJECT_DIR="{_bash_path(project)}"
+    source "{_bash_path(LOG_SH)}"
+    log "ndc" "REJECTED: $(head -c 4 "{_bash_path(src)}")def-tail-content"
+    echo "SCRIPT_EXIT_OK"
+    cat "$MEMORY_LOG_FILE"
+    """
+    result = _run(script, project)
+    assert "SCRIPT_EXIT_OK" in result.stdout, (
+        "log() aborted the calling script under set -e instead of completing "
+        f"(stderr: {result.stderr!r})"
+    )
+    log_lines = [l for l in result.stdout.splitlines() if l.strip() and l != "SCRIPT_EXIT_OK"]
+    assert len(log_lines) == 1, f"malformed byte forged an extra log entry: {log_lines!r}"
+    assert "def-tail-content" in log_lines[0], (
+        f"content after the malformed byte was silently dropped: {log_lines[0]!r}"
+    )

--- a/tests/test_log_newline_sanitization_599.py
+++ b/tests/test_log_newline_sanitization_599.py
@@ -1,0 +1,86 @@
+"""Regression test for #599: embedded newline in log() forges a second entry."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LOG_SH = REPO_ROOT / "scripts" / "log.sh"
+
+
+def _bash_path(p) -> str:
+    return str(p).replace("\\", "/")
+
+
+def _find_bash():
+    if sys.platform != "win32":
+        return "bash"
+    import shutil
+    candidates = []
+    for env_var in ("ProgramFiles", "ProgramFiles(x86)", "ProgramW6432"):
+        base = os.environ.get(env_var)
+        if base:
+            candidates.append(Path(base) / "Git" / "bin" / "bash.exe")
+            candidates.append(Path(base) / "Git" / "usr" / "bin" / "bash.exe")
+    for cand in candidates:
+        if cand.is_file():
+            return str(cand)
+    resolved = shutil.which("bash")
+    if resolved and "git" in resolved.replace("\\", "/").lower():
+        return resolved
+    return None
+
+
+_BASH = _find_bash()
+pytestmark = pytest.mark.skipif(_BASH is None, reason="Git Bash not found (Windows without Git for Windows)")
+
+
+def _make_project(tmp_path):
+    project = tmp_path / "proj"
+    (project / ".claude" / "remember").mkdir(parents=True)
+    (project / ".remember" / "logs").mkdir(parents=True)
+    return project
+
+
+def _run(script, project_dir):
+    env = {**os.environ, "PROJECT_DIR": _bash_path(project_dir)}
+    result = subprocess.run([_BASH, "-c", script], env=env, capture_output=True, text=True)
+    assert result.returncode == 0, f"script failed: {result.stderr}"
+    return result
+
+
+def test_embedded_newline_does_not_forge_a_second_log_entry(tmp_path):
+    project = _make_project(tmp_path)
+    script = f"""
+    set -e
+    export PROJECT_DIR="{_bash_path(project)}"
+    source "{_bash_path(LOG_SH)}"
+    log "ndc" "REJECTED (provider: claude; not a summary): fake header
+[hook] session-start: PROJECT_DIR=/evil PIPELINE_DIR=/evil"
+    cat "$MEMORY_LOG_FILE"
+    """
+    result = _run(script, project)
+    log_lines = [l for l in result.stdout.splitlines() if l.strip()]
+    assert len(log_lines) == 1, f"embedded newline forged a second log entry: {log_lines!r}"
+    assert "[ndc]" in log_lines[0]
+    assert "[hook]" in log_lines[0], "message content lost, not just flattened"
+
+
+def test_ordinary_multifield_message_still_logs_fully(tmp_path):
+    project = _make_project(tmp_path)
+    script = f"""
+    set -e
+    export PROJECT_DIR="{_bash_path(project)}"
+    source "{_bash_path(LOG_SH)}"
+    log "extract" "42 exchanges (7 human), position -> 1234, span quarantined"
+    cat "$MEMORY_LOG_FILE"
+    """
+    result = _run(script, project)
+    log_lines = [l for l in result.stdout.splitlines() if l.strip()]
+    assert len(log_lines) == 1
+    assert "[extract]" in log_lines[0]
+    assert "42 exchanges (7 human), position -> 1234, span quarantined" in log_lines[0]


### PR DESCRIPTION
## What

log() (scripts/log.sh) wrote its message argument verbatim into the daily log
file, with no newline handling. Several call sites in
scripts/save-session.sh embed the first 80 bytes of a model's reply straight
into a log line -- untrusted text since #593 -- and an embedded newline
landed at column 0 of the log file, reading as a second, forged log entry to
anything parsing the log.

## Approach

Sanitize once, inside log() itself, rather than at each of the (at least
three) call sites that embed such text, so the class is closed everywhere
log() is used rather than only at the newest call site.

Follow-up commit: self-review (Explore + oss:auditor) found that
`tr '[:cntrl:]'` under the caller's own UTF-8 locale errors on a byte
sequence truncated mid-multibyte-character -- exactly what save-session.sh's
`head -c 80` cut of a model reply produces whenever the 80-byte offset lands
inside a multibyte character. `tr` then exits nonzero and truncates its own
output at the bad byte, and because save-session.sh runs under `set -e`, the
`message=$(...)` assignment's nonzero exit aborted the whole script on an
otherwise ordinary non-English model reply. `LC_ALL=C` makes tr classify
every byte 0-255 on its own, identically on GNU and BSD, so the
embedded-newline/CR/tab class this fix exists to close is still caught while
a non-ASCII byte that is not itself a control code passes through untouched.

## Verification

- **Observed:** tests/test_log_newline_sanitization_599.py pins both --
  sanitization of embedded control bytes, and
  test_truncated_multibyte_reply_does_not_abort_or_lose_the_tail (red without
  LC_ALL=C: script aborts, content lost; green with it).

## Changelog

changelog.d/599.fixed.md added.

Closes #599

This PR was assembled by a maintainer tick from two already-committed and
pushed commits (a developer lane dispatched in a prior tick whose handback
never opened the pull request) -- the commit messages above are that
developer's own record of the work and its self-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9WexZb39yUjQgJ53Zmf1c

[AI-generated]