### PR TITLE
Fix NUL-interleaved UTF-16LE bash probe output by using resolve_bash() and defensive decode

### DIFF
--- a/changelog.d/672.fixed.md
+++ b/changelog.d/672.fixed.md
@@ -1,0 +1,1 @@
+- Fixed the Windows Git-Bash benchmark's hook-dir probe: it invoked the literal `bash` (which resolves to the WSL launcher and emits UTF-16LE/NUL-interleaved output, exit 127 on a missing distribution) instead of `resolve_bash()`'s Git Bash, and its output decoding is now UTF-16LE-aware (#672).

--- a/tests/_bash_runner.py
+++ b/tests/_bash_runner.py
@@ -62,3 +62,28 @@ def resolve_bash() -> str | None:
     if sys.platform != "win32":
         return shutil.which("bash")
     return find_git_bash()
+
+
+def decode_bash_output(raw: bytes) -> str:
+    """Decode a bash subprocess byte stream defensively (#672).
+
+    On Windows, invoking the literal ``"bash"`` can resolve to the WSL
+    launcher or a WindowsApps alias stub instead of Git Bash. Those
+    launchers write UTF-16LE-framed text to a redirected pipe -- each
+    ASCII byte followed by a NUL -- which a locale/UTF-8 decode turns into
+    NUL-interleaved garbage, or raises outright on a UTF-8 locale. Detect
+    a UTF-16LE frame by its NUL density and decode it as UTF-16LE;
+    otherwise fall back to UTF-8 with replacement, the same policy
+    ``subprocess`` itself uses for undecodable bytes when ``text=True``.
+    """
+    if not raw:
+        return ""
+    if raw.count(b"\x00") >= len(raw) // 4:
+        try:
+            decoded = raw.decode("utf-16-le")
+        except UnicodeDecodeError:
+            pass
+        else:
+            if "\x00" not in decoded:
+                return decoded
+    return raw.decode("utf-8", errors="replace")

--- a/tests/test_decode_bash_output_672.py
+++ b/tests/test_decode_bash_output_672.py
@@ -1,0 +1,41 @@
+"""Unit tests for decode_bash_output() (#672).
+
+decode_bash_output lives in tests/_bash_runner.py next to resolve_bash(),
+the helper that locates a real POSIX bash. These tests are pure-bytes and
+run on every platform -- no bash required -- so the UTF-16LE decode path
+is exercised deterministically even on machines (and CI legs) where the
+exact WSL-launcher corruption does not reproduce.
+"""
+
+from __future__ import annotations
+
+from ._bash_runner import decode_bash_output
+
+
+def test_utf16le_interleaved_blob_decodes_to_readable_text():
+    """Positive control: a UTF-16LE-framed blob -- the shape the WSL
+    launcher or a WindowsApps alias stub writes to a redirected pipe --
+    must come back as readable text, not NUL-interleaved garbage."""
+    raw = "HOOK_DIR=/some/plugin/root/scripts\n".encode("utf-16-le")
+    assert b"\x00" in raw  # the corruption signature is actually present
+    assert decode_bash_output(raw) == "HOOK_DIR=/some/plugin/root/scripts\n"
+
+
+def test_plain_utf8_output_is_returned_unchanged():
+    """Negative control: ordinary UTF-8 output (what Git Bash writes) must
+    pass through untouched -- the decoder must not mangle what is fine."""
+    raw = "HOOK_DIR=/some/plugin/root/scripts\n".encode("utf-8")
+    assert b"\x00" not in raw
+    assert decode_bash_output(raw) == "HOOK_DIR=/some/plugin/root/scripts\n"
+
+
+def test_empty_stream_returns_empty_string():
+    assert decode_bash_output(b"") == ""
+
+
+def test_undecodable_bytes_fall_back_without_raising():
+    """A blob that is neither clean UTF-8 nor a usable UTF-16LE frame must
+    still return a str (with replacement characters), never raise."""
+    raw = b"\xff\xfe\x00\x00garbage\x80\x81"
+    out = decode_bash_output(raw)
+    assert isinstance(out, str)

--- a/tests/test_session_start_windows_benchmark_669.py
+++ b/tests/test_session_start_windows_benchmark_669.py
@@ -109,7 +109,7 @@ SESSION_START = REPO_ROOT / "scripts" / "session-start-hook.sh"
 sys.path.insert(0, str(REPO_ROOT))
 from pipeline.slug import session_dir_slug as _slug
 
-from ._bash_runner import resolve_bash
+from ._bash_runner import decode_bash_output, resolve_bash
 from .spawn_counting import make_shim_dir, spawns
 
 # #432's own narrowing, not a platform skip: the windows-latest leg genuinely
@@ -561,19 +561,11 @@ def _extract_hook_dir_lines() -> str:
     )
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="PR #671: a bash subprocess probe's own stdout/returncode arrives "
-    "NUL-interleaved (UTF-16LE) on windows-latest, reproduced identically "
-    "across every call in this function -- including the FIRST, plain "
-    "forward-slash case, not only the backslash one -- and across two "
-    "structurally different invocation shapes (round 5's inline `bash -c`, "
-    "round 7's plain script-path via .as_posix()). Root cause not yet "
-    "identified; this is an environment-level corruption, not a defect in "
-    "the %/* mechanism this test pins or in _run_once's own .as_posix() fix "
-    "(which is independently exercised and green via the benchmark tests "
-    "in this file, on every Windows leg). Tracked in #672.",
-)
+# #672: this test was skipped on win32 while a bare ``"bash"`` probe resolved
+# to the WSL launcher and its UTF-16LE/NUL-interleaved output (exit 127 on a
+# missing distribution) looked environment-level. The probe now invokes
+# ``resolve_bash()``'s Git Bash instead of the literal ``"bash"`` and decodes
+# output UTF-16LE-aware (see decode_bash_output), so the skip is gone.
 def test_hook_dir_derivation_needs_a_forward_slash_path(tmp_path):
     """Round 5 (#669): windows-latest/3.10 CI showed session-start-hook.sh
     failing to source resolve-paths.sh at all ('./resolve-paths.sh: No such
@@ -644,11 +636,11 @@ def test_hook_dir_derivation_needs_a_forward_slash_path(tmp_path):
     def _probe(fake_source: str) -> str:
         env = {**os.environ, "FAKE_SOURCE_ENV": fake_source}
         result = subprocess.run(
-            ["bash", probe_script.as_posix()],
-            env=env, capture_output=True, text=True, timeout=10, check=False,
+            [BASH, probe_script.as_posix()],
+            env=env, capture_output=True, timeout=10, check=False,
         )
-        assert result.returncode == 0, result.stderr
-        return result.stdout.strip()
+        assert result.returncode == 0, decode_bash_output(result.stderr or b"")
+        return decode_bash_output(result.stdout or b"").strip()
 
     posix = _probe("/some/plugin/root/scripts/session-start-hook.sh")
     assert posix == "HOOK_DIR=/some/plugin/root/scripts", (
@@ -684,13 +676,16 @@ def test_hook_dir_derivation_needs_a_forward_slash_path(tmp_path):
         encoding="utf-8",
     )
     real_result = subprocess.run(
-        ["bash", real_probe_script.as_posix()],
-        capture_output=True, text=True, timeout=10, check=False,
+        [BASH, real_probe_script.as_posix()],
+        capture_output=True, timeout=10, check=False,
     )
-    assert real_result.returncode == 0, real_result.stderr
-    assert real_result.stdout.strip() == f"HOOK_DIR={real_probe_script.parent.as_posix()}", (
+    assert real_result.returncode == 0, decode_bash_output(real_result.stderr or b"")
+    assert decode_bash_output(real_result.stdout or b"").strip() == (
+        f"HOOK_DIR={real_probe_script.parent.as_posix()}"
+    ), (
         f"invoking with .as_posix() (what _run_once now does) must resolve "
-        f"_HOOK_DIR to the script's real parent directory: {real_result.stdout!r}"
+        f"_HOOK_DIR to the script's real parent directory: "
+        f"{decode_bash_output(real_result.stdout or b'')!r}"
     )
 
 


### PR DESCRIPTION
Closes #672

## Problem
`test_hook_dir_derivation_needs_a_forward_slash_path` (tests/test_session_start_windows_benchmark_669.py:577) failed on every `windows-latest` CI leg: the probe invoked the literal `"bash"`, which on Windows resolves to the WSL launcher (or a WindowsApps alias stub) instead of Git Bash. Those launchers write UTF-16LE-framed text to a redirected pipe (each ASCII byte followed by a NUL), which locale decoding turns into NUL-interleaved garbage — the `...stro>' to install.` byte pattern in the issue's job log is the WSL launcher's missing-distribution message.

## Root cause (reproduced on a Windows host)
`where bash` → `C:\WINDOWS\system32\bash.EXE` (WSL launcher). Its redirected stderr is UTF-16LE, and Windows paths (`C:/...`) are unresolvable inside WSL (rc=127, "No such file or directory"). With `text=True` on a UTF-8 locale the decode raises outright; on CI's locale it silently produced NUL-interleaved text. The test's own `_probe` bypassed `resolve_bash()` — the repo's existing Git-Bash locator (#432) that every other Windows test in this repo uses.

## Fix
- The probe now invokes `resolve_bash()`'s Git Bash instead of the literal `"bash"`, so the WSL launcher is never reached.
- Output is captured as raw bytes and decoded via the new `decode_bash_output()` helper, which detects a UTF-16LE frame by NUL density and falls back to UTF-8-with-replacement.
- The `skipif(sys.platform == "win32")` guard referencing #672 is removed — the harness defect is fixed, not worked around.

## Changes
- `tests/_bash_runner.py`: add `decode_bash_output(raw: bytes) -> str`
- `tests/test_session_start_windows_benchmark_669.py`: probe + real-probe use `BASH` with defensive decode; #672 skipif removed
- `tests/test_decode_bash_output_672.py`: unit tests (UTF-16LE positive control, UTF-8 passthrough, empty, undecodable fallback)
- `changelog.d/672.fixed.md`: changelog fragment

## Testing
Environment: Windows host (no Git Bash installed; `bash` resolves to the WSL launcher), Python 3.12.6, pytest 9.1.1.

- Baseline: `python -m pytest -o addopts="" -q` → **13 failed, 851 passed, 1578 skipped** (13 pre-existing WSL-bash environment failures in test_shell_parse_gate.py / test_safe_eval_seam.py, unrelated to #672)
- After fix: same command → **13 failed, 855 passed, 1578 skipped** — identical failure set, **zero new failures**, +4 new passing unit tests
- Unit: `python -m pytest tests/test_decode_bash_output_672.py -o addopts="" -q` → **4 passed**
- `python -m py_compile` on all three touched modules → clean

Note: `windows-latest` CI ships Git for Windows, so `resolve_bash()` returns a real Git Bash there and this test now runs for real; hosts without Git Bash hit the pre-existing module-level "no usable bash" skip (#432). The UTF-16LE decode path is covered deterministically by the unit tests on every platform.