### PR TITLE
Fix: distinguish absent from unreadable NDC generation marker (#619)

### DIFF
--- a/changelog.d/619.fixed.md
+++ b/changelog.d/619.fixed.md
@@ -1,0 +1,8 @@
+- Fixed: save-session.sh's NDC generation guard (#614) now tells "the
+  generation marker was never created" (legitimately generation 0) apart from
+  "the marker exists but a read of it failed" (a permission or I/O error, or a
+  reader racing the truncating write that bumps it). Both used to collapse to
+  the same 0 at both read sites, so two failed reads could compare equal to
+  each other -- and to a legitimately absent marker -- and the guard would go
+  silent exactly when it could not tell whether another NDC round had already
+  committed, restoring the pre-#614 risk of content landing nowhere (#619).

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -111,10 +111,17 @@ NDC_GEN_FILE="${REMEMBER_DIR}/tmp/ndc-generation"
 # exactly when it can least afford to (#619). Echoes a generation number, or
 # the literal "unreadable", which a numeric generation can never equal.
 ndc_read_gen() {
-    if [ ! -e "$NDC_GEN_FILE" ]; then
+    # -e follows a symlink and is false for BOTH "nothing was ever created
+    # here" and "a symlink was created here and its target is now gone" --
+    # it cannot tell those apart. -L catches the second: a path that is a
+    # symlink, dangling or not, is a path something created, so it belongs
+    # on the "exists" side of this check, falling through to the failed
+    # `cat` below rather than being read as a fresh, legitimate 0.
+    if [ ! -e "$NDC_GEN_FILE" ] && [ ! -L "$NDC_GEN_FILE" ]; then
         echo 0
         return 0
     fi
+    local _ndc_gen
     _ndc_gen=$(cat "$NDC_GEN_FILE" 2>/dev/null)
     case "$_ndc_gen" in
         (''|*[!0-9]*) echo unreadable ;;

--- a/scripts/save-session.sh
+++ b/scripts/save-session.sh
@@ -101,6 +101,26 @@ MEMORY_FILE="${REMEMBER_DIR}/now.md"
 # own Haiku call never summarized -- content that then exists nowhere. See
 # Step 8 for where this is read and bumped, both under LOCK_DIR.
 NDC_GEN_FILE="${REMEMBER_DIR}/tmp/ndc-generation"
+# Read NDC_GEN_FILE, distinguishing "never created" (legitimately generation 0
+# -- no commit has ever landed) from "exists but a read of it failed" (a
+# permission or I/O error, or a reader racing the truncating `>` this file's
+# own writer uses to bump it below). #614's mismatch check compares two such
+# reads; collapsing both failure shapes to the same 0 -- what a bare
+# `cat ... || echo 0` does -- makes two independent failures compare equal to
+# each other and to a legitimately absent file, and the guard goes silent
+# exactly when it can least afford to (#619). Echoes a generation number, or
+# the literal "unreadable", which a numeric generation can never equal.
+ndc_read_gen() {
+    if [ ! -e "$NDC_GEN_FILE" ]; then
+        echo 0
+        return 0
+    fi
+    _ndc_gen=$(cat "$NDC_GEN_FILE" 2>/dev/null)
+    case "$_ndc_gen" in
+        (''|*[!0-9]*) echo unreadable ;;
+        (*) echo "$_ndc_gen" ;;
+    esac
+}
 # Which day now.md's contents belong to (#141) — see Step 7.
 NOW_DAY_FILE="${REMEMBER_DIR}/tmp/now-day"
 LAST_SAVE_FILE="${REMEMBER_DIR}/tmp/last-save.json"
@@ -869,10 +889,7 @@ if [ "$RUN_NDC" = true ]; then
     # round's committed generation is the value this round's own offset is
     # only valid against; anything else means a commit has landed since and
     # the offset no longer describes a real boundary in the live file.
-    NDC_SRC_GEN=$(cat "$NDC_GEN_FILE" 2>/dev/null || echo 0)
-    case "$NDC_SRC_GEN" in
-        (''|*[!0-9]*) NDC_SRC_GEN=0 ;;
-    esac
+    NDC_SRC_GEN=$(ndc_read_gen)
     NDC_PROMPT=$(mktemp "${TMPDIR:-/tmp}"/remember-ndc-XXXXXX)
 
     cd "$PIPELINE_DIR" && $PYTHON -m pipeline.shell build-ndc-prompt "$MEMORY_FILE" "$NDC_PROMPT"
@@ -1035,12 +1052,19 @@ if [ "$RUN_NDC" = true ]; then
                         # against means such a commit has landed since, and
                         # this round's offset no longer describes a real
                         # boundary in the live file, regardless of size.
-                        NDC_LIVE_GEN=$(cat "$NDC_GEN_FILE" 2>/dev/null || echo 0)
-                        case "$NDC_LIVE_GEN" in
-                            (''|*[!0-9]*) NDC_LIVE_GEN=0 ;;
-                        esac
+                        NDC_LIVE_GEN=$(ndc_read_gen)
                         if [ "$NDC_LIVE_BYTES" -lt "$NDC_SRC_BYTES" ]; then
                             log "ndc" "SKIPPED commit: now.md is ${NDC_LIVE_BYTES}b, below the ${NDC_SRC_BYTES}b snapshot this offset was taken from -- left untouched (today-${NDC_DAY}.md may now hold a duplicate of this span)"
+                        elif [ "$NDC_SRC_GEN" = "unreadable" ] || [ "$NDC_LIVE_GEN" = "unreadable" ]; then
+                            # #619: a marker that EXISTS but could not be read is
+                            # not the same fact as one that was never created --
+                            # ndc_read_gen only ever returns 0 for the latter. A
+                            # failed read tells this round nothing about whether
+                            # another round committed since its snapshot, so it
+                            # must not be treated as "no commit landed" just
+                            # because a bare `cat ... || echo 0` used to produce
+                            # that same 0 for both cases.
+                            log "ndc" "SKIPPED commit: could not read ${NDC_GEN_FILE} (src=${NDC_SRC_GEN}, live=${NDC_LIVE_GEN}) -- now.md left untouched, this round cannot tell whether another round committed since its snapshot (today-${NDC_DAY}.md may now hold a duplicate of this span)"
                         elif [ "$NDC_LIVE_GEN" != "$NDC_SRC_GEN" ]; then
                             log "ndc" "SKIPPED commit: another NDC round already committed since this round's snapshot (generation ${NDC_SRC_GEN} -> ${NDC_LIVE_GEN}) -- now.md left untouched, this round's offset no longer describes a real boundary (today-${NDC_DAY}.md may now hold a duplicate of this span)"
                         else

--- a/tests/test_ndc_commit_lock.py
+++ b/tests/test_ndc_commit_lock.py
@@ -326,3 +326,33 @@ class TestNdcCommitLock:
             "just because a failed read and an absent file happen to produce "
             "the same fallback value"
         )
+
+    def test_commit_skips_when_generation_marker_is_a_broken_symlink(self, tmp_path):
+        """#619 follow-up: a dangling symlink is not the same fact as no path at all.
+
+        `[ ! -e PATH ]` follows symlinks and is false for a plain missing path
+        and for a symlink whose target is missing alike -- `-e` cannot tell
+        "nothing was ever created here" from "something was created here and
+        then its target went away". A dangling symlink left in place of the
+        marker (a partial/aborted write by some other tool, e.g.) would
+        therefore read as legitimate generation 0 under a bare `-e` check,
+        reopening the exact absent-vs-unreadable ambiguity this issue closes,
+        just one layer further down.
+        """
+        env, project, plugin, calls, sid = _ndc_env(tmp_path)
+        memory_file = project / ".remember" / "now.md"
+        gen_file = project / ".remember" / "tmp" / "ndc-generation"
+        gen_file.symlink_to(project / ".remember" / "tmp" / "does-not-exist")
+
+        result = _run(plugin, env, sid)
+        assert result.returncode == 0, subprocess_failure_detail(
+            result, project / ".remember"
+        )
+
+        _wait_for_background_ndc(memory_file)
+        assert "SKIPPED commit" in _log_text(project), (
+            "the generation marker exists (as a symlink) but its target does "
+            "not, so every read of it fails -- that is not the same fact as "
+            "the marker never having been created, and must not be treated "
+            "as generation 0"
+        )

--- a/tests/test_ndc_commit_lock.py
+++ b/tests/test_ndc_commit_lock.py
@@ -261,3 +261,68 @@ class TestNdcCommitLock:
             "longer describes any real boundary in the file -- losing bytes "
             "that exist nowhere else (#614)"
         )
