### PR TITLE
Fix two test-suite amnesties: jq-probe line skip and promo-suppression silence

### DIFF
--- a/changelog.d/601.fixed.md
+++ b/changelog.d/601.fixed.md
@@ -1,0 +1,9 @@
+- Fixed: `tests/test_path_resolution.py`'s `test_scripts_use_jq_var_not_hardcoded`
+  excluded a `command -v jq` availability probe by `continue`-ing past the WHOLE
+  matched line, not just the probe span, so a hardcoded `jq` call sharing a line
+  with a probe would never reach any later check in that loop -- the exact
+  exclusion the docstring already promised ("but not `command -v jq`") never
+  actually implemented that way (#601). The scanning logic is now a standalone
+  `_line_has_hardcoded_jq()` helper that strips only the `command -v jq` substring
+  before scanning the rest of the line, closing the amnesty; a new regression test
+  pins a fixture line combining a probe and a hardcoded call on the same line.

--- a/changelog.d/602.fixed.md
+++ b/changelog.d/602.fixed.md
@@ -1,0 +1,7 @@
+- Fixed: `tests/test_plugin_promo_574.py`'s suppression tests (`test_suppressed_when_key_present`,
+  `test_cannot_tell_suppresses_like_installed`, `test_wrong_version_is_cannot_tell`) asserted only
+  that `systemMessage` was absent from the hook's output -- an assertion equally satisfied by the
+  hook printing nothing at all, on the one path covering the common every-session case (promo
+  suppressed, buffer flushed) (#602). Each now also asserts `=== REMEMBER ===` (the history hint
+  from `prompts/session-history-hint.txt`, printed unconditionally on every `SessionStart` run) is
+  present in the output, so a total-loss regression on this path fails the test instead of passing it.

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -1225,6 +1225,22 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from pipeline.extract import _session_dir
 
 
+def _line_has_hardcoded_jq(line):
+    """True if `line` uses a hardcoded `jq` call rather than `$JQ` (#601).
+
+    A `command -v jq` availability probe never invokes jq against real
+    input, so it is excluded -- but only the probe SPAN is removed before
+    the hardcoded-call check runs, not the whole line via `continue`. A
+    `continue` would silently amnesty a real hardcoded call sharing the
+    same line as a probe, since `continue` drops the entire line from
+    every later check in the loop, not just the probe check itself.
+    """
+    if line.strip().startswith("#"):
+        return False
+    scan = line.replace("command -v jq", "")
+    return " jq " in scan or "(jq " in scan or "$(jq " in scan
+
+
 class TestWindowsCompatIssue11:
     """GitHub issue #11: Windows compatibility — 6 sub-issues."""
 
@@ -1467,23 +1483,7 @@ class TestWindowsCompatIssue11:
                         "post-tool-hook.sh", "session-start-hook.sh"):
             with open(os.path.join(REPO_ROOT, "scripts", script)) as f:
                 for i, line in enumerate(f, 1):
-                    if line.strip().startswith("#"):
-                        continue
-                    # `command -v jq` is an AVAILABILITY PROBE, not an invocation --
-                    # it never runs jq against real input, so it is exactly the
-                    # exclusion this docstring already promised ("but not ...
-                    # 'command -v jq'") and never implemented (#574 CI follow-up):
-                    # the substring check below matches " jq " against "command -v
-                    # jq >/dev/null" too (the "v jq >" span), refusing a guard the
-                    # comment says is fine. Skipped BEFORE the substring check, not
-                    # folded into it, so a real hardcoded call on the SAME line as
-                    # a probe (unlikely, but not this test's job to rule out) still
-                    # has a chance to be caught by a later line instead of being
-                    # silently amnestied by one `continue`.
-                    if "command -v jq" in line:
-                        continue
-                    # Match raw 'jq' but not '$JQ' or 'JQ=' or 'command -v jq'
-                    if " jq " in line or "(jq " in line or "$(jq " in line:
+                    if _line_has_hardcoded_jq(line):
                         assert False, (
                             f"{script}:{i} uses hardcoded jq: {line.strip()}"
                         )
