### PR TITLE
Document #621's abandoned hot-path pre-check accurately, and record the macOS case/glob landmine

### DIFF
--- a/changelog.d/629.changed.md
+++ b/changelog.d/629.changed.md
@@ -3,9 +3,11 @@
   optimization). PR #627 closed #621 via GitHub's `Closes #621`, but the
   pre-check was never shipped -- three attempts on that branch (a POSIX
   `[[:cntrl:]]` bracket-class `case`, an ANSI-C byte-range `case` meant to
-  fix that, and a test-harness PATH-injection fix aimed at the still-red
-  macOS leg) all failed on CI in ways this repo could not reproduce
-  locally, so #627 shipped a straight revert to the pre-#621 unconditional
+  fix that, and a test-harness PATH-injection fix that diagnosed and
+  resolved a separate windows-latest artifact in the same CI run, leaving
+  the macOS mechanism unexplained) all failed on CI in ways this repo
+  could not reproduce locally, so #627 shipped a straight revert to the
+  pre-#621 unconditional
   flatten instead. `log()` still forks `tr` on every call today. #621's own
   closed state now carries a correcting comment so the board does not read
   the optimization as shipped, and `CHANGELOG.md`'s 0.30.0 entry for #621

--- a/changelog.d/629.changed.md
+++ b/changelog.d/629.changed.md
@@ -1,16 +1,17 @@
 - Closed without a code change: #621 asked for a cheap in-shell pre-check
   ahead of `log()`'s `printf | tr` control-byte flatten (an optional cost
   optimization). PR #627 closed #621 via GitHub's `Closes #621`, but the
-  pre-check was never shipped -- three attempts on that branch (a POSIX
-  `[[:cntrl:]]` bracket-class `case`, an ANSI-C byte-range `case` meant to
-  fix that, and a test-harness PATH-injection fix that diagnosed and
-  resolved a separate windows-latest artifact in the same CI run, leaving
-  the macOS mechanism unexplained) all failed on CI in ways this repo
-  could not reproduce locally, so #627 shipped a straight revert to the
-  pre-#621 unconditional
-  flatten instead. `log()` still forks `tr` on every call today. #621's own
+  pre-check was never shipped -- two portability attempts at the pre-check
+  itself (a POSIX `[[:cntrl:]]` bracket-class `case`, then an ANSI-C
+  byte-range `case` meant to fix that) each broke a different CI platform,
+  and a third round -- a test-harness PATH-injection fix -- diagnosed and
+  resolved a separate windows-latest artifact in the same CI run without
+  ever explaining the macOS symptom, so #627 shipped a straight revert to
+  the pre-#621 unconditional flatten instead. `log()` still forks `tr` on
+  every call today. This matches `scripts/log.sh`'s own comment on `log()`
+  ("tried twice... a two-attempt failure record") and `CHANGELOG.md`'s
+  0.30.0 entry for #621 ("two portability attempts... a third round of
+  unreproducible platform fragility"), both already accurate. #621's own
   closed state now carries a correcting comment so the board does not read
