### PR TITLE
Fix stale changelog claim about #595/#613 (#617), and comma-splitting lane undercount in statusline (#622)

### DIFF
--- a/.oss/statusline.py
+++ b/.oss/statusline.py
@@ -1651,32 +1651,34 @@ def _gh_unlabelled_issue_counts(repo, total, priority_labels, lane_labels):
             "per_page=100",
             "--jq",
             ".[] | select(.pull_request == null)"
-            ' | "L:" + ([.labels[].name] | join(","))',
+            " | ([.labels[].name] | tojson)",
         ],
         timeout=25,
     )
     if out is None:
         return None
-    # The "L:" prefix on every line (rather than a bare comma-joined list) is not
-    # decoration -- `_run` strips the whole blob's leading/trailing whitespace, and
-    # an issue with zero labels would otherwise print a genuinely empty line. That
-    # line is real data (one issue read, and it carries neither axis's label), but a
-    # *trailing* empty line -- the last open issue in the page happening to carry no
-    # labels -- is indistinguishable from ordinary trailing whitespace and would be
-    # silently stripped away, undercounting `lines` by one against `total` below and
-    # failing the cross-check for a page that was, in fact, read completely. Every
-    # line is non-empty by construction with the prefix in place, so `.strip()` never
-    # eats one.
+    # One JSON array per line, `tojson`-encoded server-side, rather than the earlier
+    # comma-joined string this used to split back apart in Python. A GitHub label name
+    # may legally contain a comma -- a label literally named e.g. `blocked,lane-storage`
+    # split into two names under the old scheme, one of which could coincidentally
+    # collide with a real declared lane, so the issue silently counted as *placed in a
+    # lane* when no triage sweep had placed it there (#622). `tojson` needs no delimiter
+    # a label name could ever contain, and unlike the old bare comma-joined line, `[]`
+    # (zero labels) is never empty, so there is no longer a trailing-blank-line hazard
+    # to guard against with a prefix.
     lines = out.split("\n") if out else []
     if len(lines) != total:
         return None
     no_priority = 0
     no_lane = 0
     for line in lines:
-        if not line.startswith("L:"):
+        try:
+            parsed = json.loads(line)
+        except ValueError:
             return None
-        names = set(line[2:].split(",")) if line[2:] else set()
-        names.discard("")
+        if not isinstance(parsed, list):
+            return None
+        names = {str(name) for name in parsed}
         if priority_set and not (names & priority_set):
             no_priority += 1
         if lane_set and not (names & lane_set):

