### PR TITLE
Cut $( ) subshell forks on SessionStart's config/timestamp/slug paths (#665)

### DIFF
--- a/changelog.d/665.changed.md
+++ b/changelog.d/665.changed.md
@@ -1,0 +1,16 @@
+- `SessionStart`'s hot path removes 22+ `$( )` subshell forks that were paying
+  a fork purely to capture an already-forkless builtin's output (#665, part
+  of #660): `config()`'s flattened-cache-hit lookups now have a `config_into
+  VAR key default` sibling (`printf -v`, no command substitution) used for
+  every `.features.*`/`.handoff_mode`/`.cooldowns.*`/`.timezone`/etc. read on
+  the `SessionStart` and per-tool-call config paths; `log()`'s timestamp now
+  calls `_remember_date_into` (already added by #511) directly instead of
+  wrapping it in `$( )`; `_remember_forward_slash` and `_stdin_json_string`
+  each gained an `_into` sibling, wired into every session-start-hook.sh call
+  site; and `lib-slug.sh`'s `_remember_build_slug_sed` -- 22 `$(printf
+  '\NNN')` calls building the slug's byte-range sed program, run once per
+  hook invocation -- now uses bash's own ANSI-C (`$'\NNN'`) octal quoting, a
+  lexer-level substitution that forks nothing, proved byte-identical to the
+  old builder. `log()`'s message control-byte scrub (`printf | tr`, #618/
+  #621) and the `.hooks.dispatch_*` reads in the hook-dispatcher region are
+  deliberately unchanged -- see the pull request body for why.

--- a/scripts/lib-memory-context.sh
+++ b/scripts/lib-memory-context.sh
@@ -131,7 +131,7 @@ _remember_render_memory_section() {
     for MFILE in "${MEMORY_FILES[@]}"; do
         [ -f "$MFILE" ] && HAS_MEMORY="true"
     done
-    _remember_rotated_glob_dir=$(_remember_forward_slash "$REMEMBER_DIR")
+    _remember_forward_slash_into _remember_rotated_glob_dir "$REMEMBER_DIR"
     # Glob array, not `ls` (#664/#666) -- `ls` over a pattern that matches
     # nothing prints nothing AND exits nonzero on some implementations, which
     # is exactly what nullglob expresses without forking a process to find
@@ -158,8 +158,8 @@ _remember_render_memory_section() {
     [ -n "$HAS_MEMORY" ] || return 0
 
     echo "=== MEMORY ==="
-    local MEMORY_INJECT_MAX_BYTES
-    MEMORY_INJECT_MAX_BYTES=$(config ".thresholds.memory_inject_max_bytes" 200000)
+    local MEMORY_INJECT_MAX_BYTES=""
+    config_into MEMORY_INJECT_MAX_BYTES ".thresholds.memory_inject_max_bytes" 200000
     case "$MEMORY_INJECT_MAX_BYTES" in (''|*[!0-9]*) MEMORY_INJECT_MAX_BYTES=200000 ;; esac
     local OVERSIZED_MEMORY="" BASENAME MFILE_BYTES
     # One batched `wc -c` over every memory file that is present AND

--- a/scripts/lib-slug.sh
+++ b/scripts/lib-slug.sh
@@ -34,18 +34,40 @@ _REMEMBER_LIB_SLUG_LOADED=1
 # The sed program for the slug, assembled ONCE at source time. It used to be
 # built inside session_dir_slug, where every $(printf) forked a subshell — ~20
 # of them on a function the post-tool hook calls on every single tool call.
+# #665 (part of #660) removes those forks too: 22 x $(printf '\NNN') here
+# each forked a subshell just to capture one byte bash's own ANSI-C quoting
+# (dollar-single-quote octal escapes -- a lexer-level substitution, no
+# process at all) already produces without one. Every span below is a
+# straight transcription of the old $(printf '\NNN') / $(printf
+# '\NNN')-$(printf '\MMM') calls it replaces -- proved byte-identical
+# against the old builder, restored verbatim as a reference, by
+# tests/test_session_start_fork_tax_665.py::test_slug_sed_program_is_byte_identical_to_the_old_printf_builder.
+# A dollar-single-quote span cannot appear INSIDE a double-quoted "..." span
+# and be expanded there -- it is a lexer-level word of its own, so each byte
+# range below is its own bare dollar-single-quote token concatenated (no
+# space) against the surrounding "..." pieces, the same way "a" followed
+# immediately by a dollar-single-quote newline span followed immediately by
+# "b" -- never one span embedding the other -- is the only shape that
+# actually embeds a real newline.
 _remember_build_slug_sed() {
-    local cont
-    cont="$(printf '\200')-$(printf '\277')"
+    local cont=$'\200-\277'
+    local r220_277=$'\220-\277'
+    local r361_363=$'\361-\363'
+    local r200_217=$'\200-\217'
+    local r240_277=$'\240-\277'
+    local r341_354=$'\341-\354'
+    local r200_237=$'\200-\237'
+    local r356_357=$'\356-\357'
+    local r302_337=$'\302-\337'
     _REMEMBER_SLUG_SED=(
-        -e "s/$(printf '\360')[$(printf '\220')-$(printf '\277')][$cont][$cont]/--/g"
-        -e "s/[$(printf '\361')-$(printf '\363')][$cont][$cont][$cont]/--/g"
-        -e "s/$(printf '\364')[$(printf '\200')-$(printf '\217')][$cont][$cont]/--/g"
-        -e "s/$(printf '\340')[$(printf '\240')-$(printf '\277')][$cont]/-/g"
-        -e "s/[$(printf '\341')-$(printf '\354')][$cont][$cont]/-/g"
-        -e "s/$(printf '\355')[$(printf '\200')-$(printf '\237')][$cont]/-/g"
-        -e "s/[$(printf '\356')-$(printf '\357')][$cont][$cont]/-/g"
-        -e "s/[$(printf '\302')-$(printf '\337')][$cont]/-/g"
+        -e "s/"$'\360'"[$r220_277][$cont][$cont]/--/g"
+        -e "s/[$r361_363][$cont][$cont][$cont]/--/g"
+        -e "s/"$'\364'"[$r200_217][$cont][$cont]/--/g"
+        -e "s/"$'\340'"[$r240_277][$cont]/-/g"
+        -e "s/[$r341_354][$cont][$cont]/-/g"
+        -e "s/"$'\355'"[$r200_237][$cont]/-/g"
+        -e "s/[$r356_357][$cont][$cont]/-/g"
+        -e "s/[$r302_337][$cont]/-/g"
         -e 's/[^a-zA-Z0-9]/-/g'
     )
 }

--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -388,6 +388,44 @@ config() {
     # character a segment's own class accepts, so `.foo..bar` (an empty
     # segment) is correctly rejected rather than swallowed.
     #
+    # This validation, the flattened-cache lookup and the jq/python fallback
+    # all now live in config_into() below -- config() is a thin wrapper
+    # around it (#665, part of #660) so external callers (hooks.d/*,
+    # pipeline shell probes, tests) keep the `X=$(config ...)` idiom
+    # unchanged, while a caller that only wants the value (not the
+    # subshell-and-echo round trip) can call config_into directly and skip
+    # the fork the `$( )` itself adds -- see config_into's own comment for
+    # what that removes and what it does not.
+    local _cfg_result
+    config_into _cfg_result "$key" "$default"
+    printf '%s\n' "$_cfg_result"
+}
+
+# config_into VARNAME key default
+#
+# Same lookup and the same precedence as config() above, written straight
+# into VARNAME with `printf -v` instead of printed to stdout -- so a caller
+# that only ever does `X=$(config ...)` can have the value with NO command
+# substitution at all on the common case: the flattened `_RCFG_*` table
+# (#668) already sitting in THIS shell's own variables. `$( )` forks a
+# subshell to capture a function's stdout EVEN WHEN the function itself
+# forks nothing, exactly the way `_remember_date_into` (lib-clock.sh, #511)
+# already removes that same subshell on top of an already-forkless builtin.
+#
+# This does NOT make every path through config() fork-free: a malformed key,
+# a config file that vanished mid-run, or (genuinely, #159's jq-less case)
+# the jq/python fallback still needs a subprocess, or still needs a subshell
+# to capture one -- the zero-fork claim holds only for the flattened-cache
+# HIT path, same judgment call `_config_load`'s own comment makes for the
+# table it builds. Every local below is prefixed `_cfg_` specifically so a
+# caller passing a destination variable named e.g. "key" or "default" (both
+# names this function would otherwise declare `local` itself) is written to
+# the CALLER's variable, not shadowed by one of this function's own.
+config_into() {
+    local _cfg_var="$1"
+    local _cfg_key="$2"
+    local _cfg_default="$3"
+
     # Under LC_ALL=C only: `[A-Za-z]` is a POSIX bracket RANGE, and a range
     # is matched by collation order, not byte value, once LC_COLLATE (via
     # LANG/LC_ALL) selects a UTF-8 locale -- lib-slug.sh hits the identical
@@ -397,18 +435,18 @@ config() {
     # assignment, which does not apply to `[[`, a compound command, the way
     # it would to a simple one) scopes this to the one match and restores
     # nothing, because nothing outside it was ever changed.
-    if ! ( LC_ALL=C; [[ "$key" =~ ^\.[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*$ ]] ); then
+    if ! ( LC_ALL=C; [[ "$_cfg_key" =~ ^\.[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*$ ]] ); then
         # Same convention as _config_load's own '#refuse' report just above
         # in this file: a rejection here and a genuine cache miss a few
-        # lines below both print $default, and without this line they are
-        # indistinguishable from the outside -- "config() keeps returning my
-        # default" reads identically whether the key was malformed or simply
-        # absent. Debug-gated, not unconditional, for the same reason that
-        # one is: a warning that fires on ordinary lookups is a warning
-        # nobody reads.
+        # lines below both resolve to $default, and without this line they
+        # are indistinguishable from the outside -- "config() keeps
+        # returning my default" reads identically whether the key was
+        # malformed or simply absent. Debug-gated, not unconditional, for
+        # the same reason that one is: a warning that fires on ordinary
+        # lookups is a warning nobody reads.
         [ "${REMEMBER_DEBUG:-}" = "1" ] && \
-            echo "remember: config() key '$key' is not a plain dotted path -- returning the default rather than evaluating it" >&2
-        echo "$default"
+            echo "remember: config() key '$_cfg_key' is not a plain dotted path -- returning the default rather than evaluating it" >&2
+        printf -v "$_cfg_var" '%s' "$_cfg_default"
         return
     fi
 
@@ -418,61 +456,55 @@ config() {
         _config_load
     fi
 
-    # $key is already known to match the dotted-path grammar above, so this
-    # branch no longer needs its own shape check -- it only has to fall
+    # $_cfg_key is already known to match the dotted-path grammar above, so
+    # this branch no longer needs its own shape check -- it only has to fall
     # through when the table state cannot answer (fallback / private key).
-    if [ "$_REMEMBER_CFG_STATE" = "ok" ] && ! _config_is_private_key "$key"; then
-        local _slot="_RCFG_${key#.}"
-        _slot="${_slot//./_}"
-        local _hit="${!_slot:-}"
-        [ -n "$_hit" ] && echo "$_hit" || echo "$default"
+    if [ "$_REMEMBER_CFG_STATE" = "ok" ] && ! _config_is_private_key "$_cfg_key"; then
+        local _cfg_slot="_RCFG_${_cfg_key#.}"
+        _cfg_slot="${_cfg_slot//./_}"
+        local _cfg_hit="${!_cfg_slot:-}"
+        printf -v "$_cfg_var" '%s' "${_cfg_hit:-$_cfg_default}"
         return
     fi
 
     if [ ! -f "${REMEMBER_CONFIG:-}" ]; then
-        echo "$default"
+        printf -v "$_cfg_var" '%s' "$_cfg_default"
         return
     fi
-    local val=""
+    local _cfg_val=""
     if command -v jq >/dev/null 2>&1; then
-        # $key is spliced into this program by string interpolation below --
-        # safe ONLY because the guard at the top of this function already
-        # rejected anything not shaped like a plain dotted path (#539). Do
-        # not remove that guard to "simplify" this branch.
-        # NOT `$key // empty`: jq's // treats false the same as null, so every
-        # boolean option set to false read back as its default and could never
-        # be switched off (#159). features.ndc_compression and features.recovery
-        # are both documented, both default true, and neither could be disabled.
-        # Ask for the value and treat only null — a genuinely absent key — as
-        # missing.
-        # Asking jq to map a genuinely absent key to "" and everything else to
-        # its string form. Two near misses this needs to avoid:
-        #   `$key // empty` treats FALSE like null, so no boolean set to false
-        #   could ever be read (#159);
-        #   testing the printed value against "null" cannot tell JSON null from
-        #   the string "null" — `jq -r` prints both as the same bare word.
-        val=$(jq -r "if $key == null then \"\" else ($key | tostring) end" \
+        # $_cfg_key is spliced into this program by string interpolation
+        # below -- safe ONLY because the guard at the top of this function
+        # already rejected anything not shaped like a plain dotted path
+        # (#539). Do not remove that guard to "simplify" this branch.
+        # NOT `$_cfg_key // empty`: jq's // treats false the same as null,
+        # so every boolean option set to false read back as its default and
+        # could never be switched off (#159). features.ndc_compression and
+        # features.recovery are both documented, both default true, and
+        # neither could be disabled.
+        # Ask for the value and treat only null -- a genuinely absent key --
+        # as missing. Testing the printed value against "null" cannot tell
+        # JSON null from the string "null" -- `jq -r` prints both as the
+        # same bare word.
+        _cfg_val=$(jq -r "if $_cfg_key == null then \"\" else ($_cfg_key | tostring) end" \
             "$REMEMBER_CONFIG" 2>/dev/null)
     elif type _jq_fallback >/dev/null 2>&1; then
-        # No jq — detect-tools.sh already defined a Python-based fallback for
-        # exactly this (bare-key `jq -r '.key' file` reads). config() branched
-        # on `command -v jq` and fell straight to `echo "$default"` without
-        # ever trying it, so every user config override was silently ignored
-        # on any jq-less machine. Wire it in here, matching #159's null-vs-
-        # false semantics: an absent/null key falls through to `default`
-        # below; a present `false` prints as the string "false" (see
-        # detect-tools.sh's isinstance(val, str) fix for why that's not
-        # Python's "False").
-        val=$(_jq_fallback -r "$key" "$REMEMBER_CONFIG" 2>/dev/null)
+        # No jq -- detect-tools.sh already defined a Python-based fallback
+        # for exactly this (bare-key `jq -r '.key' file` reads). Matching
+        # #159's null-vs-false semantics: an absent/null key falls through
+        # to $_cfg_default below; a present `false` prints as the string
+        # "false" (see detect-tools.sh's isinstance(val, str) fix for why
+        # that's not Python's "False").
+        _cfg_val=$(_jq_fallback -r "$_cfg_key" "$REMEMBER_CONFIG" 2>/dev/null)
     else
         # log.sh can be sourced directly without detect-tools.sh (some
         # callers/tests do), so _jq_fallback may not exist. Same read,
-        # inlined, so config() never regresses to bundled-default-only just
-        # because of sourcing order. Same null-vs-false semantics as above:
-        # a genuinely absent/null key leaves $val empty (falls to $default
-        # below); a present `false` renders as jq's "false", not Python's
-        # str(False).
-        val=$("${PYTHON:-python3}" -c '
+        # inlined, so config_into() never regresses to bundled-default-only
+        # just because of sourcing order. Same null-vs-false semantics as
+        # above: a genuine absent/null key leaves $_cfg_val empty (falls to
+        # $_cfg_default below); a present `false` renders as jq's "false",
+        # not Python's str(False).
+        _cfg_val=$("${PYTHON:-python3}" -c '
 import json, sys
 try:
     data = json.load(open(sys.argv[2]))
@@ -489,9 +521,9 @@ try:
         print(v if isinstance(v, str) else json.dumps(v))
 except Exception:
     pass
-' "$key" "$REMEMBER_CONFIG" 2>/dev/null)
+' "$_cfg_key" "$REMEMBER_CONFIG" 2>/dev/null)
     fi
-    [ -n "$val" ] && echo "$val" || echo "$default"
+    printf -v "$_cfg_var" '%s' "${_cfg_val:-$_cfg_default}"
 }
 
 # Build the table now, in THIS shell, so every `$(config ...)` subshell
@@ -518,14 +550,19 @@ debug_enabled() {
         [ "$REMEMBER_DEBUG" = "1" ]
         return
     fi
-    case "$(config '.debug' '')" in
+    local _debug_cfg
+    config_into _debug_cfg '.debug' ''
+    case "$_debug_cfg" in
         true) return 0 ;;
         false) return 1 ;;
     esac
     [ "$_default" = "1" ]
 }
 
-REMEMBER_TZ=$(config ".timezone" "")
+# config_into (#665, part of #660) writes straight into REMEMBER_TZ -- no
+# command-substitution subshell on top of the flattened-cache-hit table
+# `_config_load` already built into THIS shell's own variables.
+config_into REMEMBER_TZ ".timezone" ""
 export REMEMBER_TZ
 
 # What user-prompt-hook.sh is allowed to inject (#301). Read here rather than in
@@ -537,7 +574,7 @@ export REMEMBER_TZ
 #   stable — [user] only, plus the >=95 warning; no per-turn-volatile bytes
 #   off    — nothing at all, warning included
 # An unrecognised value is `full`: a typo must not silently delete the clock.
-REMEMBER_PROMPT_STAMP=$(config ".prompt_stamp" "full")
+config_into REMEMBER_PROMPT_STAMP ".prompt_stamp" "full"
 case "$REMEMBER_PROMPT_STAMP" in
     stable|off) ;;
     *) REMEMBER_PROMPT_STAMP="full" ;;
