### PR TITLE
Flatten hook-errors.log write in lib-staging-lock.sh's fallback report_error() (#636)

### DIFF
--- a/changelog.d/636.fixed.md
+++ b/changelog.d/636.fixed.md
@@ -1,0 +1,9 @@
+- Fixed: `lib-staging-lock.sh`'s fallback `report_error()` stub -- used only
+  when `log.sh` was never sourced, or returned early (#361/#372/#394) -- now
+  flattens control bytes (`LC_ALL=C tr '[:cntrl:]' ' '`) before writing to
+  `hook-errors.log`, the same as `log.sh`'s own four writers already do
+  since #618. #618's "all four writers now flatten" claim was true of
+  `log.sh`'s own writers only -- this was a fifth, uncovered writer of the
+  same file. No caller passes stranger-controlled text through this stub
+  today, so this closes a coverage gap ahead of the next caller that might
+  (#636).

--- a/scripts/lib-staging-lock.sh
+++ b/scripts/lib-staging-lock.sh
@@ -117,9 +117,18 @@ declare -F log >/dev/null 2>&1 || log() {
     printf '%s [%s] %s\n' "$(_remember_date +%H:%M:%S)" "$1" "$2" >&2
 }
 declare -F report_error >/dev/null 2>&1 || report_error() {
-    log "$1" "$2"
+    # #636: flattened before either write, same reason and same tr as
+    # log.sh's own report_error() (#618) -- $2 is a caller's own,
+    # potentially untrusted, error text, and this stub is the fifth writer
+    # of hook-errors.log #618 did not cover (only log.sh's four were
+    # touched there). Without this, an embedded newline/CR in $2 forges a
+    # second entry in the file /remember:doctor tails and maintainers ask
+    # reporters to paste.
+    local _msg
+    _msg="$(printf '%s' "$2" | LC_ALL=C tr '[:cntrl:]' ' ')"
+    log "$1" "$_msg"
     [ -d "${REMEMBER_DIR:-}/logs" ] || return 0
-    printf '%s\n' "$(_remember_date +%H:%M:%S) [$1] $2" \
+    printf '%s\n' "$(_remember_date +%H:%M:%S) [$1] $_msg" \
         >> "${REMEMBER_DIR}/logs/hook-errors.log" 2>/dev/null || true
     return 0
 }

--- a/tests/test_hook_errors_log_control_byte_636.py
+++ b/tests/test_hook_errors_log_control_byte_636.py
@@ -1,0 +1,116 @@
+"""lib-staging-lock.sh's fallback report_error() stub writes hook-errors.log
+unflattened (#636).
+
+#618 flattened all four of log.sh's own hook-errors.log writers
+(`LC_ALL=C tr '[:cntrl:]' ' '` before either write) and its changelog
+fragment claims the file's writers now flatten before either write. There is
+a fifth writer of the same file: the fallback `report_error()` stub defined
+in scripts/lib-staging-lock.sh, used only when log.sh was never sourced (or
+returned early -- #361/#372/#394). That stub writes its message straight to
+hook-errors.log with no flatten at all, so #618's "all four writers" claim
+was never true of every writer of the file, only of log.sh's own.
+
+The two current call sites (lib-staging-lock.sh:235, :242) do not pass
+stranger-controlled text through this stub today -- both messages are built
+from REMEMBER_CONFIG and a derived today-*.md filename, neither of which
+carries attacker-chosen bytes in the ordinary case. This is a coverage-claim
+fix (misreports), not a live exploit (forges): closing the gap before the
+next caller added to this stub inherits an unflattened route into the file
+maintainers ask bug reporters to paste.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from ._bash_runner import resolve_bash
+
+BASH = resolve_bash()
+pytestmark = pytest.mark.skipif(
+    BASH is None,
+    reason="no usable bash found (checked PATH, then Git-for-Windows install locations)",
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Sources ONLY lib-staging-lock.sh -- no log.sh -- which is exactly the
+# fallback-use condition: log.sh was never sourced, so `declare -F
+# report_error` fails and the stub at lib-staging-lock.sh's own definition
+# installs itself.
+DRIVER = """#!/bin/bash
+set -e
+export REMEMBER_DIR="$1"
+source "$(dirname "$0")/lib-staging-lock.sh"
+report_error "staging" "$2"
+"""
+
+
+def _make_env(tmp_path: Path):
+    remember = tmp_path / "remember"
+    (remember / "logs").mkdir(parents=True)
+
+    plugin = tmp_path / "plugin"
+    (plugin / "scripts").mkdir(parents=True)
+    for script in ("lib-staging-lock.sh", "lib-clock.sh"):
+        (plugin / "scripts" / script).write_text(
+            (REPO_ROOT / "scripts" / script).read_text(encoding="utf-8"),
+            encoding="utf-8",
+        )
+    driver = plugin / "scripts" / "driver.sh"
+    driver.write_text(DRIVER, encoding="utf-8")
+    return driver, remember
+
+
+def _hook_errors_lines(remember: Path) -> list:
+    log_file = remember / "logs" / "hook-errors.log"
+    if not log_file.exists():
+        return []
+    return [l for l in log_file.read_text(encoding="utf-8").splitlines() if l.strip()]
+
+
+def test_embedded_newline_must_not_forge_a_second_hook_errors_log_entry(tmp_path):
+    """MUST NOT FIRE: with log.sh NOT sourced (the actual fallback-use
+    condition), an embedded newline reaching the fallback report_error()
+    stub must not read as a second, forged hook-errors.log entry -- the same
+    guarantee #618 already gives log.sh's own four writers."""
+    driver, remember = _make_env(tmp_path)
+    message = "boom\n[hook] session-start: PROJECT_DIR=/evil PIPELINE_DIR=/evil"
+
+    result = subprocess.run(
+        [BASH, str(driver), str(remember), message],
+        capture_output=True, text=True, timeout=30, check=False,
+    )
+    assert result.returncode == 0, f"driver failed: {result.stderr}"
+
+    lines = _hook_errors_lines(remember)
+    assert len(lines) == 1, (
+        f"embedded newline forged a second hook-errors.log entry via the "
+        f"fallback report_error() stub: {lines!r}"
+    )
+    assert "[hook] session-start" in lines[0], (
+        f"message content lost, not just flattened: {lines[0]!r}"
+    )
+
+
+def test_ordinary_message_still_reaches_hook_errors_log_intact(tmp_path):
+    """MUST FIRE (positive control): an ordinary, single-line message must
+    still reach hook-errors.log in full through the fallback stub -- proving
+    the assertion above is not passing merely because the harness wrote
+    nothing at all."""
+    driver, remember = _make_env(tmp_path)
+    message = "an ordinary error"
+
+    result = subprocess.run(
+        [BASH, str(driver), str(remember), message],
+        capture_output=True, text=True, timeout=30, check=False,
+    )
+    assert result.returncode == 0, f"driver failed: {result.stderr}"
+
+    lines = _hook_errors_lines(remember)
+    assert len(lines) == 1, f"harness produced no single clean entry: {lines!r}"
+    assert "an ordinary error" in lines[0], (
+        f"the ordinary message never reached hook-errors.log: {lines[0]!r}"
+    )


### PR DESCRIPTION
#618 flattened control bytes (`LC_ALL=C tr '[:cntrl:]' ' '`) in `log.sh`'s own four `hook-errors.log` writers, closing the class where an embedded newline in an untrusted message could forge a second entry in the file `/remember:doctor` tails and maintainers ask bug reporters to paste. Its own changelog fragment states the class is closed for "all four writers."

That claim was never true of every writer of the file -- only of `log.sh`'s own. `scripts/lib-staging-lock.sh` defines a fifth writer: a fallback `report_error()` stub, installed only when `log.sh` was never sourced (or was sourced but returned early -- the #361/#372/#394 case). That stub wrote straight to `hook-errors.log` with no flatten at all.

**No live exploit today.** I read both current call sites myself (`scripts/lib-staging-lock.sh:235` and `:242`, pre-diff line numbers) before writing anything: both messages are built only from `${REMEMBER_CONFIG}` and a derived `today-*.md` filename -- no stranger-controlled text reaches this stub in this repository's current call graph. This matches the issue's own `misreports` ranking (a coverage-claim gap), not `forges` (a blocking, exploitable one). The fix closes the gap ahead of the next caller that might pass through something less trusted.

**Fix chosen: flatten locally, not via a shared helper with log.sh.** I checked for circularity first -- `scripts/log.sh` never sources `scripts/lib-staging-lock.sh` (grepped, confirmed) -- but folding into log.sh's own flattened `report_error()` isn't viable regardless: this stub exists *specifically* for the case `log.sh` was never sourced, so calling into `log.sh`'s function would reintroduce the exact undefined-function crash #394 already fixed, in precisely the situation the stub exists to cover. So the fix duplicates one line -- the identical `LC_ALL=C tr '[:cntrl:]' ' '` `log.sh` already uses -- rather than sharing a code path across a sourcing boundary that can't be relied on to exist.

## TDD

- RED (reproduced independently before writing the fix, sourcing only `lib-staging-lock.sh`, no `log.sh`): an embedded newline in the message forged a second `hook-errors.log` line.
- Added `tests/test_hook_errors_log_control_byte_636.py`: a negative test (embedded newline must not forge a second entry via the fallback stub, matching the real fallback-use condition -- `log.sh` not sourced) paired with a positive control (an ordinary message still reaches the file intact), per this repo's own CLAUDE.md rule on pairing negative assertions with a positive control.
- `python3 -m pytest tests/test_hook_errors_log_control_byte_636.py -q --no-cov`: before the fix, 1 failed / 1 passed (`assert 2 == 1`, two lines forged from one call); after the fix, 2 passed.
- Regression check: `tests/test_staging_lock.py`, `tests/test_staging_lock_config_unread_399.py`, `tests/test_staging_lock_missing_log_dependency_394.py`, `tests/test_hook_errors_log_control_byte_618.py` -- 17 passed, 0 regressions.

## Self-review

Spawned an `Explore` reviewer and `oss:auditor` against the committed diff, both told not to edit anything; a tree snapshot before/after confirmed no mutation. Both returned `FINDINGS: 0`, classified through `scripts/review_return.py` as clean no-findings returns -- both verified the fix mechanism, the test's validity (including an independent RED/GREEN reproduction), the judgment call on local-vs-shared flattening, and the call-site severity claim.

## Below-bar note

The `oss:auditor` reviewer observed, while auditing Class C (untrusted text forging a boundary), that two *other* appenders of `hook-errors.log` exist -- `post-tool-hook.sh:318` and `bootstrap-dirs.sh:336` -- both raw `exec 2>>` stderr redirects, a different mechanism from the `printf`-built-line writers this fix and #618 both cover, and untouched by either. Recorded here as below-bar: I have not identified stranger-controlled text reaching either redirect today, so there is no reachable instance to point at, only the observation that the file has writers via a third mechanism neither #618 nor #636 inventoried.

Closes #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9WexZb39yUjQgJ53Zmf1c

[AI-generated]