@@ -1491,20 +1491,37 @@ class TestWindowsCompatIssue11:
     def test_scripts_use_jq_var_not_hardcoded_allows_command_dash_v_probe(self):
         """Positive control for the exclusion above (#574 CI follow-up).
 
-        Without the `continue` on a `command -v jq` line, this exact shape --
-        session-start-hook.sh's own jq-availability guard -- trips the hardcoded-
-        jq check even though the docstring explicitly says it should not: the
-        naive `" jq " in line` substring test matches the `v jq >` span inside
-        `command -v jq >/dev/null 2>&1 || return 0`. Asserted directly against
-        the scanning logic (not just "the real file happens to pass today") so a
-        future edit that deletes the `continue` fails this test even if nobody
-        touches session-start-hook.sh again.
+        Without excluding the `command -v jq` probe SPAN, this exact shape --
+        session-start-hook.sh's own jq-availability guard -- would trip the
+        hardcoded-jq check even though the docstring explicitly says it should
+        not: the naive `" jq " in line` substring test matches the `v jq >`
+        span inside `command -v jq >/dev/null 2>&1 || return 0`. Asserted
+        directly against the real scanning function (not just "the real file
+        happens to pass today") so a future edit that removes the exclusion
+        fails this test even if nobody touches session-start-hook.sh again.
         """
         line = "command -v jq >/dev/null 2>&1 || return 0\n"
         assert "command -v jq" in line
         # The exact substring the un-excluded check would have matched --
         # confirms this is a real trip hazard and not a hypothetical one.
         assert " jq " in line
+        assert not _line_has_hardcoded_jq(line)
+
+    def test_scripts_use_jq_var_not_hardcoded_catches_call_sharing_probe_line(self):
+        """#601: a hardcoded jq call sharing a line with a `command -v jq`
+        probe must still be caught.
+
+        The old scanning logic used `continue` to skip any line containing
+        `command -v jq`, which drops the ENTIRE line from every later check
+        in the loop -- not just the probe check. A real hardcoded jq call
+        appended to the same line as a probe (e.g. `command -v jq
+        >/dev/null 2>&1 && jq -r '.x' file.json`) would therefore never be
+        examined at all. Narrowing the exclusion to the probe SPAN itself
+        (stripping `command -v jq` before scanning) closes that gap: this
+        line must be flagged, not amnestied.
+        """
+        line = "command -v jq >/dev/null 2>&1 && jq -r '.x' file.json\n"
+        assert _line_has_hardcoded_jq(line)
 
     def test_jq_fallback_reads_json(self, tmp_path):
         """The jq fallback correctly reads a value from a JSON file."""

--- a/tests/test_plugin_promo_574.py
+++ b/tests/test_plugin_promo_574.py
@@ -145,6 +145,13 @@ class TestPromoOnlyWhenNotInstalled:
         # No systemMessage at all: plain-text output, byte-for-byte the old shape.
         assert not out.lstrip().startswith("{")
         assert "systemMessage" not in out
+        # Positive control (#602): both assertions above pass just as well if
+        # the hook printed nothing at all. `=== REMEMBER ===` is the history
+        # hint (prompts/session-history-hint.txt) printed unconditionally on
+        # every SessionStart run, on the plain-text path, after the promo
+        # decision -- its presence proves the hook actually ran this path
+        # rather than emitting nothing.
+        assert "=== REMEMBER ===" in out
 
     def test_cannot_tell_suppresses_like_installed(self, tmp_path):
         """installed_plugins.json absent -> cannot-tell -> no promo, ever.
@@ -154,10 +161,14 @@ class TestPromoOnlyWhenNotInstalled:
         """
         out, _home, _remember = _run(tmp_path, write_installed=False)
         assert "systemMessage" not in out