+
+    def test_commit_proceeds_when_generation_marker_is_absent(self, tmp_path):
+        """Positive control: no commit has ever landed, so 0 is legitimate.
+
+        Paired with the unreadable-marker test below -- both currently produce
+        the same fallback value in the script, but only one of them describes
+        a state the guard should let through (#619).
+        """
+        env, project, plugin, calls, sid = _ndc_env(tmp_path)
+        memory_file = project / ".remember" / "now.md"
+        gen_file = project / ".remember" / "tmp" / "ndc-generation"
+        assert not gen_file.exists(), "setup must start from a marker that was never created"
+
+        result = _run(plugin, env, sid)
+        assert result.returncode == 0, subprocess_failure_detail(
+            result, project / ".remember"
+        )
+
+        _wait_for_background_ndc(memory_file)
+        today_text = "".join(
+            f.read_text() for f in (project / ".remember").glob("today-*.md")
+        )
+        assert "compressed summary" in today_text, (
+            "the generation marker was never created -- that is legitimately "
+            "generation 0, and the commit must proceed, landing the "
+            "compressed span in today-*.md"
+        )
+        assert "SKIPPED commit" not in _log_text(project), (
+            "an absent marker is not a read failure; it must not skip the commit"
+        )
+
+    def test_commit_skips_when_generation_marker_exists_but_cannot_be_read(self, tmp_path):
+        """#619: a marker that exists but cannot be read is not the same as absent.
+
+        Both `NDC_SRC_GEN` (read before the Haiku call) and `NDC_LIVE_GEN`
+        (re-read under the lock before the commit) defaulted a failed `cat` to
+        0 -- the identical value a genuinely absent marker produces. When the
+        marker exists but a read of it fails (a permission or I/O error, or a
+        write from the commit below truncated mid-flight), both reads collapse
+        to the same fallback and the mismatch check this guard exists to
+        enforce (#614) never has a chance to fire: it silently reports two
+        equal generations instead of two reads that told it nothing.
+
+        A directory in place of the marker reproduces "exists but every read
+        fails" without depending on this process's uid ever being denied a
+        permission bit -- a bit CI's usual root uid ignores outright.
+        """
+        env, project, plugin, calls, sid = _ndc_env(tmp_path)
+        memory_file = project / ".remember" / "now.md"
+        gen_file = project / ".remember" / "tmp" / "ndc-generation"
+        gen_file.mkdir()  # exists, but `cat` on a directory always fails
+
+        result = _run(plugin, env, sid)
+        assert result.returncode == 0, subprocess_failure_detail(
+            result, project / ".remember"
+        )
+
+        _wait_for_background_ndc(memory_file)
+        assert "SKIPPED commit" in _log_text(project), (
+            "the generation marker exists but neither read of it could "
+            "succeed -- this round cannot tell whether another round "
+            "committed since its snapshot, and must not assume it did not "
+            "just because a failed read and an absent file happen to produce "
+            "the same fallback value"
+        )