--- a/changelog.d/617.fixed.md
+++ b/changelog.d/617.fixed.md
@@ -1,0 +1,16 @@
+- Fixed: the CHANGELOG.md entry for #595 (folded into the 0.29.1 release
+  section) stated as current fact that `docs/windows-skip-triage.md` "now
+  states 102/82" and that `tests/test_windows_skip_triage_prose_totals_595.py`
+  is "a new guard" tying that doc's prose sentences to its own table. Both
+  were true only for the few commits between #595's own merge and #613's:
+  three commits later in that same release, #613 (landed as PR #615) removed
+  the hand-maintained prose counts from the doc entirely and replaced the
+  guard with `tests/test_windows_skip_triage_no_stale_prose_counts_613.py`,
+  which the #613 entry a little further down the same release section
+  already documents correctly. This fragment is not a correction to
+  `changelog.d/595.fixed.md` itself -- that file was already folded into
+  `CHANGELOG.md` and deleted by the time #617 was filed, so there is nothing
+  left under `changelog.d/` to amend. Read the #595 entry as a historical
+  record of what PR #605 did, not as a claim about the doc's state at HEAD;
+  the #613 entry immediately below it in the same release is the current
+  description (#617).

--- a/changelog.d/622.fixed.md
+++ b/changelog.d/622.fixed.md
@@ -1,0 +1,20 @@
+- Fixed: `_gh_unlabelled_issue_counts` in `.oss/statusline.py` built one line per
+  open issue by joining its label names with `,` in a `gh api --jq` call and
+  splitting that line back apart in Python. A GitHub label name may legally
+  contain a comma -- a label literally named e.g. `blocked,lane-storage` split
+  into two names, one of which (`lane-storage`) could coincidentally collide
+  with a real declared lane, so the issue silently counted as *placed in a
+  lane* when no triage sweep had actually placed it there. The direction of
+  the error was an under-count of `no_lane`/`no_priority`, the opposite of
+  this function's own documented convention of never under-counting -- and
+  the existing `len(lines) != total` cross-check could not catch it, because
+  the line count stayed correct; only the per-line parse was wrong (#622).
+  The wire format is now one JSON array of label names per line
+  (`[.labels[].name] | tojson` server-side, `json.loads` in Python) instead
+  of a comma-joined string, closing the hole with a delimiter no label name
+  can contain rather than trying to escape or reject commas after the fact.
+  `.oss/statusline.py` had no test coverage before this change; a first,
+  narrow test file (`tests/test_statusline_gh_unlabelled_issue_counts_622.py`)
+  covers this one function directly by stubbing `_run`, rather than adding
+  broader coverage for the module -- the smallest fix proportionate to what
+  was actually reported.

--- a/tests/test_statusline_gh_unlabelled_issue_counts_622.py
+++ b/tests/test_statusline_gh_unlabelled_issue_counts_622.py
@@ -1,0 +1,57 @@
+"""#622: a GitHub label name may legally contain a comma. The old wire format for
+``_gh_unlabelled_issue_counts`` joined a label list with ``,`` and split it back apart
+in Python, so a label literally named e.g. ``blocked,lane-storage`` split into two
+names, one of which can coincidentally collide with a real declared lane -- counting
+an issue as *placed in a lane* when no triage sweep ever placed it there. That is an
+under-count of ``no_lane``/``no_priority``, the opposite of this function's own
+documented convention (never under-count; return ``None`` when a reading cannot be
+trusted).
+
+Each case below stubs ``statusline._run`` directly rather than shelling out to a real
+``gh`` -- reproducing the collapse needs no GitHub label-creation rights, only a
+comma-bearing label name fed through the same code path the real ``gh api --jq`` call
+would produce.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / ".oss"))
+
+import statusline
+
+LANES = ["lane-capture", "lane-storage", "lane-other"]
+PRIORITIES = ["priority:high", "priority:low"]
+
+
+def test_comma_bearing_label_name_is_not_split_into_a_false_lane_match(monkeypatch):
+    """Positive: the defect. A single label literally named
+    ``blocked,lane-storage`` must not be read as two labels, one of which
+    (``lane-storage``) happens to be a real declared lane -- the issue carries no
+    real lane label at all and must count toward ``no_lane``.
+    """
+    monkeypatch.setattr(
+        statusline,
+        "_run",
+        lambda command, timeout=25: '["blocked,lane-storage"]',
+    )
+    result = statusline._gh_unlabelled_issue_counts(
+        "acme/widgets", 1, PRIORITIES, LANES
+    )
+    assert result == {"no_priority": 1, "no_lane": 1}
+
+
+def test_ordinary_comma_free_labels_still_count_correctly(monkeypatch):
+    """Positive control: an issue with a real, comma-free lane label and no
+    priority label must still read as placed-in-a-lane / no-priority -- the fix
+    must not break the ordinary case while closing the comma hole.
+    """
+    monkeypatch.setattr(
+        statusline,
+        "_run",
+        lambda command, timeout=25: '["lane-storage"]',
+    )
+    result = statusline._gh_unlabelled_issue_counts(
+        "acme/widgets", 1, PRIORITIES, LANES
+    )
+    assert result == {"no_priority": 1, "no_lane": 0}


### PR DESCRIPTION
Two unrelated issues bundled in one lane because their fixed cost is otherwise duplicated; each keeps its own test story and its own changelog fragment.

## #617 -- stale changelog claim

`changelog.d/595.fixed.md`, the fragment the issue named, no longer exists in this tree: it was already folded into `CHANGELOG.md` and deleted by the 0.29.1 release commit (`1f5d3f9`), which was cut earlier the same day this lane ran. Verified independently with the two greps the issue itself suggests:

```
grep -nE '[0-9]+ (of|modules|files|tests|rows|skips)|all [0-9]+|these [0-9]+' docs/windows-skip-triage.md   # no matches
ls tests/test_windows_skip_triage_prose_totals_595.py   # No such file or directory
```

Both agree with the issue text. `git log --oneline --follow -- changelog.d/595.fixed.md` shows the fragment was created by `7819c5e` (PR #605, closing #595) and deleted only by the release commit -- so there is nothing left under `changelog.d/` to amend. Three commits later, still before that release, PR #615 (closing #613) removed the doc's hand-maintained prose numbers entirely and replaced the guard test with `tests/test_windows_skip_triage_no_stale_prose_counts_613.py`. Both the #595 entry and the #613 entry that supersedes it ended up folded into the same `CHANGELOG.md` release section (0.29.1) -- the #595 entry (lines ~12-25) states the stale claim as fact, and the #613 entry (lines ~103-114) further down the same section already documents the correction.

Rather than hand-editing an already-released `CHANGELOG.md` entry (against `changelog.d/README.md`'s own convention of never hand-editing the assembled file), this adds a new fragment, `changelog.d/617.fixed.md`, that records the correction as an erratum: read the #595 entry as history of what PR #605 did at the time, not as a claim about the doc's state at HEAD, and read the #613 entry as the current description. No code, doc, or test file changed for #617 -- only the new fragment.

## #622 -- comma-splitting lane undercount

`_gh_unlabelled_issue_counts` in `.oss/statusline.py` built one line per open issue via `gh api --jq` as `"L:" + ([.labels[].name] | join(","))`, then split that line on `,` in Python. A GitHub label name may legally contain a comma -- a label literally named e.g. `blocked,lane-storage` would split into two names, one of which (`lane-storage`) could coincidentally match a real declared lane, so the issue silently counted as *placed in a lane* when no triage sweep had actually placed it there. The direction of the error was an under-count of `no_lane`/`no_priority`, the opposite of this function's own documented convention (never under-count), and the existing `len(lines) != total` cross-check could not catch it, because the line count stayed correct -- only the per-line parse was wrong.

Fixed by switching the wire format to one JSON array of label names per line (`[.labels[].name] | tojson` server-side, `json.loads` client-side) -- a delimiter no label name can contain, rather than trying to escape or reject commas after the fact. This also removes the old `"L:"`-prefix trick and its trailing-empty-line hazard: `tojson` of an empty label list is `[]`, never an empty line, so there is nothing left to guard against there.

TDD: `tests/test_statusline_gh_unlabelled_issue_counts_622.py` was written first, stubbing `statusline._run` directly (no `gh` calls, no GitHub label-creation rights needed) with a comma-bearing label name containing a real declared lane as a substring after the comma. Run against the pre-fix code: both tests failed (red) -- `None` returned instead of the expected counts, because the stub's JSON-array output does not start with the old `"L:"` prefix the pre-fix code required. After the fix: both pass (green). Paired with a positive control (`test_ordinary_comma_free_labels_still_count_correctly`) so the fix does not break the ordinary case.

`.oss/statusline.py` had zero test coverage in this repo before this change (confirmed: 0 hits across all test files). Judgment call: added a first, narrow test file covering only this one function, rather than broader coverage for the module -- the smallest fix proportionate to what was actually reported.

## Adjacent, reported for filing

`.oss/statusline.py` carries a header stating it is vendored verbatim from the `oss` plugin and overwritten on every `/oss:scaffold` run; a byte-for-byte diff against the plugin cache's `scripts/statusline.py` (version 0.26.0) confirms this file is identical apart from that header comment. The comma-splitting defect this PR fixes therefore also exists in the plugin's own source, at `Digital-Process-Tools/claude-oss` (per `doctor.loop_repository()`), and will be silently reintroduced into this repo's `.oss/statusline.py` at the next `/oss:scaffold` unless it is fixed upstream too. Out of this lane's blast radius to fix here (would need its own PR and review in that repository) -- **reported for filing against `Digital-Process-Tools/claude-oss`, `scripts/statusline.py`, same function, same fix.**

## Tests

Narrowed run only (`tests/test_statusline_gh_unlabelled_issue_counts_622.py`), plus the changelog fragment checker (`python3 .oss/assemble_changelog.py --check`, both fragments pass). Full `test_command` (`pytest`) intentionally not run -- CI is the merge gate and covers the full matrix (3 OS x 4 interpreters, 12 legs) this run's own platform cannot speak for.

## Review

Two self-review spawns (Explore and oss:auditor) against the committed diff, both returned NO FINDINGS -- independently re-verified the #595/#613 factual claims and the #622 fix's edge cases (unicode, quotes, empty label lists, JSON round-tripping) rather than trusting the commit message. Both final messages classified `no-findings` by `review_return.py`. Tree-mutation check (`tree_snapshot.py`) verdict: clean.

Closes #617, closes #622.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-generated]