+        # Positive control (#602): see test_suppressed_when_key_present.
+        assert "=== REMEMBER ===" in out
 
     def test_wrong_version_is_cannot_tell(self, tmp_path):
         out, _home, _remember = _run(tmp_path, installed_keyed={}, installed_version="1")
         assert "systemMessage" not in out
+        # Positive control (#602): see test_suppressed_when_key_present.
+        assert "=== REMEMBER ===" in out
 
 
 class TestOffSwitch:


### PR DESCRIPTION
## What

Bundle of two unrelated, test-suite-only fixes (no user-facing behavior change), sharing a worktree because their files do not overlap with any other running lane.

### #601: jq-probe line skip amnesties the whole line

`tests/test_path_resolution.py`'s `test_scripts_use_jq_var_not_hardcoded` used `continue` to skip an ENTIRE line whenever it matched `command -v jq` (a legitimate availability probe). `continue` drops the whole line from every later check in the loop, so a hardcoded `jq` call sharing that same line with a probe would never be examined at all -- the exact exclusion the adjacent comment claimed (incorrectly) was still safe.

Extracted the scanning logic into a module-level helper, `_line_has_hardcoded_jq(line)`, that strips only the `command -v jq` substring before checking the rest of the line for a hardcoded invocation, instead of skipping the whole line. Closes the class rather than just correcting the comment.

TDD: added `test_scripts_use_jq_var_not_hardcoded_catches_call_sharing_probe_line` with a fixture line combining a probe and a hardcoded call on one line. Confirmed RED against the old whole-line-skip logic, then GREEN after narrowing the skip to the probe span. Grepped all four scanned scripts and confirmed the narrowing does not surface any previously-amnestied real violation currently in this repo.

Closes #601

### #602: promo-suppression tests have no positive control

Three tests in `tests/test_plugin_promo_574.py` (`test_suppressed_when_key_present`, `test_cannot_tell_suppresses_like_installed`, `test_wrong_version_is_cannot_tell`) asserted only `"systemMessage" not in out` -- satisfied equally by the hook printing nothing at all. `test_suppressed_when_key_present` in particular is the one test covering the common every-session path (feature on, promo suppressed, buffer flushed).

Each now also asserts `"=== REMEMBER ===" in out` -- the history-hint marker from `prompts/session-history-hint.txt`, `cat`'d unconditionally by `scripts/session-start-hook.sh` on every `SessionStart` run, after the promo decision, regardless of whether the promo fired. Verified this by running the real hook against the tests' own fixtures and reading stdout directly, and by tracing the surrounding control flow for any early-exit that could skip it in these fixtures (there is none).

TDD: confirmed RED with a stub script emitting nothing (old assertions pass, new assertion fails), then GREEN against the real hook path.

All three named tests (lines 145/156/160 of the issue) fixed, since they share the identical flaw.

Closes #602

## Also noticed (not fixed here)

The identical shape recurs in TestOffSwitch and TestThrottle (`test_disabled_via_project_config_suppresses` and `test_repeat_session_within_cooldown_does_not_repromote`): both assert only
`"systemMessage" not in <stdout>` with no positive control, and would equally
pass on total output loss. Not fixed here because #602 named only the three
`TestPromoOnlyWhenNotInstalled` tests explicitly, and fixing these two would
have widened the diff beyond what was asked. Same one-line fix
(`assert "=== REMEMBER ===" in <stdout var>`) would close it, if wanted as a
follow-up.

## Test plan

- `python3 -m pytest tests/test_path_resolution.py tests/test_plugin_promo_574.py -q --no-cov` -- 185 passed.
- `python3 .oss/assemble_changelog.py --check` -- ok, both fragments named their issue.
- Reviewed by both `Explore` and `oss:auditor` against the committed diff -- NO FINDINGS from both, independently verified rather than skimmed (re-derived the helper logic by hand, grepped all four scripts, traced the marker's control flow, checked the CI matrix genuinely runs windows-latest so the pre-existing win32 skip on both files is not vacuous).
- Full `pytest` not run locally, per house convention -- CI is the gate for the whole matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-generated]