### PR DESCRIPTION
Closes #619.

save-session.sh's NDC generation guard (added by #614) read the generation counter (`NDC_GEN_FILE`) at two sites with `cat "$NDC_GEN_FILE" 2>/dev/null || echo 0`, which collapses "the file does not exist yet" (legitimately generation 0) and "the read failed" (a permission or I/O error, or a reader racing the truncating write that bumps the counter) into the identical fallback value 0. When both reads fail the same way, `NDC_LIVE_GEN` equals `NDC_SRC_GEN`, the mismatch check the guard exists to enforce never fires, and the commit proceeds on the byte-size check alone -- silently restoring the pre-#614 behaviour whose failure mode is content that then exists nowhere.

## What changed

Adds `ndc_read_gen()`, used at both read sites, which echoes `0` only when the marker was never created (`-e` and, after a review follow-up, `-L`, so a dangling symlink is not mistaken for a plain absent path) and the literal string `unreadable` when it exists but a read of it fails or produces non-numeric content -- a value a real generation number can never equal. A new `elif` branch in the commit gate treats `unreadable` from either read as a reason to skip the commit and log why, ordered before the existing generation-mismatch check (load-bearing: an `unreadable == unreadable` string match would otherwise fall through to arithmetic on a non-numeric value and abort the script).

