### PR TITLE
docs: privacy policy and terms of service pages

### DIFF
--- a/changelog.d/683.added.md
+++ b/changelog.d/683.added.md
@@ -1,0 +1,1 @@
+- Privacy policy (`docs/privacy.md`) and terms of service (`docs/terms.md`) pages, required by the OpenAI plugin directory submission form (#683).

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,53 @@
+# Privacy Policy — Remember
+
+Last updated: 2026-09-12. Publisher: Digital Process Tools (Florian David).
+
+## What Remember does with data
+
+Remember is a plugin for agent CLIs (Claude Code, Codex, Antigravity). It keeps a
+record of your coding sessions so the next session can continue where the last one
+stopped.
+
+## Data collected
+
+- **Session content.** Remember reads the transcript of your session with the host
+  CLI and writes summaries and handoff notes to files on your machine, under
+  `.remember/` in the project directory or under `~/.remember/`. This content can
+  include anything you typed or the assistant produced during the session.
+- **Nothing else.** Remember collects no account information, no telemetry, no
+  analytics, no device identifiers.
+
+## Where data goes
+
+- All files stay on your machine. Digital Process Tools operates no server and
+  receives no data from Remember.
+- Summaries are produced by calling the host CLI's model (for example `claude -p`).
+  That call is governed by the privacy policy of the model provider you already use
+  (Anthropic, OpenAI, or Google), under your own account. Remember adds no other
+  third party.
+- The skills-only edition published in the OpenAI plugin directory sends nothing
+  anywhere: it only writes a local note file.
+
+## Sharing
+
+Remember shares no data with anyone. Digital Process Tools has no access to your
+files.
+
+## Retention and controls
+
+- Files persist until you delete them. Remove `.remember/` or `~/.remember/` to
+  erase everything Remember has stored.
+- Capture can be disabled or scoped per project through the plugin configuration
+  (see [configuration.md](configuration.md)), or by uninstalling the plugin.
+- Add `.remember/` to `.gitignore` if you do not want notes committed to a
+  repository.
+
+## Children
+
+Remember is a developer tool and is not directed at children under 13.
+
+## Changes and contact
+
+Changes to this policy are recorded in this file's git history. Questions:
+open an issue at https://github.com/Digital-Process-Tools/claude-remember/issues
+or email florian.david.info@gmail.com.

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -1,0 +1,24 @@
+# Terms of Service — Remember
+
+Last updated: 2026-09-12. Publisher: Digital Process Tools (Florian David).
+
+1. **License.** Remember is provided under the Community License in
+   [LICENSE](../LICENSE): free for personal, educational and internal business use;
+   no commercial redistribution; no competing use. Installing or using Remember
+   means you accept that license and these terms.
+2. **No warranty.** Remember is provided "as is", without warranty of any kind.
+   Digital Process Tools does not guarantee that sessions are captured, that notes
+   are accurate, or that the plugin works on any given host or version.
+3. **Your data.** Everything Remember writes stays on your machine and belongs to
+   you. You are responsible for what you store and where you commit it. See the
+   [privacy policy](privacy.md).
+4. **Third-party services.** Summarization calls go through the agent CLI and
+   model provider you already use, under their terms, not ours.
+5. **Limitation of liability.** To the extent permitted by law, Digital Process
+   Tools is not liable for any loss of data, lost work, or other damages arising
+   from use of Remember.
+6. **Changes.** These terms may change; the current version is always this file on
+   the `main` branch, and its history is in git.
+7. **Governing law.** French law. Disputes go to the courts of Toulouse, France.
+8. **Contact.** https://github.com/Digital-Process-Tools/claude-remember/issues or
+   florian.david.info@gmail.com.


### PR DESCRIPTION
The OpenAI plugin directory submission form requires a privacy policy URL and a terms of service URL. Remember has no server and stores everything locally, so both pages are short and link to LICENSE for the license terms.

Docs-only; no code or test change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018fGwQYLcBAf7wUCKJjoXer

[AI-generated]