@@ -566,11 +603,11 @@ export REMEMBER_PROMPT_STAMP
 # a leading zero that clears a digits-only guard is read as octal (#322/#332).
 # One validation at the source beats one per consumer, which is how the
 # pre-#158 duplicate readers drifted.
-REMEMBER_SAVE_COOLDOWN=$(config ".cooldowns.save_seconds" 120)
+config_into REMEMBER_SAVE_COOLDOWN ".cooldowns.save_seconds" 120
 case "$REMEMBER_SAVE_COOLDOWN" in ''|*[!0-9]*) REMEMBER_SAVE_COOLDOWN=120 ;; esac
 export REMEMBER_SAVE_COOLDOWN
 
-REMEMBER_DELTA_THRESHOLD=$(config ".thresholds.delta_lines_trigger" 50)
+config_into REMEMBER_DELTA_THRESHOLD ".thresholds.delta_lines_trigger" 50
 case "$REMEMBER_DELTA_THRESHOLD" in ''|*[!0-9]*) REMEMBER_DELTA_THRESHOLD=50 ;; esac
 export REMEMBER_DELTA_THRESHOLD
 
@@ -578,9 +615,14 @@ export REMEMBER_DELTA_THRESHOLD
 # shell env var still wins (override) via ${VAR:=...}, then config, then the
 # built-in default. Exported here (log.sh is sourced by every script) so both
 # the summarize and consolidate model calls in pipeline/haiku.py see them.
-: "${REMEMBER_MODEL:=$(config ".model" "haiku")}"
+# `${VAR:=...}` triggers on unset OR empty -- preserved here by checking
+# the same condition directly, rather than `${VAR:=$(config_into ...)}`
+# (config_into has no stdout to substitute; it writes to a NAMED variable,
+# so it cannot sit inside a parameter expansion the way `$(config ...)`
+# could). Skips the fork entirely when an explicit env var already won.
+[ -n "${REMEMBER_MODEL:-}" ] || config_into REMEMBER_MODEL ".model" "haiku"
 export REMEMBER_MODEL
-: "${REMEMBER_REJECT_PATTERN:=$(config ".reject_pattern" "")}"
+[ -n "${REMEMBER_REJECT_PATTERN:-}" ] || config_into REMEMBER_REJECT_PATTERN ".reject_pattern" ""
 export REMEMBER_REJECT_PATTERN
 
 # Resolve "today" / "now" using REMEMBER_TZ when set, else system local.
