### PR TITLE
Fix: NDC commit race where a stale offset survives the size check (#614)

### DIFF
--- a/changelog.d/614.fixed.md
+++ b/changelog.d/614.fixed.md
@@ -1,0 +1,25 @@
+- Fixed: a narrow NDC compression race (#614) could silently drop bytes from
+  `now.md` that existed nowhere else -- not in `now.md`, not in any
+  `today-*.md`. NDC's own commit re-checks the size of `now.md` under the save
+  lock before trusting its pre-Haiku byte offset, but a *size* check alone
+  cannot tell a legitimate append from a REPLACEMENT that happens to still be
+  at least as long: exactly what another, overlapping NDC round's own commit
+  produces (its own tail, written over `now.md` by its own `mv`). Two
+  overlapping rounds are reachable when a second round's hour-long cooldown
+  gate opens while the first round's Haiku call, or its own lock-reacquisition
+  wait, is still in flight -- for example across a laptop sleep/wake spanning
+  the cooldown. When that happens, the second-committing round's own
+  `tail -c +N` offset no longer describes any real boundary in the file, and
+  can slice into bytes its own Haiku call never summarized.
+  `save-session.sh` now tracks a small monotonic generation counter
+  (`.remember/tmp/ndc-generation`), bumped by every NDC commit that lands and
+  checked, under the same lock, before any later round is allowed to commit --
+  any mismatch means a commit has landed since that round's snapshot was
+  taken, and the round is skipped exactly like the pre-existing "shrank below
+  the snapshot" case, rather than acting on a now-meaningless offset.
+  A prior triage pass on #614 could not confirm the reporter's own suspected
+  cause (a hook blind-truncating `now.md`) -- the append path never truncates,
+  and this race is unrelated to that guess. `tests/test_ndc_commit_lock.py`
+  adds a regression test that reproduces the exact byte loss (a replacement
+  at least as long as the stale snapshot, going undetected by the byte-count
+  check alone) and confirms the generation check now catches it.

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -87,6 +87,20 @@ LOCK_DIR="${REMEMBER_DIR}/tmp/save.lock"
 # without pinning a lock for half a minute — same shape as _LOCK_ADOPT_AFTER.
 NDC_COMMIT_LOCK_TIMEOUT="${REMEMBER_NDC_COMMIT_LOCK_TIMEOUT:-30}"
 MEMORY_FILE="${REMEMBER_DIR}/now.md"
+# Monotonic counter, bumped by every NDC commit that lands (#614). The
+# byte-count staleness check below (NDC_LIVE_BYTES < NDC_SRC_BYTES) only
+# catches a replacement that ends up SHORTER than the snapshot it is being
+# checked against. Two overlapping NDC rounds -- reachable when a second
+# round's cooldown gate opens while the first round's Haiku call, or its own
+# NDC_COMMIT_LOCK_TIMEOUT wait, is still in flight (e.g. a laptop sleep/wake
+# spanning the hour-long cooldown) -- can have the FIRST round's commit
+# already retire+replace now.md with its own tail before the SECOND round
+# reaches its own commit check. If enough was appended in between that the
+# replacement is still >= the second round's now-meaningless offset, the size
+# check alone passes and `tail -c +N` slices into bytes the second round's
+# own Haiku call never summarized -- content that then exists nowhere. See
+# Step 8 for where this is read and bumped, both under LOCK_DIR.
+NDC_GEN_FILE="${REMEMBER_DIR}/tmp/ndc-generation"
 # Which day now.md's contents belong to (#141) — see Step 7.
 NOW_DAY_FILE="${REMEMBER_DIR}/tmp/now-day"
 LAST_SAVE_FILE="${REMEMBER_DIR}/tmp/last-save.json"
@@ -850,6 +864,15 @@ if [ "$RUN_NDC" = true ]; then
     log "ndc" "now.md -> today-${NDC_DAY}.md"
     date +%s > "$NDC_MARKER"
     NDC_SRC_BYTES=$(wc -c < "$MEMORY_FILE" | tr -d ' ')
+    # Read under LOCK_DIR, which this (parent) process still holds at this
+    # point in the script — see #614's NDC_GEN_FILE comment above. A prior
+    # round's committed generation is the value this round's own offset is
+    # only valid against; anything else means a commit has landed since and
+    # the offset no longer describes a real boundary in the live file.
+    NDC_SRC_GEN=$(cat "$NDC_GEN_FILE" 2>/dev/null || echo 0)
+    case "$NDC_SRC_GEN" in
+        (''|*[!0-9]*) NDC_SRC_GEN=0 ;;
+    esac
     NDC_PROMPT=$(mktemp "${TMPDIR:-/tmp}"/remember-ndc-XXXXXX)
 
     cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell build-ndc-prompt "$MEMORY_FILE" "$NDC_PROMPT"
@@ -1002,8 +1025,24 @@ if [ "$RUN_NDC" = true ]; then
                         case "$NDC_LIVE_BYTES" in
                             (''|*[!0-9]*) NDC_LIVE_BYTES=0 ;;
                         esac
+                        # #614: size alone cannot tell a legitimate append from
+                        # a REPLACEMENT that happens to still be >= this
+                        # round's snapshot -- and a replacement is exactly what
+                        # another NDC round's own commit produces (its own
+                        # tail, written over now.md by its own `mv`). Read
+                        # under the same LOCK_DIR this block already holds:
+                        # any generation other than the one this round started
+                        # against means such a commit has landed since, and
+                        # this round's offset no longer describes a real
+                        # boundary in the live file, regardless of size.
+                        NDC_LIVE_GEN=$(cat "$NDC_GEN_FILE" 2>/dev/null || echo 0)
+                        case "$NDC_LIVE_GEN" in
+                            (''|*[!0-9]*) NDC_LIVE_GEN=0 ;;
+                        esac
                         if [ "$NDC_LIVE_BYTES" -lt "$NDC_SRC_BYTES" ]; then
                             log "ndc" "SKIPPED commit: now.md is ${NDC_LIVE_BYTES}b, below the ${NDC_SRC_BYTES}b snapshot this offset was taken from -- left untouched (today-${NDC_DAY}.md may now hold a duplicate of this span)"
+                        elif [ "$NDC_LIVE_GEN" != "$NDC_SRC_GEN" ]; then
+                            log "ndc" "SKIPPED commit: another NDC round already committed since this round's snapshot (generation ${NDC_SRC_GEN} -> ${NDC_LIVE_GEN}) -- now.md left untouched, this round's offset no longer describes a real boundary (today-${NDC_DAY}.md may now hold a duplicate of this span)"
                         else
                             # Beside now.md, not in $TMPDIR (#242). #142's whole
                             # argument for why this commit is safe is "mv-over is
@@ -1090,6 +1129,15 @@ if [ "$RUN_NDC" = true ]; then
                                         rm -f "$NOW_DAY_FILE"
                                     fi
                                     [ "$NDC_KEPT" -gt 0 ] && log "ndc" "kept ${NDC_KEPT}b appended during compression"
+                                    # #614: retire this round's own offset for
+                                    # every OTHER live round (there can be at
+                                    # most one concurrently reachable given
+                                    # the hour-long cooldown, but nothing here
+                                    # depends on that staying true). Written
+                                    # under the same LOCK_DIR this commit just
+                                    # used, right after the mv that makes it
+                                    # true.
+                                    echo $(( NDC_SRC_GEN + 1 )) > "$NDC_GEN_FILE" 2>/dev/null || true
                                 else
                                     # now.md still holds every byte it had, so the
                                     # marker describing that content is still

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -1143,7 +1143,8 @@ if [ "$RUN_NDC" = true ]; then
                                     # above accepts a leading zero ("08"),
                                     # which bash arithmetic reads as octal and
                                     # "08"/"09" are not valid octal digits --
-                                    # `$(( NDC_SRC_GEN + 1 ))` would abort that
+                                    # feeding a bare NDC_SRC_GEN into `$(( ))`
+                                    # without that prefix would abort the
                                     # statement instead of bumping the
                                     # counter. record_summary_failure() hit
                                     # this exact shape and fixed it the same

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -1137,7 +1137,31 @@ if [ "$RUN_NDC" = true ]; then
                                     # under the same LOCK_DIR this commit just
                                     # used, right after the mv that makes it
                                     # true.
-                                    echo $(( NDC_SRC_GEN + 1 )) > "$NDC_GEN_FILE" 2>/dev/null || true
+                                    #
+                                    # `10#$NDC_SRC_GEN` (#332's own fix,
+                                    # applied here too): the digit-only guard
+                                    # above accepts a leading zero ("08"),
+                                    # which bash arithmetic reads as octal and
+                                    # "08"/"09" are not valid octal digits --
+                                    # `$(( NDC_SRC_GEN + 1 ))` would abort that
+                                    # statement instead of bumping the
+                                    # counter. record_summary_failure() hit
+                                    # this exact shape and fixed it the same
+                                    # way (see its own `10#$_prev_count`).
+                                    #
+                                    # Logged, not `|| true` alone: a failed
+                                    # write here leaves the on-disk generation
+                                    # at its PRE-commit value even though the
+                                    # commit itself already landed (the mv
+                                    # above already succeeded) -- silently
+                                    # reopening the exact #614 window this
+                                    # check exists to close, for any other
+                                    # round that snapshotted the same
+                                    # generation. Matches the sibling mv
+                                    # failure's own logging a few lines above.
+                                    if ! NDC_GEN_ERR=$(echo $(( 10#$NDC_SRC_GEN + 1 )) > "$NDC_GEN_FILE" 2>&1); then
+                                        log "ndc" "WARNING: could not bump ${NDC_GEN_FILE} past ${NDC_SRC_GEN} -- a later round that started from this same generation will not detect that this commit already landed: ${NDC_GEN_ERR:-unknown error}"
+                                    fi
                                 else
                                     # now.md still holds every byte it had, so the
                                     # marker describing that content is still

--- a/tests/test_ndc_commit_lock.py
+++ b/tests/test_ndc_commit_lock.py
@@ -213,3 +213,51 @@ class TestNdcCommitLock:
         assert "SKIPPED commit" in _log_text(project), (
             "acting on a stale offset must be refused out loud, not silently"
         )
+
+    def test_commit_skips_when_now_md_was_replaced_by_a_later_committed_round(self, tmp_path):
+        """#614: a stale offset that survives the size check is still stale.
+
+        The size check above (`NDC_LIVE_BYTES < NDC_SRC_BYTES`) only catches a
+        REPLACEMENT that ends up SHORTER than the snapshot. Two overlapping NDC
+        rounds -- reachable when a second round's cooldown gate opens while the
+        first round's Haiku call (or its own NDC_COMMIT_LOCK_TIMEOUT wait) is
+        still in flight, e.g. after a laptop sleep/wake spanning the cooldown --
+        can have the FIRST round's own commit already retire+replace now.md with
+        a whole new file (its own tail past ITS offset) before the SECOND round
+        reaches its commit check. If enough was appended in between that the
+        replacement's size is still >= the second round's own (now meaningless)
+        snapshot offset, the size check passes and `tail -c +N` cuts into bytes
+        that were never part of what this round's own Haiku call summarized --
+        content that then exists nowhere: not in now.md, not in any today-*.md.
+        """
+        env, project, plugin, calls, sid = _ndc_env(tmp_path)
+        memory_file = project / ".remember" / "now.md"
+
+        # Stands in for "another NDC round already committed its own tail here
+        # first" (see the comment above `NDC_LIVE_BYTES` re: "a rotation, or an
+        # earlier NDC round that committed its own tail first"). Longer than
+        # this round's own pre-Haiku snapshot (~36 bytes in this harness), so
+        # the size-only check cannot tell it apart from legitimate growth --
+        # but it is unrelated content this round's offset says nothing about.
+        head = "REPLACEMENT-HEAD-MUST-SURVIVE-0123456789\n"
+        tail_text = "TAIL-CONTENT-KEPT\n"
+        env = dict(env)
+        env["STUB_REPLACE_DURING_NDC"] = head + tail_text
+
+        result = _run(plugin, env, sid)
+        assert result.returncode == 0, subprocess_failure_detail(
+            result, project / ".remember"
+        )
+
+        remaining = _wait_for_background_ndc(memory_file)
+        today_text = "".join(
+            f.read_text() for f in (project / ".remember").glob("today-*.md")
+        )
+        assert head.strip() in remaining or head.strip() in today_text, (
+            "now.md was replaced by another round's own committed tail between "
+            "this round's snapshot and its commit; the replacement's own "
+            "content is live data no compression here has ever seen, and this "
+            "round's `tail -c +N` sliced into it using an offset that no "
+            "longer describes any real boundary in the file -- losing bytes "
+            "that exist nowhere else (#614)"
+        )

--- a/tests/test_save_session_gates.py
+++ b/tests/test_save_session_gates.py
@@ -96,12 +96,21 @@ elif cmd == "call-haiku":
         with open(os.environ["STUB_MEMORY_FILE"], "a") as f:
             f.write(os.environ["STUB_APPEND_DURING_NDC"])
     if is_ndc and os.environ.get("STUB_REPLACE_DURING_NDC"):
-        # Stand in for now.md being REPLACED with something shorter while the
-        # compression is in flight — a rotation, or another NDC round that
-        # committed its own tail first. The snapshot offset then points past
-        # the end of a file it no longer describes (#223).
+        # Stand in for now.md being REPLACED while the compression is in
+        # flight — a rotation, or another NDC round that committed its own
+        # tail first. The snapshot offset then points past the end of a file
+        # it no longer describes (#223), or — if the replacement happens to
+        # be at least as long as the snapshot — into the WRONG file, one the
+        # offset was never taken from at all (#614).
         with open(os.environ["STUB_MEMORY_FILE"], "w") as f:
             f.write(os.environ["STUB_REPLACE_DURING_NDC"])
+        # A real "another round already committed" bumps the generation
+        # counter as part of that commit (#614's own fix) — reproduce that
+        # here so this stub models what actually produces a replacement, not
+        # just its byte-level shape.
+        gen_file = os.path.join(os.path.dirname(os.environ["STUB_MEMORY_FILE"]), "tmp", "ndc-generation")
+        with open(gen_file, "w") as f:
+            f.write("1")
     if is_ndc and os.environ.get("STUB_HOLD_LOCK_DURING_NDC"):
         # Take the save lock and keep it, so the NDC commit that runs after
         # this call returns is guaranteed to find it held by a LIVE process


### PR DESCRIPTION
Closes #614.

## What was actually wrong

The reporter's own suspected cause (a hook blind-truncating `now.md`) is **not** what is happening -- confirmed by reading `scripts/save-session.sh` in full. The ordinary append path (a `cat old > tmp; append entry; mv tmp -> now.md` sequence under `save.lock`) never truncates; that class of bug (#142) stays closed.

The real gap is narrower and lives entirely inside NDC (Now-Day Compression), the backgrounded subshell that snapshots `now.md`'s byte length before an up-to-180s Haiku call, then later re-acquires the save lock and commits by `tail -c +(snapshot+1)` of whatever `now.md` holds at commit time. The existing staleness guard only checked `NDC_LIVE_BYTES < NDC_SRC_BYTES` (skip if the live file shrank below the snapshot). It never considered a replacement that is the same size or larger -- which is exactly what happens when a second, overlapping NDC round's own commit lands first (its own tail, written over `now.md` by its own `mv`). The first-to-commit round's replacement can easily be `>=` a later round's now-stale snapshot size, which passes the size check and lets `tail -c +N` slice into content that round's own Haiku call never summarized -- lost from `now.md` and never written to any `today-*.md` either.

Two overlapping NDC rounds require the shared hour-long cooldown marker to be legitimately re-passed while an earlier round is still alive -- not reachable via two ordinary sibling-worktree sessions saving close together under default config, but reachable via e.g. a laptop sleep/wake spanning the cooldown window, or the marker's own documented self-heal path recurring.

## Reproduction

Confirmed red before the fix with a targeted scratch repro (using the existing `STUB_REPLACE_DURING_NDC` harness hook, already built for "now.md replaced mid-compression -- a rotation, or another NDC round that committed its own tail first"): a replacement longer than the snapshot but otherwise unrelated to it loses its own first bytes, present nowhere -- not in `now.md`, not in any `today-*.md`. Turned into a tracked regression test, `tests/test_ndc_commit_lock.py::TestNdcCommitLock::test_commit_skips_when_now_md_was_replaced_by_a_later_committed_round`, red before the fix (`AssertionError`), green after, alongside the other 27 NDC-adjacent tests (all still green).

## The fix

Adds a small monotonic generation counter file, `.remember/tmp/ndc-generation`: read under the save lock at snapshot time, re-checked under the same lock at commit time, mismatch skips the commit exactly like the pre-existing size-based skip, bumped by 1 on every successful commit. This closes the exact window the byte-count-only check missed -- size alone cannot distinguish a legitimate append from a same-or-larger replacement, but a counter bumped only by an actual commit can.

## Self-review

Spawned `Explore` and `oss:auditor` concurrently against the first commit; both independently flagged the same real defect from different angles (a swallowed write-failure on the generation-bump, silently reopening the exact race being fixed for that one round -- below-bar consideration weighed and rejected since it is directly load-bearing for the fix's own guarantee, so it was fixed rather than filed), and `Explore` additionally caught a leading-zero octal-parsing bug in the new arithmetic, matching a precedent this same file already fixed once (`record_summary_failure()`'s `10#$_prev_count`, #332). Both fixed in a second commit; all 28 NDC-adjacent tests re-ran green.

Neither commit required `test_command`'s full suite -- run narrowly (`pytest tests/test_ndc_*.py -q`, 131 tests including every `save_session`/`ndc`-keyed test), per the developer brief's own guidance; CI is the gate for the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-generated]