## TDD

Red, before the fix (right assertion, right reason -- the marker exists as a directory so every read of it fails, and the guard silently let the commit through anyway):
```
AssertionError: the generation marker exists but neither read of it could succeed -- this round cannot tell whether another round committed since its snapshot, and must not assume it did not just because a failed read and an absent file happen to produce the same fallback value
1 failed, 1 passed, 4 deselected in 3.63s
```
Green after:
```
7 passed in 15.54s
```
Paired with a positive control (`test_commit_proceeds_when_generation_marker_is_absent`): a marker that was never created is legitimately generation 0 and must still commit.

## On the brief's invited pushback

The brief flagged this finding as AI-generated and reasoned-not-observed, and asked that `tests/test_save_session_gates.py:111` be read first to confirm the collapse actually reaches production behaviour before building around it. Read it: that line does drive the generation file (via `STUB_REPLACE_DURING_NDC`), but only ever writes a *valid numeric* generation -- it never exercises a read failure, so the described collapse was real and genuinely unguarded. No pushback is warranted; the finding held up.

## Self-review

Two agents (`Explore` and `oss:auditor`) reviewed the first commit independently. The auditor came back clean across all four classes (silent absence, guard reachability, untrusted-input boundary, platform band), with one filing suggestion. The reviewer raised four findings:

1. **Fixed** -- `[ ! -e "$NDC_GEN_FILE" ]` alone treats a dangling symlink the same as a plain absent path (both fail `-e`), reopening the same absent-vs-unreadable ambiguity one layer down. Added a `-L` check, pinned by a new red/green test (`test_commit_skips_when_generation_marker_is_a_broken_symlink`).
2. **Fixed** -- the helper's scratch variable wasn't declared `local`, unlike this file's other helper function. Harmless today (every call site is inside `$( )`, which forks a subshell) but a latent trap; added `local`.
3. **report-for-filing** -- if the marker becomes durably unreadable outside the transient race this fix targets (e.g. left empty by a crash, or replaced by a directory by external tooling), every future NDC round skips forever with no operator-facing hint in the log that deleting the marker resets it to generation 0. A reasonable fail-safe trade (skip forever beats losing data), but a new failure mode this fix introduces for the durable case, previously self-healing by accident under the old "collapse to 0" behaviour. Needs a design decision (bounded retry? richer log message naming the remedy?) rather than a one-line fix, so it is not folded into this PR.
4. **report-for-filing** (also independently raised by the auditor as a filing suggestion) -- the identical `cat FILE 2>/dev/null || echo 0` collapsing pattern is still present, unfixed, at two other sites in the same file: `COOLDOWN_MARKER` (`scripts/save-session.sh:239`) and `NDC_MARKER` (`scripts/save-session.sh:851`). Lower stakes than the generation-marker case -- a failed read there makes the cooldown look expired, i.e. fails open to running NDC/summarization more often than intended (extra Haiku calls), not to silent data loss -- and out of #619's stated scope, but the same code smell and immediately adjacent.

## Scope notes

- README.md (this repo's only `docs_targets` entry) needed no change: purely an internal bugfix, no user-facing behaviour or interface changed.
- No repo diagnostic/convention file applies: nothing moved, no file added or removed, no `CLAUDE.md`/`pyproject.toml` change.
- The narrowed test run (`pytest tests/test_ndc_commit_lock.py`) trips a pre-existing 80% coverage-gate failure unrelated to this diff -- confirmed identical against the pre-#619 baseline. Full `test_command` was not run locally per policy; CI is the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-generated]