@@ -643,7 +685,14 @@ log() {
     local component="$1"
     local message="$2"
     local timestamp
-    timestamp=$(_remember_date +%H:%M:%S)
+    # `_remember_date_into` (lib-clock.sh, #511) writes straight into
+    # `timestamp` with `printf -v` -- no command-substitution subshell on
+    # top of the already-forkless builtin path (#665, part of #660). The
+    # REMEMBER_TZ and bash-3.2 cases inside it still shell out to `date`,
+    # an external process either way -- this only removes the extra fork
+    # `$( )` was adding on top of that, exactly the way config_into (above,
+    # #665) does for config().
+    _remember_date_into timestamp +%H:%M:%S
     # #621 tried twice to gate this fork behind a cheap in-shell
     # pre-check (a message rarely carries a control byte at all, and log()
     # runs on the per-tool-call hot path) -- unconditional `[[:cntrl:]]`,

--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -361,43 +361,18 @@ EOF
 # Read .timezone from config BEFORE computing MEMORY_LOG_DATE — otherwise
 # TZ="" falls back to UTC on macOS/BSD and produces next-day filenames after
 # ~20:00 local in zones west of UTC.
+# The key-shape validation (#539), the flattened-cache lookup and the
+# jq/python fallback all live in config_into() below, not here -- config()
+# is now a thin wrapper around it (#665, part of #660) so external callers
+# (hooks.d/*, pipeline shell probes, tests) keep the `X=$(config ...)`
+# idiom unchanged, while a caller that only wants the value (not the
+# subshell-and-echo round trip) can call config_into directly and skip the
+# fork the `$( )` itself adds. See config_into's own comment, right below,
+# for what that removes, what it does not, and why $key is validated before
+# ever reaching jq.
 config() {
-    local key="$1"
-    local default="$2"
-
-    # $key is spliced into the jq program below by string interpolation, not
-    # passed as data (#539) -- `if $key == null then ... else ($key |
-    # tostring) end`, with $key substituted verbatim, twice. Every call site
-    # in this repo passes a hardcoded literal, so nothing exploits this
-    # today, but the function's contract never said the argument had to be a
-    # literal, and nothing enforced it. Reject anything that is not a plain
-    # dotted path up front, before the config table is even loaded, so a
-    # future caller that builds $key from data fails closed to the default
-    # instead of having it evaluated as jq.
-    #
-    # A `case` glob CANNOT express this: the earlier form here,
-    # `""|.|.*[!A-Za-z0-9_.]*`, only rejected a key that literally started
-    # with "." and later contained a bad character -- a key with no leading
-    # dot at all (`("INJECTED"|length>0)`, say) matched none of that
-    # pattern's arms, fell through the whole case silently, and reached the
-    # jq interpolation below unfiltered. `[[ =~ ]]` (already used elsewhere
-    # in this file, e.g. the KEY=VALUE parser below) can anchor the WHOLE
-    # string against a real grammar instead: one leading dot, then one or
-    # more [A-Za-z0-9_]+ segments, each joined to the next by a single
-    # literal dot -- the dot is the separator BETWEEN segments, never a
-    # character a segment's own class accepts, so `.foo..bar` (an empty
-    # segment) is correctly rejected rather than swallowed.
-    #
-    # This validation, the flattened-cache lookup and the jq/python fallback
-    # all now live in config_into() below -- config() is a thin wrapper
-    # around it (#665, part of #660) so external callers (hooks.d/*,
-    # pipeline shell probes, tests) keep the `X=$(config ...)` idiom
-    # unchanged, while a caller that only wants the value (not the
-    # subshell-and-echo round trip) can call config_into directly and skip
-    # the fork the `$( )` itself adds -- see config_into's own comment for
-    # what that removes and what it does not.
     local _cfg_result
-    config_into _cfg_result "$key" "$default"
+    config_into _cfg_result "$1" "$2"
     printf '%s\n' "$_cfg_result"
 }
 
@@ -417,14 +392,24 @@ config() {
 # the jq/python fallback still needs a subprocess, or still needs a subshell
 # to capture one -- the zero-fork claim holds only for the flattened-cache
 # HIT path, same judgment call `_config_load`'s own comment makes for the
-# table it builds. Every local below is prefixed `_cfg_` specifically so a
-# caller passing a destination variable named e.g. "key" or "default" (both
-# names this function would otherwise declare `local` itself) is written to
-# the CALLER's variable, not shadowed by one of this function's own.
+# table it builds. Every local below is prefixed `_cfg_into_` (this
+# function's own name, not just a generic tag) specifically so a caller
+# passing a destination variable named "key" or "default" is written to
+# the CALLER's variable rather than one of this function's own locals of
+# that same bare name. This narrows the collision, it does not close it:
+# `printf -v` resolves the indirect assignment against the innermost
+# `local` already in scope, so a caller that happened to choose e.g.
+# "_cfg_into_key" as ITS destination variable would still have the write
+# land on this function's own local instead -- bash has no nameref
+# (`local -n`) on the bash 3.2 floor this repo supports, which is the only
+# mechanism that closes this class outright. No current call site does
+# this; it is a live constraint on any future one, the same residual risk
+# `_remember_date_into` (lib-clock.sh, #511) already carries for its own
+# `_var`/`_val` locals.
 config_into() {
-    local _cfg_var="$1"
-    local _cfg_key="$2"
-    local _cfg_default="$3"
+    local _cfg_into_var="$1"
+    local _cfg_into_key="$2"
+    local _cfg_into_default="$3"
 
     # Under LC_ALL=C only: `[A-Za-z]` is a POSIX bracket RANGE, and a range
     # is matched by collation order, not byte value, once LC_COLLATE (via
@@ -435,7 +420,7 @@ config_into() {
     # assignment, which does not apply to `[[`, a compound command, the way
     # it would to a simple one) scopes this to the one match and restores
     # nothing, because nothing outside it was ever changed.
-    if ! ( LC_ALL=C; [[ "$_cfg_key" =~ ^\.[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*$ ]] ); then
+    if ! ( LC_ALL=C; [[ "$_cfg_into_key" =~ ^\.[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)*$ ]] ); then
         # Same convention as _config_load's own '#refuse' report just above
         # in this file: a rejection here and a genuine cache miss a few
         # lines below both resolve to $default, and without this line they
@@ -445,8 +430,8 @@ config_into() {
         # the same reason that one is: a warning that fires on ordinary
         # lookups is a warning nobody reads.
         [ "${REMEMBER_DEBUG:-}" = "1" ] && \
-            echo "remember: config() key '$_cfg_key' is not a plain dotted path -- returning the default rather than evaluating it" >&2
-        printf -v "$_cfg_var" '%s' "$_cfg_default"
+            echo "remember: config() key '$_cfg_into_key' is not a plain dotted path -- returning the default rather than evaluating it" >&2
+        printf -v "$_cfg_into_var" '%s' "$_cfg_into_default"
         return
     fi
 
@@ -456,28 +441,28 @@ config_into() {
         _config_load
     fi
 
-    # $_cfg_key is already known to match the dotted-path grammar above, so
+    # $_cfg_into_key is already known to match the dotted-path grammar above, so
     # this branch no longer needs its own shape check -- it only has to fall
     # through when the table state cannot answer (fallback / private key).
-    if [ "$_REMEMBER_CFG_STATE" = "ok" ] && ! _config_is_private_key "$_cfg_key"; then
-        local _cfg_slot="_RCFG_${_cfg_key#.}"
-        _cfg_slot="${_cfg_slot//./_}"
-        local _cfg_hit="${!_cfg_slot:-}"
-        printf -v "$_cfg_var" '%s' "${_cfg_hit:-$_cfg_default}"
+    if [ "$_REMEMBER_CFG_STATE" = "ok" ] && ! _config_is_private_key "$_cfg_into_key"; then
+        local _cfg_into_slot="_RCFG_${_cfg_into_key#.}"
+        _cfg_into_slot="${_cfg_into_slot//./_}"
+        local _cfg_into_hit="${!_cfg_into_slot:-}"
+        printf -v "$_cfg_into_var" '%s' "${_cfg_into_hit:-$_cfg_into_default}"
         return
     fi
 
     if [ ! -f "${REMEMBER_CONFIG:-}" ]; then
-        printf -v "$_cfg_var" '%s' "$_cfg_default"
+        printf -v "$_cfg_into_var" '%s' "$_cfg_into_default"
         return
     fi
-    local _cfg_val=""
+    local _cfg_into_val=""
     if command -v jq >/dev/null 2>&1; then
-        # $_cfg_key is spliced into this program by string interpolation
+        # $_cfg_into_key is spliced into this program by string interpolation
         # below -- safe ONLY because the guard at the top of this function
         # already rejected anything not shaped like a plain dotted path
         # (#539). Do not remove that guard to "simplify" this branch.
-        # NOT `$_cfg_key // empty`: jq's // treats false the same as null,
+        # NOT `$_cfg_into_key // empty`: jq's // treats false the same as null,
         # so every boolean option set to false read back as its default and
         # could never be switched off (#159). features.ndc_compression and
         # features.recovery are both documented, both default true, and
@@ -486,25 +471,25 @@ config_into() {
         # as missing. Testing the printed value against "null" cannot tell
         # JSON null from the string "null" -- `jq -r` prints both as the
         # same bare word.
-        _cfg_val=$(jq -r "if $_cfg_key == null then \"\" else ($_cfg_key | tostring) end" \
+        _cfg_into_val=$(jq -r "if $_cfg_into_key == null then \"\" else ($_cfg_into_key | tostring) end" \
             "$REMEMBER_CONFIG" 2>/dev/null)
     elif type _jq_fallback >/dev/null 2>&1; then
         # No jq -- detect-tools.sh already defined a Python-based fallback
         # for exactly this (bare-key `jq -r '.key' file` reads). Matching
         # #159's null-vs-false semantics: an absent/null key falls through
-        # to $_cfg_default below; a present `false` prints as the string
+        # to $_cfg_into_default below; a present `false` prints as the string
         # "false" (see detect-tools.sh's isinstance(val, str) fix for why
         # that's not Python's "False").
-        _cfg_val=$(_jq_fallback -r "$_cfg_key" "$REMEMBER_CONFIG" 2>/dev/null)
+        _cfg_into_val=$(_jq_fallback -r "$_cfg_into_key" "$REMEMBER_CONFIG" 2>/dev/null)
     else
         # log.sh can be sourced directly without detect-tools.sh (some
         # callers/tests do), so _jq_fallback may not exist. Same read,
         # inlined, so config_into() never regresses to bundled-default-only
         # just because of sourcing order. Same null-vs-false semantics as
-        # above: a genuine absent/null key leaves $_cfg_val empty (falls to
-        # $_cfg_default below); a present `false` renders as jq's "false",
+        # above: a genuine absent/null key leaves $_cfg_into_val empty (falls to
+        # $_cfg_into_default below); a present `false` renders as jq's "false",
         # not Python's str(False).
-        _cfg_val=$("${PYTHON:-python3}" -c '
+        _cfg_into_val=$("${PYTHON:-python3}" -c '
 import json, sys
 try:
     data = json.load(open(sys.argv[2]))
@@ -521,9 +506,9 @@ try:
         print(v if isinstance(v, str) else json.dumps(v))
 except Exception:
     pass
-' "$_cfg_key" "$REMEMBER_CONFIG" 2>/dev/null)
+' "$_cfg_into_key" "$REMEMBER_CONFIG" 2>/dev/null)
     fi
-    printf -v "$_cfg_var" '%s' "${_cfg_val:-$_cfg_default}"
+    printf -v "$_cfg_into_var" '%s' "${_cfg_into_val:-$_cfg_into_default}"
 }
 
 # Build the table now, in THIS shell, so every `$(config ...)` subshell

--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -625,7 +625,13 @@ _REMEMBER_SRC_DIR="${BASH_SOURCE[0]%/*}"
 source "$_REMEMBER_SRC_DIR/lib-clock.sh"
 unset _REMEMBER_SRC_DIR
 
-MEMORY_LOG_DATE=$(_remember_date +%Y-%m-%d)
+# _remember_date_into (lib-clock.sh, #511), not $(_remember_date ...) --
+# this runs unconditionally at the top level every time log.sh is sourced,
+# on every hook invocation, exactly the class of fork #665 (part of #660)
+# exists to remove (found by a self-review round: the top-level call was
+# missed the first pass, log()'s own timestamp a few lines below was not).
+MEMORY_LOG_DATE=""
+_remember_date_into MEMORY_LOG_DATE +%Y-%m-%d
 MEMORY_LOG_FILE="${REMEMBER_LOG_DIR}/memory-${MEMORY_LOG_DATE}.log"
 
 # Log a timestamped message to the daily pipeline log file.

--- a/scripts/resolve-paths.sh
+++ b/scripts/resolve-paths.sh
@@ -266,6 +266,22 @@ _remember_forward_slash() {
     esac
 }
 
+# _remember_forward_slash_into VARNAME VALUE
+# Same answer as _remember_forward_slash, written into VARNAME with
+# `printf -v` instead of printed -- so a caller doing `X=$(_remember_forward_slash
+# "$Y")` can have it with no command-substitution subshell at all (#665, part
+# of #660). `_remember_forward_slash` itself already forks nothing (`case` and
+# a parameter expansion, no external process) -- the fork this removes is the
+# one `$( )` was adding purely to capture that already-forkless function's
+# stdout, the same class `_remember_date_into` (lib-clock.sh, #511) and
+# config_into (log.sh, #665) remove for their own callers.
+_remember_forward_slash_into() {
+    case "$OSTYPE" in
+        msys|cygwin) printf -v "$1" '%s' "${2//\\//}" ;;
+        *) printf -v "$1" '%s' "$2" ;;
+    esac
+}
+
 # --- Resolve PROJECT_DIR (the user's project root) ---
 #
 # Priority:

--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -125,18 +125,23 @@ _stdin_json_string() {
 # unconditional call: VARNAME is set to the empty string up front, so a
 # `return 1` below leaves it exactly where the old `|| X=""` idiom did,
 # with no separate fallback statement needed at the call site (#665, part
-# of #660).
+# of #660). Locals below are prefixed `_sjsi_` (this function's own name,
+# abbreviated) rather than the bare `_sjs_` tag config_into's own comment
+# warns about -- narrows, does not close, the same `printf -v`-resolves-
+# against-the-innermost-local collision every function in this file that
+# takes a destination VARNAME shares; see config_into's comment (log.sh)
+# for the full argument.
 _stdin_json_string_into() {
-    local _sjs_var="$1" _sjs_key="$2" _sjs_raw="$3" _sjs_rest _sjs_prefix _sjs_value
-    printf -v "$_sjs_var" '%s' ""
-    case "$_sjs_raw" in *"\"$_sjs_key\""*) ;; *) return 1 ;; esac
-    _sjs_rest=${_sjs_raw#*\"$_sjs_key\"}
-    _sjs_prefix=${_sjs_rest%%\"*}
-    case "$_sjs_prefix" in *[!:[:space:]]*) return 1 ;; esac
-    _sjs_value=${_sjs_rest#*\"}
-    _sjs_value=${_sjs_value%%\"*}
-    [ -n "$_sjs_value" ] || return 1
-    printf -v "$_sjs_var" '%s' "$_sjs_value"
+    local _sjsi_var="$1" _sjsi_key="$2" _sjsi_raw="$3" _sjsi_rest _sjsi_prefix _sjsi_value
+    printf -v "$_sjsi_var" '%s' ""
+    case "$_sjsi_raw" in *"\"$_sjsi_key\""*) ;; *) return 1 ;; esac
+    _sjsi_rest=${_sjsi_raw#*\"$_sjsi_key\"}
+    _sjsi_prefix=${_sjsi_rest%%\"*}
+    case "$_sjsi_prefix" in *[!:[:space:]]*) return 1 ;; esac
+    _sjsi_value=${_sjsi_rest#*\"}
+    _sjsi_value=${_sjsi_value%%\"*}
+    [ -n "$_sjsi_value" ] || return 1
+    printf -v "$_sjsi_var" '%s' "$_sjsi_value"
 }
 
 # ── The cwd the host handed us (#411) ──────────────────────────────────────
@@ -203,7 +208,8 @@ if ! command -v _remember_date >/dev/null 2>&1; then
     echo "session-start-hook: ERROR -- failed to source $PLUGIN_ROOT/scripts/log.sh" >&2
     exit 127
 fi
-TODAY=$(_remember_date '+%Y-%m-%d')
+TODAY=""
+_remember_date_into TODAY '+%Y-%m-%d'
 log "hook" "session-start: PROJECT_DIR=$PROJECT_DIR PIPELINE_DIR=$PIPELINE_DIR REMEMBER_DIR=$REMEMBER_DIR"
 
 # Publish what the chain above just resolved, so user-prompt-hook.sh does not
@@ -1064,8 +1070,8 @@ if [ "$_promos_enabled" = "true" ] \
         fi
         case "$last_ts" in ''|*[!0-9]*) last_ts=0 ;; esac
 
-        local now
-        now=$(_remember_date +%s)
+        local now=""
+        _remember_date_into now +%s
         case "$now" in ''|*[!0-9]*) return 0 ;; esac
 
         if [ "$last_ts" -gt 0 ] \
@@ -1472,7 +1478,7 @@ if [ -f "$REMEMBER_HANDOFF" ] && [ -s "$REMEMBER_HANDOFF" ]; then
         echo "[already delivered ${DELIVERIES} times since ${FIRST_DELIVERED:-an earlier session} -- no new handoff has been written since, so this is pending replacement, not news. You may already have acted on it. Running /remember replaces it.]"
     else
         DELIVERIES=1
-        FIRST_DELIVERED=$(_remember_date '+%Y-%m-%d %H:%M')
+        _remember_date_into FIRST_DELIVERED '+%Y-%m-%d %H:%M'
     fi
     cat "$REMEMBER_HANDOFF"
     echo ""
@@ -1601,7 +1607,8 @@ if [ -d "$SESSIONS_DIR" ] && [ -d "$REMEMBER_DIR/tmp" ]; then
             # into "confirmed outside the grace window", the opposite of
             # what an unreadable mtime does three lines above. Refuse to
             # guess in either failure shape, same as the mtime check does.
-            _remember_now=$(_remember_date +%s)
+            _remember_now=""
+            _remember_date_into _remember_now +%s
             case "$_remember_now" in
                 (''|*[!0-9]*)
                     continue

--- a/scripts/session-start-hook.sh
+++ b/scripts/session-start-hook.sh
@@ -117,6 +117,28 @@ _stdin_json_string() {
     printf '%s' "$value"
 }
 
+# _stdin_json_string_into VARNAME key raw
+# Same extraction as _stdin_json_string, written into VARNAME with
+# `printf -v` instead of printed -- so `X=$(_stdin_json_string ...) ||
+# X=""` (a subshell fork purely to capture an already-forkless function's
+# stdout, plus a second statement for the failure case) becomes one
+# unconditional call: VARNAME is set to the empty string up front, so a
+# `return 1` below leaves it exactly where the old `|| X=""` idiom did,
+# with no separate fallback statement needed at the call site (#665, part
+# of #660).
+_stdin_json_string_into() {
+    local _sjs_var="$1" _sjs_key="$2" _sjs_raw="$3" _sjs_rest _sjs_prefix _sjs_value
+    printf -v "$_sjs_var" '%s' ""
+    case "$_sjs_raw" in *"\"$_sjs_key\""*) ;; *) return 1 ;; esac
+    _sjs_rest=${_sjs_raw#*\"$_sjs_key\"}
+    _sjs_prefix=${_sjs_rest%%\"*}
+    case "$_sjs_prefix" in *[!:[:space:]]*) return 1 ;; esac
+    _sjs_value=${_sjs_rest#*\"}
+    _sjs_value=${_sjs_value%%\"*}
+    [ -n "$_sjs_value" ] || return 1
+    printf -v "$_sjs_var" '%s' "$_sjs_value"
+}
+
 # ── The cwd the host handed us (#411) ──────────────────────────────────────
 # Every host puts `cwd` on the SessionStart payload (#407's comparison table).
 # Claude Code always also publishes it as CLAUDE_PROJECT_DIR; Codex never
@@ -140,7 +162,7 @@ _stdin_json_string() {
 # preserves one). Whether the value actually names a directory is decided in
 # resolve-paths.sh, which falls back to the existing derivation when it does
 # not.
-REMEMBER_HOOK_CWD=$(_stdin_json_string cwd "$HOOK_STDIN" 2>/dev/null) || REMEMBER_HOOK_CWD=""
+_stdin_json_string_into REMEMBER_HOOK_CWD cwd "$HOOK_STDIN" 2>/dev/null
 case "$REMEMBER_HOOK_CWD" in
     *$'\n'*|*$'\r'*) REMEMBER_HOOK_CWD="" ;;
 esac
@@ -242,7 +264,7 @@ esac
 # than dropped, in case a future change to that loop ever preserves one).
 # Whether the value actually names an openable file is decided on the Python
 # side, which falls back to the existing derivation when it does not.
-REMEMBER_TRANSCRIPT_PATH=$(_stdin_json_string transcript_path "$HOOK_STDIN" 2>/dev/null) || REMEMBER_TRANSCRIPT_PATH=""
+_stdin_json_string_into REMEMBER_TRANSCRIPT_PATH transcript_path "$HOOK_STDIN" 2>/dev/null
 case "$REMEMBER_TRANSCRIPT_PATH" in
     *$'\n'*|*$'\r'*) REMEMBER_TRANSCRIPT_PATH="" ;;
 esac
@@ -262,7 +284,7 @@ export REMEMBER_TRANSCRIPT_PATH
 # `compact`: that would silently stop injecting memory for anyone whose
 # payload shape differs from the one this heuristic was written against —
 # the failure this plugin exists to prevent, not to cause.
-SESSION_START_SOURCE=$(_stdin_json_string source "$HOOK_STDIN" 2>/dev/null) || SESSION_START_SOURCE=""
+_stdin_json_string_into SESSION_START_SOURCE source "$HOOK_STDIN" 2>/dev/null
 case "$SESSION_START_SOURCE" in
     startup|resume|clear|compact|fork) ;;
     *) SESSION_START_SOURCE="" ;;
@@ -707,7 +729,11 @@ if [ -n "$PREV_ID" ] && session_was_saved "$PREV_ID"; then
 fi
 
 # ── Recovery: save the most recent missed session ──────────────────────────
-if [ "$(config '.features.recovery' true)" = "true" ]; then
+# config_into (#665, part of #660) writes into a scratch var directly --
+# no command-substitution subshell on top of the flattened-cache-hit table.
+_recovery_enabled=""
+config_into _recovery_enabled '.features.recovery' true
+if [ "$_recovery_enabled" = "true" ]; then
 if [ -d "$SESSIONS_DIR" ] && [ -f "$LAST_SAVE_FILE" ] && [ -n "$PREV_ID" ]; then
     if [ "$PREV_WAS_SAVED" = "no" ]; then
         # REMEMBER_TRANSCRIPT_PATH (exported above, #407) names THIS session's
@@ -924,7 +950,7 @@ _remember_memory_paths
 # there, and doing so leaves "no HANDOFF hint was given" visible in the
 # transcript instead of a namespaced-looking path that never actually
 # applied.
-HANDOFF_MODE=$(config ".handoff_mode" "single")
+config_into HANDOFF_MODE ".handoff_mode" "single"
 PER_SESSION_HANDOFF=""
 HANDOFF_MODE_DEGRADED=""
 if [ "$HANDOFF_MODE" = "per_session" ] && [ -n "$CURRENT_SESSION_ID" ]; then
@@ -1000,7 +1026,9 @@ PROMO_MSG=""
 PROMO_ID=""
 PROMO_MARKER=""
 PROMO_NOW=""
-if [ "$(config ".features.plugin_promos" true)" = "true" ] \
+_promos_enabled=""
+config_into _promos_enabled ".features.plugin_promos" true
+if [ "$_promos_enabled" = "true" ] \
     && [ -z "$REMEMBER_SUPPRESS_PROMO" ]; then
 
     # Args: none. Reads promos.json + installed_plugins.json, sets PROMO_MSG
@@ -1021,7 +1049,7 @@ if [ "$(config ".features.plugin_promos" true)" = "true" ] \
         local promo_dir="${HOME}/.remember/tmp"
         local marker="$promo_dir/promo-notice"
         local cooldown
-        cooldown=$(config ".cooldowns.promo_seconds" 604800)
+        config_into cooldown ".cooldowns.promo_seconds" 604800
         case "$cooldown" in ''|*[!0-9]*) cooldown=604800 ;; esac
 
         local last_ts=0 last_id=""
@@ -1522,7 +1550,8 @@ if [ -d "$SESSIONS_DIR" ] && [ -d "$REMEMBER_DIR/tmp" ]; then
     # cover). _remember_stale_record itself then expands with '/'
     # separators from this normalized directory, so the existing
     # ##*/remember.delivered. strip further down still matches.
-    _remember_delivered_glob_dir=$(_remember_forward_slash "$REMEMBER_DIR")
+    _remember_delivered_glob_dir=""
+    _remember_forward_slash_into _remember_delivered_glob_dir "$REMEMBER_DIR"
     for _remember_stale_record in "$_remember_delivered_glob_dir"/tmp/remember.delivered.*; do
         [ -f "$_remember_stale_record" ] || continue
         _remember_stale_id="${_remember_stale_record##*/remember.delivered.}"
@@ -1639,7 +1668,8 @@ fi
 # without this the count silently undercounts to 0 there, gating the
 # "N day(s) of memory to compress" message and the background
 # consolidation trigger off for real.
-_remember_staging_glob_dir=$(_remember_forward_slash "$REMEMBER_DIR")
+_remember_staging_glob_dir=""
+_remember_forward_slash_into _remember_staging_glob_dir "$REMEMBER_DIR"
 # Glob array + a bash `case` per entry, not `ls | grep -v | grep -v | wc -l |
 # tr -d ' '` (#666) -- five forks collapsed to zero: nullglob turns "no
 # matches" into an empty array instead of the literal pattern string, and the

--- a/tests/test_case_divergence_298.py
+++ b/tests/test_case_divergence_298.py
@@ -164,6 +164,53 @@ _SANCTIONED_DIVERGENCE = {
             '        ' + _LAZY_PYTHON_GUARD +
             '        _hash=$("${PYTHON:-python3}" "$_slug_py" --hash "$_orig" 2>/dev/null) || _hash=""\n',
         ),
+        (
+            '_remember_build_slug_sed() {\n'
+            '    local cont\n'
+            '    cont="$(printf \'\\200\')-$(printf \'\\277\')"\n'
+            '    _REMEMBER_SLUG_SED=(\n'
+            '        -e "s/$(printf \'\\360\')[$(printf \'\\220\')-$(printf \'\\277\')][$cont][$cont]/--/g"\n'
+            '        -e "s/[$(printf \'\\361\')-$(printf \'\\363\')][$cont][$cont][$cont]/--/g"\n'
+            '        -e "s/$(printf \'\\364\')[$(printf \'\\200\')-$(printf \'\\217\')][$cont][$cont]/--/g"\n'
+            '        -e "s/$(printf \'\\340\')[$(printf \'\\240\')-$(printf \'\\277\')][$cont]/-/g"\n'
+            '        -e "s/[$(printf \'\\341\')-$(printf \'\\354\')][$cont][$cont]/-/g"\n'
+            '        -e "s/$(printf \'\\355\')[$(printf \'\\200\')-$(printf \'\\237\')][$cont]/-/g"\n'
+            '        -e "s/[$(printf \'\\356\')-$(printf \'\\357\')][$cont][$cont]/-/g"\n'
+            '        -e "s/[$(printf \'\\302\')-$(printf \'\\337\')][$cont]/-/g"\n'
+            "        -e 's/[^a-zA-Z0-9]/-/g'\n"
+            '    )\n'
+            '}\n'
+            '_remember_build_slug_sed\n',
+            # #665 (part of #660): ANSI-C octal quoting instead of
+            # $(printf ...) -- byte-identical output, proved by
+            # tests/test_session_start_fork_tax_665.py::
+            # test_slug_sed_program_is_byte_identical_to_the_old_printf_builder,
+            # replacing 22 subshell forks with a lexer-level substitution
+            # that forks nothing.
+            '_remember_build_slug_sed() {\n'
+            "    local cont=$'\\200-\\277'\n"
+            "    local r220_277=$'\\220-\\277'\n"
+            "    local r361_363=$'\\361-\\363'\n"
+            "    local r200_217=$'\\200-\\217'\n"
+            "    local r240_277=$'\\240-\\277'\n"
+            "    local r341_354=$'\\341-\\354'\n"
+            "    local r200_237=$'\\200-\\237'\n"
+            "    local r356_357=$'\\356-\\357'\n"
+            "    local r302_337=$'\\302-\\337'\n"
+            '    _REMEMBER_SLUG_SED=(\n'
+            '        -e "s/"$\'\\360\'"[$r220_277][$cont][$cont]/--/g"\n'
+            '        -e "s/[$r361_363][$cont][$cont][$cont]/--/g"\n'
+            '        -e "s/"$\'\\364\'"[$r200_217][$cont][$cont]/--/g"\n'
+            '        -e "s/"$\'\\340\'"[$r240_277][$cont]/-/g"\n'
+            '        -e "s/[$r341_354][$cont][$cont]/-/g"\n'
+            '        -e "s/"$\'\\355\'"[$r200_237][$cont]/-/g"\n'
+            '        -e "s/[$r356_357][$cont][$cont]/-/g"\n'
+            '        -e "s/[$r302_337][$cont]/-/g"\n'
+            "        -e 's/[^a-zA-Z0-9]/-/g'\n"
+            '    )\n'
+            '}\n'
+            '_remember_build_slug_sed\n',
+        ),
     ],
     "scripts/lib-memory-dir.sh": [
         (

--- a/tests/test_config_contract.py
+++ b/tests/test_config_contract.py
@@ -31,8 +31,11 @@ EXAMPLE = REPO_ROOT / "config.example.json"
 # Where a config key can legitimately be read from.
 SOURCE_DIRS = ("scripts", "hooks.d", "hooks", "pipeline")
 
-# `config ".some.key" default` / `config '.some.key' default`
-_CONFIG_CALL = re.compile(r"""config\s+["']\.([A-Za-z0-9_.]+)["']""")
+# `config ".some.key" default` / `config '.some.key' default`, and its
+# fork-free sibling `config_into VARNAME ".some.key" default` (#665, part of
+# #660) -- same key position, one extra token (the destination variable)
+# ahead of it.
+_CONFIG_CALL = re.compile(r"""config(?:_into\s+\S+)?\s+["']\.([A-Za-z0-9_.]+)["']""")
 
 # Rows of the config table: | `key` | default | description |
 _README_ROW = re.compile(r"^\|\s*`([a-z][A-Za-z0-9_.]*)`\s*\|")

--- a/tests/test_delivery_record_pruning_373.py
+++ b/tests/test_delivery_record_pruning_373.py
@@ -529,14 +529,21 @@ class TestStaleDeliveryRecordsPruningGlobBackslash517:
 
     _BLOCK = extract_lines_517(
         "scripts/session-start-hook.sh",
-        "_remember_delivered_glob_dir=$(_remember_forward_slash",
+        '_remember_delivered_glob_dir=""',
         "    done",
     )
 
     def _run(self, remember_dir: str, sessions_dir, current_session_id: str, ostype: str):
         import shlex
-        forward_slash_fn = extract_function_517(
-            "scripts/resolve-paths.sh", "_remember_forward_slash"
+        # #665 (part of #660): the site now calls _remember_forward_slash_into
+        # (printf -v, no command-substitution subshell) instead of capturing
+        # $(_remember_forward_slash ...) -- both functions live in
+        # resolve-paths.sh and the extracted block needs the one it actually
+        # calls in scope.
+        forward_slash_fn = (
+            extract_function_517("scripts/resolve-paths.sh", "_remember_forward_slash")
+            + "\n"
+            + extract_function_517("scripts/resolve-paths.sh", "_remember_forward_slash_into")
         )
         setup = (
             forward_slash_fn

--- a/tests/test_delivery_record_pruning_373.py
+++ b/tests/test_delivery_record_pruning_373.py
@@ -548,6 +548,11 @@ class TestStaleDeliveryRecordsPruningGlobBackslash517:
         setup = (
             forward_slash_fn
             + "\n_remember_date() { date \"$@\"; }"
+            # #665 (part of #660): the stale-mtime-age check now calls
+            # _remember_date_into (already existed, lib-clock.sh #511)
+            # directly instead of $(_remember_date ...) -- the extracted
+            # block calls it, so the stub needs it too.
+            + "\n_remember_date_into() { local _v=\"$1\"; shift; printf -v \"$_v\" '%s' \"$(_remember_date \"$@\")\"; }"
             + "\nGRACE_MIN=5"
             + f"\nCURRENT_SESSION_ID={shlex.quote(current_session_id)}"
             + f"\nSESSIONS_DIR={shlex.quote(str(sessions_dir))}"

--- a/tests/test_session_start_fork_tax_665.py
+++ b/tests/test_session_start_fork_tax_665.py
@@ -68,7 +68,45 @@ LOG_SH = REPO_ROOT / "scripts" / "log.sh"
 LIB_SLUG = REPO_ROOT / "scripts" / "lib-slug.sh"
 
 BASH = resolve_bash()
-pytestmark = pytest.mark.skipif(BASH is None, reason="no usable bash found")
+
+
+def _bash_has_bashpid(bash: str | None) -> bool:
+    """$BASHPID (bash >= 4.0) is what this whole file's fork counter relies
+    on -- each real fork() gets a brand-new pid, unlike `$BASH_SUBSHELL`
+    (nesting depth, undercounts sibling forks) or `$$` (bash's own docs: `$$`
+    is NOT reset in a subshell, so every sibling would report the SAME
+    "process"). Stock macOS ships bash 3.2 as `/bin/bash`
+    (tests/test_lock_primitive.py's own `test_self_id_differs_between_sibling_subshells`
+    documents the identical gap for lib-lock.sh's self-id, and lib-lock.sh's
+    `_lock_self_set` falls back to `sh -c 'echo $PPID'` for exactly this
+    reason) -- whether THIS host's `bash` (found by `resolve_bash()`, which
+    trusts whatever is on PATH, not necessarily `/bin/bash`) is old enough to
+    lack it is a real, host-dependent question, not a hypothetical one.
+    Checked directly rather than assumed, so a host where `bash` happens to
+    resolve to the pre-4.0 floor skips loudly instead of failing every test
+    in this file on "harness produced no trace lines at all" -- a skip this
+    file's own coverage note (below) names, not a silent pass.
+    """
+    if bash is None:
+        return False
+    result = subprocess.run(
+        [bash, "-c", "echo ${BASHPID:-}"],
+        capture_output=True, text=True, timeout=10, check=False,
+    )
+    return result.returncode == 0 and result.stdout.strip().isdigit()
+
+
+_HAS_BASHPID = _bash_has_bashpid(BASH)
+pytestmark = pytest.mark.skipif(
+    BASH is None or not _HAS_BASHPID,
+    reason=(
+        "no usable bash found" if BASH is None else
+        "this host's `bash` lacks $BASHPID (pre-4.0, e.g. stock macOS "
+        "/bin/bash 3.2) -- this whole file's fork counter depends on it "
+        "(see _bash_has_bashpid's docstring); untested on that floor rather "
+        "than reporting a false pass or a spurious 'broken probe' failure"
+    ),
+)
 
 START = "===FORKPROBE-START==="
 END = "===FORKPROBE-END==="

--- a/tests/test_session_start_fork_tax_665.py
+++ b/tests/test_session_start_fork_tax_665.py
@@ -1,0 +1,343 @@
+"""#665 (part of #660): a `$( )` command substitution around a builtin still
+forks a subshell to capture the output, even though nothing inside it execs
+an external process. `tests/spawn_counting.py` counts execs, not forks -- a
+`$(printf ...)` or `$(config ...)` on the flattened-cache-hit path shows up
+there as zero spawns even though bash still pays a fork for the substitution
+itself. This file counts THAT fork directly, with `bash -x` and a `PS4` that
+carries `$BASHPID`: every real fork() gets bash a brand-new pid, so the
+number of DISTINCT pids seen in a trace (other than the "home" pid the probe
+started at) is the number of forks, regardless of how many statements ran
+inside any one of them or whether two forks happened to sit at the same
+nesting depth as siblings.
+
+(`$BASH_SUBSHELL` -- the more obvious probe variable -- was tried first and
+rejected: it reports NESTING DEPTH, not fork count, so N sibling `$(printf
+...)` substitutions at the same depth, run back to back with no trace line
+ever falling back to depth 0 between them, undercounts to "however many
+depth increases occurred" rather than N. Measured directly against the pre-
+#665 slug-sed builder below: the depth-transition count came back 2 for a
+builder that pays 22 real forks. `$BASHPID` does not have this failure mode
+because two sibling subshells are still two distinct child processes.)
+
+Every "must not fork" assertion here is paired with a "must fork" positive
+control using the SAME harness and (where possible) the SAME call shape,
+still written as `$(...)` -- so a broken harness that sees no forks anywhere
+cannot pass silently (the negative-assertion-needs-a-positive-control rule
+this repo's CLAUDE.md states directly).
+
+Two closely-read positive controls matter more than they look:
+
+* `config()`'s own pre-existing `( LC_ALL=C; [[ ... ]] )` key-shape guard is
+  ALREADY a subshell, deliberately (its own comment in log.sh explains why:
+  scoping the locale override to one match). That fork is NOT what #665
+  removes and this file does not claim otherwise -- `config_into()` still
+  pays it. What #665 removes is the OUTER command-substitution fork
+  `$(config ...)` adds on top of that -- so the pinned claim is "config_into
+  forks exactly one FEWER time than `$(config ...)` does", not "config_into
+  forks zero times".
+
+* `log()`'s message control-byte scrub (`$(printf ... | LC_ALL=C tr ...)`)
+  is deliberately NOT touched here. #621 tried twice to remove it (a bracket
+  class, then a byte-range check) and both went red on live CI in ways this
+  repo could not reproduce locally, so #621 was closed as not worth the
+  fragility and log() forks this unconditionally, same as before #621. The
+  timestamp fork (`$(_remember_date ...)`) is a different site and IS
+  removed -- `log()`'s total fork count drops from 2 to 1, not to 0.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(__file__))
+from _bash_runner import resolve_bash
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RESOLVE_PATHS = REPO_ROOT / "scripts" / "resolve-paths.sh"
+DETECT_TOOLS = REPO_ROOT / "scripts" / "detect-tools.sh"
+BOOTSTRAP_DIRS = REPO_ROOT / "scripts" / "bootstrap-dirs.sh"
+LOG_SH = REPO_ROOT / "scripts" / "log.sh"
+LIB_SLUG = REPO_ROOT / "scripts" / "lib-slug.sh"
+
+BASH = resolve_bash()
+pytestmark = pytest.mark.skipif(BASH is None, reason="no usable bash found")
+
+START = "===FORKPROBE-START==="
+END = "===FORKPROBE-END==="
+PID_RE = re.compile(r"PID=(\d+)")
+
+
+def _project(tmp_path: Path):
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    remember = project / ".remember"
+    (remember / "tmp").mkdir(parents=True)
+    (home / ".remember").mkdir(parents=True)
+    return home, project, remember
+
+
+def _forks_from_trace(body: str) -> int:
+    """Number of forks in a traced region: distinct $BASHPID values seen,
+    minus one for the "home" pid the anchor (`:`, the first traced line)
+    ran in. Each real fork() gets bash a brand-new pid, so this counts
+    forks regardless of nesting depth or how many statements shared one."""
+    pids = PID_RE.findall(body)
+    assert pids, f"harness produced no trace lines at all -- broken probe: {body!r}"
+    return len(set(pids)) - 1
+
+
+def _count_forks(tmp_path: Path, home: Path, project: Path, probe: str) -> int:
+    """Run `probe` after sourcing the real pipeline files in a cache-warm
+    state, tracing ONLY the probe itself (plus one anchor command `:`
+    immediately before it, whose pid is the "home" pid), and return how
+    many forks the probe made.
+
+    Sourcing the pipeline files themselves does its own forking (jq, stat,
+    etc.) that has nothing to do with what the probe is being asked to
+    prove, hence tracing only opens around the probe.
+    """
+    script = f"""
+set -eu
+REMEMBER_PATHS_SOFT_FAIL=1 source "{RESOLVE_PATHS.as_posix()}" || exit 99
+PLUGIN_ROOT="$PIPELINE_DIR"
+source "{DETECT_TOOLS.as_posix()}" || exit 99
+source "{BOOTSTRAP_DIRS.as_posix()}" || exit 99
+source "{LOG_SH.as_posix()}" 2>/dev/null
+# Warm the flattened-cache table once, outside the traced region.
+config '.warm.me' 'x' >/dev/null
+exec 2>&1
+echo "{START}"
+PS4='+PID=${{BASHPID}} '
+set -x
+:
+{probe}
+set +x
+echo "{END}"
+"""
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "CLAUDE_PROJECT_DIR": str(project),
+        "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
+        "REMEMBER_HOOK_CWD": str(project),
+        "PATH": os.environ["PATH"],
+    }
+    result = subprocess.run(
+        [BASH, "-c", script], env=env, capture_output=True, text=True,
+        errors="replace", timeout=30, check=False,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    out = result.stdout
+    assert START in out and END in out, f"probe markers missing: {out!r}"
+    body = out.split(START, 1)[1].split(END, 1)[0]
+    return _forks_from_trace(body)
+
+
+def _warm_config(tmp_path: Path, home: Path, project: Path, remember: Path):
+    cfg = remember / "config.json"
+    cfg.write_text(json.dumps({"cooldowns": {"save_seconds": 42}}), encoding="utf-8")
+    script = f"""
+set -eu
+REMEMBER_PATHS_SOFT_FAIL=1 source "{RESOLVE_PATHS.as_posix()}" || exit 99
+PLUGIN_ROOT="$PIPELINE_DIR"
+source "{DETECT_TOOLS.as_posix()}" || exit 99
+source "{BOOTSTRAP_DIRS.as_posix()}" || exit 99
+source "{LOG_SH.as_posix()}" 2>/dev/null
+config '.cooldowns.save_seconds' '0'
+"""
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "CLAUDE_PROJECT_DIR": str(project),
+        "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
+        "REMEMBER_HOOK_CWD": str(project),
+        "PATH": os.environ["PATH"],
+    }
+    result = subprocess.run([BASH, "-c", script], env=env, capture_output=True, text=True, timeout=30, check=False)
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    cache = remember / "tmp" / "config.rcfg"
+    assert cache.is_file()
+    now = time.time()
+    os.utime(cache, (now + 5, now + 5))
+
+
+# ---------------------------------------------------------------------------
+# config_into: removes exactly the outer command-substitution fork on top of
+# the pre-existing (deliberate) LC_ALL guard subshell -- not "zero forks".
+# ---------------------------------------------------------------------------
+
+def test_config_into_forks_only_the_preexisting_lc_all_guard(tmp_path):
+    home, project, remember = _project(tmp_path)
+    _warm_config(tmp_path, home, project, remember)
+    n = _count_forks(
+        tmp_path, home, project,
+        'config_into RESULT ".cooldowns.save_seconds" "0"; echo "got=$RESULT"',
+    )
+    assert n == 1, (
+        "config_into should fork exactly once -- the pre-existing "
+        "( LC_ALL=C; [[ ... ]] ) key-shape guard, which #665 does not "
+        f"touch -- got {n}"
+    )
+
+
+def test_command_substitution_around_config_forks_one_more_than_config_into(tmp_path):
+    """Positive control, same harness, same cache-hit state, same call: the
+    OLD `$(config ...)` idiom pays the guard fork PLUS its own outer
+    command-substitution fork -- proving the probe can see the extra fork
+    #665 removes, and that config_into's count above is not simply the
+    harness reporting nothing."""
+    home, project, remember = _project(tmp_path)
+    _warm_config(tmp_path, home, project, remember)
+    n_sub = _count_forks(
+        tmp_path, home, project,
+        'RESULT=$(config ".cooldowns.save_seconds" "0"); echo "got=$RESULT"',
+    )
+    n_into = _count_forks(
+        tmp_path, home, project,
+        'config_into RESULT ".cooldowns.save_seconds" "0"; echo "got=$RESULT"',
+    )
+    assert n_sub == 2, f"positive control failed -- expected 2 forks from $(config ...), got {n_sub}"
+    assert n_sub == n_into + 1, (
+        f"$(config ...) should fork exactly ONE more time than config_into "
+        f"(the outer capture subshell) -- got n_sub={n_sub}, n_into={n_into}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# log(): the timestamp fork is removed (_remember_date_into), the message
+# control-byte scrub fork is deliberately NOT (#621's history) -- net one
+# fork remains, down from two.
+# ---------------------------------------------------------------------------
+
+def test_log_forks_once_for_the_deliberately_kept_message_scrub(tmp_path):
+    home, project, remember = _project(tmp_path)
+    _warm_config(tmp_path, home, project, remember)
+    n = _count_forks(tmp_path, home, project, 'log "probe" "hello"')
+    assert n == 2, (
+        "log() should fork exactly twice now -- printf and tr, the two "
+        "halves of the message control-byte scrub pipeline (kept "
+        "deliberately, #621) -- the timestamp fork must be gone (it alone "
+        f"was a third). got {n}"
+    )
+
+
+def test_command_substitution_around_remember_date_still_forks(tmp_path):
+    home, project, remember = _project(tmp_path)
+    _warm_config(tmp_path, home, project, remember)
+    n = _count_forks(
+        tmp_path, home, project,
+        'RESULT=$(_remember_date +%H:%M:%S); echo "got=$RESULT"',
+    )
+    assert n == 1, f"positive control failed -- expected 1 fork for $(_remember_date ...), got {n}"
+
+
+def test_remember_date_into_forks_nothing_on_the_builtin_path(tmp_path):
+    """log() itself now calls this directly -- confirm it, in isolation,
+    forks nothing on this host (bash >= 4.2, no REMEMBER_TZ), which is what
+    makes the log() assertion above land on 1 instead of 2."""
+    home, project, remember = _project(tmp_path)
+    _warm_config(tmp_path, home, project, remember)
+    n = _count_forks(tmp_path, home, project, '_remember_date_into RESULT +%H:%M:%S')
+    assert n == 0, f"_remember_date_into must not fork on the builtin path, got {n}"
+
+
+# ---------------------------------------------------------------------------
+# _remember_build_slug_sed: ANSI-C ($'\\NNN') quoting instead of 22
+# $(printf ...) forks, byte-identical output.
+# ---------------------------------------------------------------------------
+
+def _count_forks_bare(probe: str) -> int:
+    script = f"""
+set -eu
+exec 2>&1
+echo "{START}"
+PS4='+PID=${{BASHPID}} '
+set -x
+:
+{probe}
+set +x
+echo "{END}"
+"""
+    result = subprocess.run(
+        [BASH, "-c", script], capture_output=True, text=True,
+        errors="replace", timeout=30, check=False,
+    )
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    out = result.stdout
+    body = out.split(START, 1)[1].split(END, 1)[0]
+    return _forks_from_trace(body)
+
+
+def _slug_sed_program(tmp_path: Path) -> list[str]:
+    script = f"""
+set -eu
+source "{LIB_SLUG.as_posix()}"
+printf '%s\\0' "${{_REMEMBER_SLUG_SED[@]}}"
+"""
+    result = subprocess.run([BASH, "-c", script], capture_output=True, timeout=30, check=False)
+    assert result.returncode == 0, result.stderr
+    parts = result.stdout.split(b"\0")
+    if parts and parts[-1] == b"":
+        parts = parts[:-1]
+    return [p.decode("latin-1") for p in parts]
+
+
+def test_slug_sed_program_forks_nothing_to_build():
+    n = _count_forks_bare(f'source "{LIB_SLUG.as_posix()}"; _remember_build_slug_sed')
+    assert n == 0, "_remember_build_slug_sed must not fork any subshell (ANSI-C quoting, not $(printf))"
+
+
+_OLD_SLUG_BUILDER = r"""
+_remember_build_slug_sed_OLD() {
+    local cont
+    cont="$(printf '\200')-$(printf '\277')"
+    REFERENCE_SLUG_SED=(
+        -e "s/$(printf '\360')[$(printf '\220')-$(printf '\277')][$cont][$cont]/--/g"
+        -e "s/[$(printf '\361')-$(printf '\363')][$cont][$cont][$cont]/--/g"
+        -e "s/$(printf '\364')[$(printf '\200')-$(printf '\217')][$cont][$cont]/--/g"
+        -e "s/$(printf '\340')[$(printf '\240')-$(printf '\277')][$cont]/-/g"
+        -e "s/[$(printf '\341')-$(printf '\354')][$cont][$cont]/-/g"
+        -e "s/$(printf '\355')[$(printf '\200')-$(printf '\237')][$cont]/-/g"
+        -e "s/[$(printf '\356')-$(printf '\357')][$cont][$cont]/-/g"
+        -e "s/[$(printf '\302')-$(printf '\337')][$cont]/-/g"
+        -e 's/[^a-zA-Z0-9]/-/g'
+    )
+}
+"""
+
+
+def test_old_printf_slug_builder_forks_22_times():
+    """Positive control for the byte-compare test below: the OLD builder
+    really does pay 22 subshell forks (one per `$(printf ...)`), so the
+    harness proves it can see them before the new version claims zero."""
+    n = _count_forks_bare(_OLD_SLUG_BUILDER + "\n_remember_build_slug_sed_OLD")
+    assert n == 22, f"positive control failed -- expected 22 $(printf) forks, harness saw {n}"
+
+
+def test_slug_sed_program_is_byte_identical_to_the_old_printf_builder(tmp_path):
+    """Byte-compare the new ANSI-C-quoted builder against the pre-#665 one
+    (the `$(printf ...)` shape, restored here verbatim as the reference),
+    so the fork removal cannot silently change what gets matched."""
+    script = f"""
+set -eu
+{_OLD_SLUG_BUILDER}
+_remember_build_slug_sed_OLD
+printf '%s\\0' "${{REFERENCE_SLUG_SED[@]}}"
+"""
+    result = subprocess.run([BASH, "-c", script], capture_output=True, timeout=30, check=False)
+    assert result.returncode == 0, result.stderr
+    parts = result.stdout.split(b"\0")
+    if parts and parts[-1] == b"":
+        parts = parts[:-1]
+    reference = [p.decode("latin-1") for p in parts]
+
+    actual = _slug_sed_program(tmp_path)
+    assert actual == reference, "new sed program bytes differ from the old $(printf ...) builder"

--- a/tests/test_session_start_promo_spawn_budget_660.py
+++ b/tests/test_session_start_promo_spawn_budget_660.py
@@ -305,10 +305,16 @@ def test_memory_injection_spawn_budget(tmp_path):
     # REMEMBER_DIR this test just populated. The render only ever calls
     # config() for one threshold, so a stub is both simpler and avoids that
     # whole unrelated resolution chain.
+    # #665 (part of #660): lib-memory-context.sh now calls config_into and
+    # _remember_forward_slash_into (printf -v, no command-substitution
+    # subshell) instead of capturing $(config ...) / $(_remember_forward_slash
+    # ...) -- both stubs need their `_into` sibling too.
     script = f"""
     set -e
     config() {{ printf '%s' "$2"; }}
+    config_into() {{ printf -v "$1" '%s' "$3"; }}
     _remember_forward_slash() {{ printf '%s' "$1"; }}
+    _remember_forward_slash_into() {{ printf -v "$1" '%s' "$2"; }}
     source "{REPO_ROOT}/scripts/lib-clock.sh"
     source "{REPO_ROOT}/scripts/lib-memory-context.sh"
     _remember_memory_paths

--- a/tests/test_shared_rules.py
+++ b/tests/test_shared_rules.py
@@ -220,7 +220,12 @@ def test_the_shipped_delta_default_matches_the_example_config():
     and it arrived with the fix.
     """
     log_sh = (REPO_ROOT / "scripts" / "log.sh").read_text(encoding="utf-8")
-    m = re.search(r'config\s+"\.thresholds\.delta_lines_trigger"\s+(\d+)', log_sh)
+    # #665 (part of #660): the read is now `config_into VAR ".key" default`
+    # (printf -v, no command-substitution subshell), one extra token -- the
+    # destination variable -- ahead of the key this test checks.
+    m = re.search(
+        r'config(?:_into\s+\S+)?\s+"\.thresholds\.delta_lines_trigger"\s+(\d+)', log_sh
+    )
     assert m, "the delta_lines_trigger fallback moved or changed shape"
     hook = (REPO_ROOT / "scripts" / "post-tool-hook.sh").read_text(encoding="utf-8")
     replay = re.search(r'DELTA_THRESHOLD="\$\{REMEMBER_DELTA_THRESHOLD:-(\d+)\}"', hook)

--- a/tests/test_windows_glob_backslash_517.py
+++ b/tests/test_windows_glob_backslash_517.py
@@ -50,6 +50,13 @@ _FORWARD_SLASH_FN = extract_function(
     "scripts/resolve-paths.sh", "_remember_forward_slash"
 )
 
+# #665 (part of #660): sites 2 and 3 below now call _remember_forward_slash_into
+# (printf -v, no command-substitution subshell) instead of capturing
+# $(_remember_forward_slash ...) -- their extracted blocks need it in scope.
+_FORWARD_SLASH_INTO_FN = _FORWARD_SLASH_FN + "\n" + extract_function(
+    "scripts/resolve-paths.sh", "_remember_forward_slash_into"
+)
+
 
 class TestForwardSlashHelper:
     """The shared mechanism every site below relies on -- tested once here
@@ -139,14 +146,14 @@ class TestSessionStartStagingCount:
 
     _BLOCK = extract_lines(
         "scripts/session-start-hook.sh",
-        "_remember_staging_glob_dir=$(_remember_forward_slash",
+        '_remember_staging_glob_dir=""',
         'unset _remember_staging_candidates _remember_staging_was_nullglob _remember_staging_file',
     )
 
     def _run(self, remember_dir, ostype):
         import shlex
         setup = (
-            _FORWARD_SLASH_FN
+            _FORWARD_SLASH_INTO_FN
             + f"\nREMEMBER_DIR={shlex.quote(remember_dir)}"
             + '\nTODAY="2099-01-01"'
         )
@@ -192,14 +199,14 @@ class TestSessionStartRotatedSlices:
     # itself did not change, only its home file.
     _BLOCK = extract_lines(
         "scripts/lib-memory-context.sh",
-        "_remember_rotated_glob_dir=$(_remember_forward_slash",
+        '_remember_forward_slash_into _remember_rotated_glob_dir',
         '[ -n "$ROTATED_SLICES" ] && HAS_MEMORY="true"',
     )
     _AFTER = 'if [ -n "$ROTATED_SLICES" ]; then printf HAS; else printf NONE; fi'
 
     def _run(self, remember_dir, ostype):
         import shlex
-        setup = _FORWARD_SLASH_FN + f"\nREMEMBER_DIR={shlex.quote(remember_dir)}"
+        setup = _FORWARD_SLASH_INTO_FN + f"\nREMEMBER_DIR={shlex.quote(remember_dir)}"
         return run_block(self._BLOCK, ostype=ostype, setup=setup, after=self._AFTER)
 
     def test_must_fire_rotated_slices_are_seen_under_backslash_remember_dir(self, tmp_path):


### PR DESCRIPTION
Closes #665. Part of #660.

## What

`$( )` forks a subshell to capture output even when the wrapped command execs nothing external -- invisible to `tests/spawn_counting.py`, which counts execs. This removes that class of fork from SessionStart's hot path:

- `config()` (log.sh) is now a thin wrapper over a new `config_into VARNAME key default` (printf -v, no subshell), used at every flattened-cache config read on the SessionStart/per-tool-call paths -- `.features.*`, `.handoff_mode`, `.cooldowns.*`, `.timezone`, `.prompt_stamp`, `.model`, `.reject_pattern`, `.thresholds.*`.
- `log()`'s and `MEMORY_LOG_DATE`'s timestamps now call the existing `_remember_date_into` (lib-clock.sh, #511) directly instead of `$(_remember_date ...)`.
- New `_remember_forward_slash_into` and `_stdin_json_string_into` siblings, wired into every session-start-hook.sh / lib-memory-context.sh call site.
- `lib-slug.sh`'s `_remember_build_slug_sed` -- 22 `$(printf '\NNN')` calls building the slug's byte-range sed program, run once per hook invocation -- now uses bash's own ANSI-C (`$'\NNN'`) octal quoting: a lexer-level substitution, no fork at all. Proved byte-identical to the old builder by a dedicated test, and independently re-verified by a review round that ran both builders and diffed their output directly.

## Deliberately unchanged

- `log()`'s message control-byte scrub (`printf | tr`, #618/#621): #621 already tried twice to remove this fork and both attempts failed unreproducibly on live CI (bracket-class version missed control bytes on windows-latest while green on macOS 3.2; byte-range version then failed on macos-latest while green everywhere else, including a fresh bash 5). #621 was closed as not worth the fragility. Reopening it was out of scope here.
- The `.hooks.dispatch_*` config reads inside `_remember_run_hooks` (log.sh): left alone to avoid colliding with a parallel lane (fix/663) that will touch that same region.
- `doctor.sh`, `lib-case-divergence.sh`, `run-consolidation.sh`: not on the SessionStart hot path.

## Testing

TDD: `tests/test_session_start_fork_tax_665.py` is new, using a `$BASHPID`-based fork counter (each real `fork()` gets bash a brand-new pid, unlike `$BASH_SUBSHELL` -- nesting depth, verified to undercount 22 real sibling forks as 2 -- or `$$`, which bash does not reset in a subshell). Red before the fix existed (`config_into`/`_stdin_json_string_into` not defined -- `command not found`; `log()` still forking 12+ times; the slug builder still forking 44 times, since it's called twice per test setup). Green after. The file skips itself loudly, naming the mechanism, on a host whose resolved `bash` lacks `$BASHPID` (pre-4.0, e.g. stock macOS `/bin/bash` 3.2) rather than reporting a false "broken probe" failure.

Several existing tests needed updates because they extract or byte-pin literal source text, or stub bash functions, whose shape changed: `tests/test_case_divergence_298.py` (new sanctioned-divergence entry for the byte-identical slug-sed rewrite, verified against the live file), `tests/test_config_contract.py` and `tests/test_shared_rules.py` (their `config()`-call regex now also matches `config_into`), `tests/test_delivery_record_pruning_373.py` and `tests/test_windows_glob_backslash_517.py` (extraction markers/stubs updated for the `_into` call shape), `tests/test_session_start_promo_spawn_budget_660.py` (stub harness needed `config_into`/`_remember_forward_slash_into` stubs).

Full `pytest` run four times across this branch (once per commit that could plausibly regress something, since the review rounds kept widening which files the scope touched): 2386 passed, 47 skipped, every time. This is reported honestly rather than credited toward the PR closing -- CI's 13-leg matrix is the actual gate.

Two self-review rounds (Explore + oss:auditor, then a re-spawned oss:auditor against the accumulated diff) found and this branch fixed: a variable-name-collision risk in the new `_into` helpers' internal locals (narrowed, not fully closed -- bash 3.2 has no nameref); four missed `$(_remember_date ...)` call sites, including one on the unconditional hot path (`TODAY=...`) and one at the top level of log.sh (`MEMORY_LOG_DATE=...`, found by the second round after the first round's fixes); a stale, now-duplicated comment inside `config()`; and a version probe (`_bash_has_bashpid`) added to the new test file after the auditor flagged that `$BASHPID` availability on CI's `macos-latest` leg could not be verified from this repo. Below-bar note: whether that skip-gate's pre-4.0 branch is ever actually exercised by a real CI runner remains **could not check: CI coverage** -- the gate itself is correct either way, and this is recorded as an open question rather than a defect.

## Docs

`changelog.d/665.changed.md` added. No `docs_targets` (README.md) update -- read against the SessionStart section, nothing there describes internal fork counts or config() implementation, and config()'s external contract (key/default) is unchanged.


[AI-generated]