### PR TITLE
Fix stale promo budget comment: says 150, code and docs enforce 170 (#637)

### DIFF
--- a/changelog.d/637.fixed.md
+++ b/changelog.d/637.fixed.md
@@ -1,0 +1,5 @@
+- Fixed: `scripts/session-start-hook.sh`'s promo length-budget comment (#637)
+  narrated the history as "the budget moved instead (140 -> 150)" while the
+  code enforced 170, matching `docs/hooks.md` and `docs/configuration.md`. The
+  comment now reads "140 -> 150 -> 170", matching the enforced value and both
+  docs. Comment-only fix; no behavior change.

--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -1081,8 +1081,9 @@ if [ "$(config ".features.plugin_promos" true)" = "true" ] \
             # valid syntax anywhere, and a reader who pastes it literally
             # gets silence rather than an error. An unfindable hint and a
             # wrong one are the same defect; the budget moved instead
-            # (140 -> 150), which lengthens no rendered line, it only stops
-            # guarding against one that is 10 characters longer.
+            # (140 -> 150 -> 170, across #631's two off-switch-hint
+            # commits), which lengthens no rendered line, it only stops
+            # guarding against one that is 30 characters longer.
             #
             # The line also says who is speaking (#631). systemMessage is
             # emitted raw a few hundred lines below -- no plugin name is

--- a/tests/test_promo_budget_comment_637.py
+++ b/tests/test_promo_budget_comment_637.py
@@ -1,0 +1,53 @@
+"""The promo budget comment's stated number must match the enforced value (#637).
+
+`scripts/session-start-hook.sh` enforces a message-length budget with
+`[ "${#msg}" -gt N ]`. A comment a few lines above narrates the budget's
+history ("the budget moved instead (X -> Y)"). If the comment's claimed
+current value drifts from what the code actually enforces, a maintainer
+sizing a future promo string trusts the wrong number -- the exact defect
+#637 reports (comment said 150, code enforces 170).
+
+This asserts the two numbers agree by parsing both out of the live file,
+rather than hardcoding either -- so the test fails loudly again the next
+time they drift, whatever the new enforced value turns out to be.
+"""
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SESSION_START = REPO_ROOT / "scripts" / "session-start-hook.sh"
+
+
+def _enforced_budget():
+    text = SESSION_START.read_text(encoding="utf-8")
+    match = re.search(r'\[\s*"\$\{#msg\}"\s*-gt\s*(\d+)\s*\]', text)
+    assert match, "could not find the enforced budget guard in session-start-hook.sh"
+    return int(match.group(1))
+
+
+def _comment_claimed_budget():
+    text = SESSION_START.read_text(encoding="utf-8")
+    # The comment narrates the budget's history as one or more
+    # "(X -> Y)" or "(X -> Y -> Z)" arrow chains near "budget moved instead".
+    match = re.search(
+        r"budget moved instead\s*\n\s*#\s*\((\d+(?:\s*->\s*\d+)+)", text
+    )
+    assert match, "could not find the 'budget moved instead (...)' comment"
+    numbers = [int(n) for n in re.findall(r"\d+", match.group(1))]
+    assert numbers, f"no numbers parsed out of comment chain: {match.group(1)!r}"
+    return numbers[-1]
+
+
+def test_promo_budget_comment_matches_enforced_value():
+    """The comment's final claimed value must equal what the code enforces.
+
+    This test is red against the pre-fix comment, which claims the budget
+    is 150 while the code enforces 170 -- a 20-character gap that produces
+    silent under-estimation of headroom for a future promo string.
+    """
+    enforced = _enforced_budget()
+    claimed = _comment_claimed_budget()
+    assert claimed == enforced, (
+        f"promo budget comment claims {claimed}, but the code enforces "
+        f"{enforced} -- update the comment in scripts/session-start-hook.sh"
+    )


### PR DESCRIPTION
`scripts/session-start-hook.sh`'s promo message length-budget comment (around line 1080) narrated "the budget moved instead (140 -> 150)", while the guard four lines below (`[ "${#msg}" -gt 170 ]`) enforces 170, matching `docs/hooks.md`, `docs/configuration.md` and `changelog.d/631.changed.md`.

Exercised, not just read: both shipped `promos.json` entries render at 141 and 159 characters, both under the enforced 170, but the 159-character entry would be silently skipped at the 150 the comment claimed -- the exact failure `tests/test_plugin_promo_574.py`'s `TestPromoCarriesItsOwnOffSwitch` exists to prevent. A maintainer trusting the comment to size a future promo string would compute headroom 20 characters short.

## Fix

Comment-only change. Checked `git log -p -- scripts/session-start-hook.sh` and confirmed the real history is two separate commits under #631: 140 -> 150, then a second commit 150 -> 170. The comment now reads "(140 -> 150 -> 170, across #631's two off-switch-hint commits)" and the accompanying arithmetic note ("30 characters longer", i.e. 170-140) is corrected to match.

## Tests

Added `tests/test_promo_budget_comment_637.py`, which parses the enforced `-gt N` guard and the comment's claimed history out of the live shell script and asserts they agree, rather than hardcoding either side -- so a future drift fails loudly again whatever the new enforced value turns out to be.

Red before the fix (comment claimed 150, code enforces 170):
```
AssertionError: promo budget comment claims 150, but the code enforces 170 -- update the comment in scripts/session-start-hook.sh
assert 150 == 170
```
Green after the fix: `1 passed`.

`tests/test_plugin_promo_574.py` (the existing promo-budget enforcement suite) was run before and after this comment-only change: 14 passed both times, confirming the enforcement itself is untouched.

## Docs and changelog

No `docs_targets` (`README.md`) change -- this is an internal code comment, not user-facing documentation. `docs/hooks.md` and `docs/configuration.md` already state 170 correctly and needed no edit. Added `changelog.d/637.fixed.md`; `python3 .oss/assemble_changelog.py --check` passes.

## Self-review

Two reviewers (`Explore`, `oss:auditor`) ran against the committed diff, in parallel, told not to edit anything. Both returned `NO FINDINGS`, classified via `scripts/review_return.py` as `no-findings` for both. Tree-mutation check (`tree_snapshot.py compare`) reported `clean` before and after both spawns ran.

Closes #637

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AI-generated]