-  the optimization as shipped, and `CHANGELOG.md`'s 0.30.0 entry for #621
-  already recorded the abandonment accurately -- this issue is closed as
-  already correctly documented, with no further code or record change
-  needed (#629).
+  the optimization as shipped -- this issue is closed as already correctly
+  documented, with no further code or record change needed (#629).

--- a/changelog.d/629.changed.md
+++ b/changelog.d/629.changed.md
@@ -1,0 +1,14 @@
+- Closed without a code change: #621 asked for a cheap in-shell pre-check
+  ahead of `log()`'s `printf | tr` control-byte flatten (an optional cost
+  optimization). PR #627 closed #621 via GitHub's `Closes #621`, but the
+  pre-check was never shipped -- three attempts on that branch (a POSIX
+  `[[:cntrl:]]` bracket-class `case`, an ANSI-C byte-range `case` meant to
+  fix that, and a test-harness PATH-injection fix aimed at the still-red
+  macOS leg) all failed on CI in ways this repo could not reproduce
+  locally, so #627 shipped a straight revert to the pre-#621 unconditional
+  flatten instead. `log()` still forks `tr` on every call today. #621's own
+  closed state now carries a correcting comment so the board does not read
+  the optimization as shipped, and `CHANGELOG.md`'s 0.30.0 entry for #621
+  already recorded the abandonment accurately -- this issue is closed as
+  already correctly documented, with no further code or record change
+  needed (#629).

--- a/changelog.d/630.changed.md
+++ b/changelog.d/630.changed.md
@@ -1,0 +1,15 @@
+- Documented, not fixed: while working #621 on PR #627, a bash
+  `case "$var" in *[$'\xxx'-$'\yyy']*)` byte-range glob pattern -- reached
+  for as a cheap in-shell control-byte pre-check -- silently failed to
+  match a message that genuinely carried a control byte on every
+  `macos-latest` CI leg, so the `tr` flatten it guarded never ran. Not
+  reproducible locally on Apple's system bash (3.2.57) or a fresh Homebrew
+  bash (5.3.15), under several locales; the runner image
+  (`macos-26-arm64`, `20260831.0337.3`) was unavailable to test directly,
+  so the mechanism stayed unknown. `scripts/log.sh` no longer uses this
+  pattern (reverted to an unconditional flatten), so nothing shipped is
+  currently exposed, but the pattern shape is a plausible thing to reach
+  for again elsewhere in this codebase and fails silently (a `case` that
+  does not match raises no error) -- recorded as a landmine in
+  `trap.d/630.macos-case-byte-range-silent-mismatch.md` for the curation
+  pass to weigh as a jit-context rule (#630).

--- a/trap.d/630.macos-case-byte-range-silent-mismatch.md
+++ b/trap.d/630.macos-case-byte-range-silent-mismatch.md
@@ -1,0 +1,42 @@
+Observed on PR #627 (issue #621, follow-up issues #629/#630), branch fix/620,
+scripts/log.sh: a bash `case`/glob byte-range pattern used as a cheap in-shell
+control-byte pre-check silently failed to match on GitHub's `macos-latest` CI
+runner (image `macos-26-arm64`, `20260831.0337.3`), across all four Python
+versions in that job matrix.
+
+The pattern:
+
+```sh
+case "$message" in
+    *[$'\001'-$'\037']*|*$'\177'*)
+        message="$(printf '%s' "$message" | LC_ALL=C tr '[:cntrl:]' ' ')"
+        ;;
+esac
+```
+
+A message genuinely carrying a control byte (embedded newline, tab, CR, DEL,
+unit separator) did not trip the `case` branch on that runner, so the `tr`
+flatten never ran and the raw message reached the log file -- caught by
+`tests/test_log_hot_path_tr_spawn_621.py` and
+`tests/test_log_newline_sanitization_599.py`.
+
+Cost to find: two failed CI round-trips plus real local reproduction effort
+that all came back green -- Apple's system bash (3.2.57, /bin/bash) and a
+fresh Homebrew bash (5.3.15, /opt/homebrew/bin/bash), under the ambient
+locale, `LANG=en_US.UTF-8`, and several other UTF-8 locales, all matched
+correctly every time locally. The runner image was not available to test
+against directly, so the mechanism was never identified.
+
+Why it matters beyond this one call site: `scripts/log.sh` no longer uses
+this pattern (reverted to an unconditional `printf | tr` flatten in the same
+PR), so nothing shipped is currently exposed -- but the pattern shape
+(`case "$var" in *[$'\xxx'-$'\yyy']*)` for a cheap in-shell byte-range check)
+is a plausible thing to reach for anywhere else in this codebase, and a
+`case` that fails to match runs no branch and raises no error -- silent at
+the shell level, only catchable by a test that specifically asserts the
+branch fired. A confirmation that the failure is deterministic (not flaky)
+and confined to that pattern shape would need someone with hands-on access
+to a macos-26-arm64 runner, which this lane did not have.
+
+Unsure whether this rises to a permanent jit-context rule or stays a
+one-off landmine record -- logging it for the curation pass to decide.


### PR DESCRIPTION
Closes #629, closes #630.

Both issues are record-keeping follow-ups to PR #627 (which itself closed #618, #620 and #621), self-filed by a previous tick's own review process. #621 had asked for an optional, cheap in-shell pre-check to gate scripts/log.sh's control-byte tr flatten on the per-tool-call hot path. Three attempts at that pre-check failed on CI and #627 abandoned the optimization, reverting to log()'s pre-#621 unconditional flatten.

## What was checked before writing anything

Verified against the actual git history (git log on fix/620, gh-issue:621:full, gh-pr:627) rather than trusting the tracker: scripts/log.sh's own code comment on log() and CHANGELOG.md's existing 0.30.0 release entry for #621 already state accurately that the optimization was abandoned, not shipped. #621's own closed-issue state already carries a corrective comment pointing at #629 and #630 as the successor record. So no behavioural code change was warranted -- this pull request is documentation only.

## What changed

- `changelog.d/629.changed.md` -- closes #629 as already-correctly-documented (log() still forks tr unconditionally today; the optimization was never shipped).
- `changelog.d/630.changed.md` -- records the macOS CI landmine as documented rather than fixed.
- `trap.d/630.macos-case-byte-range-silent-mismatch.md` -- the discoverability artifact #630 asked for: a bash case "$var" in *[$'\xxx'-$'\yyy']*) byte-range glob pattern silently failed to match a real control byte on every macos-latest CI leg while working #621, mechanism unknown, not reproducible locally. Nothing in shipped code uses this pattern any more, but it is a plausible thing to reach for again elsewhere in this codebase, and a case that fails to match raises no error -- silent at the shell level. Logged for the curation pass (/oss:curate) to weigh as a jit-context rule.

## Self-review

Two reviewer round-trips against the committed diff, both from spawned agents (Explore and oss:auditor). The auditor found nothing (four classes checked: absence-handling, guard coverage, untrusted-text handling all clean by direct read; the cross-platform band graded not-applicable since no code was touched). The Explore reviewer caught two real, low/medium-severity prose inaccuracies across two rounds:

1. `changelog.d/629.changed.md` described a test-harness PATH-injection fix (commit 7a9069f) as "aimed at the still-red macOS leg" -- that commit's own message is unambiguously about a windows-latest/3.11 PATH-separator bug and says nothing about macOS. Fixed to say what the commit actually targeted.
2. The same fragment then said "three attempts on that branch," contradicting scripts/log.sh's own comment ("tried twice... a two-attempt failure record") and CHANGELOG.md's existing #621 entry ("two portability attempts... a third round of unreproducible platform fragility") -- the exact authoritative sources the fragment claimed to be consistent with. Fixed to match that framing, quoting both sources.

Both findings were independently re-verified against the primary source commits (git log -1 --format=%B on the commits in question) before being accepted and fixed, not merely trusted on the reviewer's say-so.

## No test

No behavioural code was touched -- only markdown fragments and a trap record -- so a red/green positive-control test does not apply here. Confirmed via python3 .oss/assemble_changelog.py --check (run after every write) that both fragments parse cleanly under this repo's real changelog-fragment checker, not just under pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9WexZb39yUjQgJ53Zmf1c

[AI-generated]