### PR TITLE
Move the #668 flattened-config cache out of the project tree, validate before evaluating

### DIFF
--- a/changelog.d/682.fixed.md
+++ b/changelog.d/682.fixed.md
@@ -18,3 +18,19 @@
   never read again -- it is not migrated, and nothing deletes it
   automatically; it is dead weight, not a hazard, once this fix is
   installed.
+
+  Follow-up (same issue, self-review + maintainer review): the value
+  validator's ASCII whitelist rejected two shapes `%q` plainly leaves bare
+  and unescaped -- a mid-word `#` (`printf %q 'a#b'` -> `a#b`) and any
+  non-ASCII byte (`e9`, `65e5 672c`) -- turning a rejection into a
+  delete-and-republish on every single run for any config value or
+  project path containing either, forever. The check is now a blacklist of
+  what can actually change how `eval "NAME=value"` parses a plain
+  assignment word (unescaped whitespace, `; & | ( ) < >`, `$`/backtick,
+  quotes), run under a function-local `LC_ALL=C` so its character classes
+  match the raw bytes `%q` wrote rather than whatever locale the caller
+  happens to be in. A second bash-3.2-only gap is also closed: bash
+  tilde-expands after an unquoted `:` in an assignment word as well as at
+  the start, and stock macOS `/bin/bash`'s `%q` does not escape that
+  position (`a:~` stays `a:~`, unlike bash 5's `a:\~`) -- a bare `:~` is
+  now rejected outright, by position, on every bash.

--- a/changelog.d/682.fixed.md
+++ b/changelog.d/682.fixed.md
@@ -1,0 +1,17 @@
+- **Security fix (#682):** the #668 flattened-config cache (`_RCFG_*`, unreleased --
+  landed in #670, after v0.31.0) used to live at `$REMEMBER_DIR/tmp/config.rcfg`
+  -- inside the PROJECT tree, a directory users commit and share -- and was
+  loaded with a bare `source`. A repository could ship that file and have
+  every hook that sources `log.sh` (every `SessionStart`, every post-tool
+  call) execute its contents as shell in the cloning user's own session, no
+  action beyond `git clone` and opening the project. The cache now lives
+  under the system temp dir instead (the same convention as
+  `lib-env-cache.sh`'s and `detect-tools.sh`'s own caches), keyed on
+  `REMEMBER_DIR` so two projects never share one file, and the loader no
+  longer trusts `source` at all: it validates every line against the exact
+  `NAME=%q-value` shape the publisher writes and rejects (and removes) the
+  whole file on the first line that does not match, before a single byte of
+  it is evaluated. A stale `.remember/tmp/config.rcfg` left behind by an
+  earlier build is simply never read again -- it is not migrated, and
+  nothing deletes it automatically; it is dead weight, not a hazard, once
+  this fix is installed.

--- a/changelog.d/682.fixed.md
+++ b/changelog.d/682.fixed.md
@@ -7,11 +7,14 @@
   action beyond `git clone` and opening the project. The cache now lives
   under the system temp dir instead (the same convention as
   `lib-env-cache.sh`'s and `detect-tools.sh`'s own caches), keyed on
-  `REMEMBER_DIR` so two projects never share one file, and the loader no
-  longer trusts `source` at all: it validates every line against the exact
-  `NAME=%q-value` shape the publisher writes and rejects (and removes) the
-  whole file on the first line that does not match, before a single byte of
-  it is evaluated. A stale `.remember/tmp/config.rcfg` left behind by an
-  earlier build is simply never read again -- it is not migrated, and
-  nothing deletes it automatically; it is dead weight, not a hazard, once
-  this fix is installed.
+  `REMEMBER_DIR` so two projects on the same machine never collide on one
+  file's mangled filename and silently read back each other's config (the
+  cache now carries its own REMEMBER_DIR identity line, checked on every
+  load), and the loader no longer trusts `source` at all: it validates
+  every line against the exact `NAME=%q-value` shape the publisher writes
+  and rejects (and removes) the whole file on the first line that does not
+  match, before a single byte of it is evaluated. A stale
+  `.remember/tmp/config.rcfg` left behind by an earlier build is simply
+  never read again -- it is not migrated, and nothing deletes it
+  automatically; it is dead weight, not a hazard, once this fix is
+  installed.

--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -196,8 +196,10 @@ sys.stdout.write("\n".join(out))
 # config() call of every process that reaches it -- session-start-hook.sh,
 # post-tool-hook.sh's slow path, user-prompt-hook.sh, save-session.sh -- even
 # though the flattened result only changes when one of the three config
-# LAYERS changes. Persisted here as sourceable `_RCFG_key='value'`
-# assignments, keyed by mtime against the same three layers lib-memory-dir.sh
+# LAYERS changes. Persisted here as `_RCFG_key=value` lines (validated, then
+# assigned per line -- see the loader below, and the #682 comment just
+# above _remember_cfg_flatten_cache_path for why it is no longer a bare
+# `source`), keyed by mtime against the same three layers lib-memory-dir.sh
 # merges (REMEMBER_CONFIG itself is a fresh mktemp path every process --
 # always "now" -- so it is useless as a cache key; the SOURCE files are what
 # must be checked).
@@ -212,13 +214,73 @@ sys.stdout.write("\n".join(out))
 # program above and the matching `p[0] != "haiku"` in the Python one), so the
 # cache below never receives it in the first place.
 #
-# Values are written with `%q` (bash's own shell-quoting printf conversion),
-# not interpolated raw, because the cache is loaded with `source`: an
-# unescaped config value containing shell metacharacters would otherwise be
-# interpreted as code the moment the cache file executes.
+# Values are written with `%q` (bash's own shell-quoting printf conversion).
+# The loader below no longer trusts that on its own -- see the #682 comment.
+#
+# SECURITY (#682): this file used to live at `$REMEMBER_DIR/tmp/config.rcfg`
+# -- inside the PROJECT tree, a directory users commit and share -- and was
+# loaded with a bare `source`. `-O` (owned by the current user) passes for a
+# file the user's own `git clone` wrote; `-L` passes for a regular file;
+# `-nt` against an absent `.remember/config.json` (the common, no-project-
+# config case) reads as "fresh". A repository could therefore ship a
+# `.remember/tmp/config.rcfg` and have every hook that sources this file
+# (SessionStart, every post-tool call) execute its contents as shell, in the
+# cloning user's own session -- one `git clone` from arbitrary code
+# execution, no user action beyond opening the project. Reproduced with a
+# planted file driven through the real detect-tools.sh -> bootstrap-dirs.sh
+# -> log.sh chain
+# (tests/test_config_flatten_cache_668.py::test_planted_cache_in_old_project_path_is_never_executed).
+#
+# Two independent fixes, both required -- either alone still leaves a hole:
+#
+# 1. The cache file now lives under the SYSTEM temp dir (same convention as
+#    lib-env-cache.sh's `_REMEMBER_ENV_CACHE_FILE` and detect-tools.sh's
+#    `_REMEMBER_TOOLS_CACHE`), never inside the project tree, so nothing a
+#    `git clone` brings in can plant it. Keyed on REMEMBER_DIR itself,
+#    mangled into a filename with the SAME non-alnum-to-`-` mapping and
+#    tail-keep truncation `_remember_env_cache_path` already uses (fork-free
+#    -- no md5/shasum/cksum exec on this hot path, #660's whole point), so
+#    two different projects on the same machine never share, or collide on,
+#    one file. The `-f`/`-L`/`-O`/`-r` guards stay: they are exactly the
+#    right guards for a file under a SHARED tmp dir, which is what this now
+#    is.
+#
+# 2. Even a cache under the system tmp dir is one race away from being
+#    planted by another local user, so the loader below no longer trusts
+#    `source` at all. It reads the file line by line and checks every line
+#    against the EXACT shape the publisher writes, below -- `_RCFG_<name>=
+#    <value>`, where <name> can only be `[A-Za-z0-9_]+` (guaranteed by the
+#    flattener's own key-shape refusal further up this file: every path
+#    segment is already `[A-Za-z0-9_]+` before the publisher ever sees it,
+#    and dots become underscores) and <value> is one of the handful of
+#    shapes bash's own `%q` conversion ever produces for a single word:
+#    `''` (empty), `$'...'` (any control character present -- the shell's
+#    own quoting, safe to eval even though a bare `;`/`|`/`&` can appear
+#    INSIDE it, because none of those are special inside this quoting, only
+#    outside it), or a run of characters %q never escapes plus backslash-
+#    escaped pairs for everything else (a bare, unescaped `;`, `$(`,
+#    backtick, `|`, `&`, quote or whitespace character never appears in this
+#    form). A line outside all three shapes -- an unknown NAME, a second
+#    unquoted word, an unescaped shell metacharacter -- rejects the WHOLE
+#    cache before a single byte of it is evaluated: the file is removed (so
+#    the next start does not re-read the same poison) and the caller falls
+#    through to a real flatten. Only once every line has validated are the
+#    lines assigned, one `eval "$name=$value"` per line -- `%q`'s output is
+#    exactly the word `eval` re-reads, so this is safe by construction for a
+#    line that has already passed the shape check above, and it is strictly
+#    narrower than a blanket `source` of a file whose contents were never
+#    inspected at all.
 _remember_cfg_flatten_cache_path() {
     [ -n "${REMEMBER_DIR:-}" ] || return 1
-    printf '%s' "$REMEMBER_DIR/tmp/config.rcfg"
+    local _key="${REMEMBER_DIR//[!a-zA-Z0-9]/-}"
+    # Same tail-keep truncation as _remember_env_cache_path
+    # (lib-env-cache.sh), same reason: a deep project path can exceed
+    # filesystem name limits (255 bytes on most filesystems), and the END of
+    # a path is what distinguishes it from a sibling -- a truncation
+    # collision only ever costs a rejected/regenerated cache, never a wrong
+    # one, because the value is never trusted from the filename alone.
+    [ "${#_key}" -gt 120 ] && _key="${_key: -120}"
+    printf '%s' "${TMPDIR:-/tmp}/remember-config-cache-${_key}"
 }
 
 _remember_cfg_flatten_cache_sources() {
@@ -248,6 +310,36 @@ _remember_cfg_flatten_cache_is_standard_merge() {
     esac
 }
 
+# A single cache line must be exactly `_RCFG_<name>=<value>` -- see the #682
+# block comment above this whole section for what <name> and <value> are
+# each allowed to be, and why. Returns 1 for anything else, including a line
+# with no `=`, an empty value (the publisher always writes `''` for an empty
+# string, never nothing), or a raw, unescaped shell metacharacter anywhere
+# in the value.
+_remember_cfg_flatten_cache_valid_line() {
+    local _line="$1"
+    [[ "$_line" =~ ^_RCFG_[A-Za-z0-9_]+= ]] || return 1
+    local _value="${_line#*=}"
+    [ -n "$_value" ] || return 1
+    # %q's own empty-string spelling.
+    [ "$_value" = "''" ] && return 0
+    # %q's control-character form: real quoting, so a bare `;`/`|`/`&`
+    # INSIDE it is inert -- only a raw, unescaped closing `'` could break
+    # out, and the character class below excludes that.
+    if [[ "$_value" =~ ^\$\'(\\.|[^\\\'])*\'$ ]]; then
+        return 0
+    fi
+    # %q's plain form: every character is either one %q never escapes, or a
+    # backslash followed by exactly one more character -- the escape pair
+    # %q emits for anything else. A bare, unescaped `;`, `$(`, backtick,
+    # `|`, `&`, quote or whitespace character matches neither alternative
+    # and rejects the whole line.
+    if [[ "$_value" =~ ^(\\.|[A-Za-z0-9_./:@%,+=~-])*$ ]]; then
+        return 0
+    fi
+    return 1
+}
+
 _remember_cfg_flatten_cache_load() {
     [ "${REMEMBER_CONFIG_CACHE:-1}" = "1" ] || return 1
     _remember_cfg_flatten_cache_is_standard_merge || return 1
@@ -268,8 +360,35 @@ _remember_cfg_flatten_cache_load() {
     done <<EOF
 $_sources
 EOF
-    # shellcheck disable=SC1090  # dynamic path, keyed and validated above
-    source "$_f" 2>/dev/null || return 1
+
+    # Validate BEFORE trusting a single byte of it -- see the #682 block
+    # comment above this whole section for why a shared-tmp-dir file is
+    # still not enough on its own. Two passes on purpose: collecting every
+    # line first means a cache that fails on its LAST line never partially
+    # executes its first N-1.
+    local _line _lines=()
+    while IFS= read -r _line || [ -n "$_line" ]; do
+        _line="${_line%$'\r'}"
+        [ -n "$_line" ] || continue
+        if ! _remember_cfg_flatten_cache_valid_line "$_line"; then
+            # Distrust the WHOLE file, and remove it: the next start must not
+            # re-read the same poison and re-pay this same rejection forever.
+            rm -f "$_f" 2>/dev/null
+            return 1
+        fi
+        _lines[${#_lines[@]}]="$_line"
+    done < "$_f"
+
+    local _assign
+    for _assign in ${_lines[@]+"${_lines[@]}"}; do
+        # shellcheck disable=SC1090  # each $_assign already passed
+        # _remember_cfg_flatten_cache_valid_line above: it is exactly one
+        # `_RCFG_name=value` word, where `value` is one of the three shapes
+        # %q ever emits, so this evaluates a plain assignment and nothing
+        # else, by construction -- never a blanket `source` of bytes that
+        # were never inspected.
+        eval "$_assign"
+    done
     return 0
 }
 

--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -310,34 +310,56 @@ _remember_cfg_flatten_cache_is_standard_merge() {
     esac
 }
 
-# A single cache line must be exactly `_RCFG_<name>=<value>` -- see the #682
-# block comment above this whole section for what <name> and <value> are
-# each allowed to be, and why. Returns 1 for anything else, including a line
-# with no `=`, an empty value (the publisher always writes `''` for an empty
-# string, never nothing), or a raw, unescaped shell metacharacter anywhere
-# in the value.
-_remember_cfg_flatten_cache_valid_line() {
-    local _line="$1"
-    [[ "$_line" =~ ^_RCFG_[A-Za-z0-9_]+= ]] || return 1
-    local _value="${_line#*=}"
+# Every value this cache ever writes -- both the config `_RCFG_*` lines
+# below and the REMEMBER_DIR identity line the loader checks against -- is
+# one of the handful of shapes bash's own `%q` conversion ever produces for
+# a single word: `''` (empty), `$'...'` (any control character present --
+# real quoting, so a bare `;`/`|`/`&` INSIDE it is inert, only a raw,
+# unescaped closing `'` could break out, and the character class below
+# excludes that), or a run of characters %q never escapes plus backslash-
+# escaped pairs for everything else. Returns 1 for anything else, including
+# an empty value (the publisher always writes `''` for an empty string,
+# never nothing) or a raw, unescaped shell metacharacter anywhere in it.
+#
+# `~` is deliberately NOT in the plain form's safe-character whitelist even
+# though %q sometimes leaves one bare (`a~b`, `foo/~bar` -- harmless,
+# embedded, no word boundary for tilde-expansion to trigger on): %q ALWAYS
+# escapes a LEADING tilde (`printf %q '~foo'` -> `\~foo`), because bash
+# performs tilde-expansion on the text right after a `=` in an assignment,
+# and `eval "$name=~foo"` would substitute a home directory instead of
+# assigning the literal string. A bare leading tilde is therefore a shape
+# the publisher could never have produced and is rejected outright, by
+# position, before the general character-class check ever runs -- a
+# non-leading one still passes it further down, since it is inert there and
+# %q is not guaranteed to escape it.
+_remember_cfg_flatten_cache_valid_value() {
+    local _value="$1"
     [ -n "$_value" ] || return 1
     # %q's own empty-string spelling.
     [ "$_value" = "''" ] && return 0
-    # %q's control-character form: real quoting, so a bare `;`/`|`/`&`
-    # INSIDE it is inert -- only a raw, unescaped closing `'` could break
-    # out, and the character class below excludes that.
     if [[ "$_value" =~ ^\$\'(\\.|[^\\\'])*\'$ ]]; then
         return 0
     fi
-    # %q's plain form: every character is either one %q never escapes, or a
-    # backslash followed by exactly one more character -- the escape pair
-    # %q emits for anything else. A bare, unescaped `;`, `$(`, backtick,
-    # `|`, `&`, quote or whitespace character matches neither alternative
-    # and rejects the whole line.
-    if [[ "$_value" =~ ^(\\.|[A-Za-z0-9_./:@%,+=~-])*$ ]]; then
+    case "$_value" in
+        \~*) return 1 ;;
+    esac
+    # A bare, unescaped `;`, `$(`, backtick, `|`, `&`, quote, comma, brace
+    # or whitespace character matches neither alternative below and rejects
+    # the whole value.
+    if [[ "$_value" =~ ^(\\.|[A-Za-z0-9_./:@%+=~-])*$ ]]; then
         return 0
     fi
     return 1
+}
+
+# A single config-data cache line must be exactly `_RCFG_<name>=<value>` --
+# see _remember_cfg_flatten_cache_valid_value just above for what <value> is
+# allowed to be, and the #682 block comment above this whole section for
+# what <name> is guaranteed to be (and why that guarantee holds).
+_remember_cfg_flatten_cache_valid_line() {
+    local _line="$1"
+    [[ "$_line" =~ ^_RCFG_[A-Za-z0-9_]+= ]] || return 1
+    _remember_cfg_flatten_cache_valid_value "${_line#*=}"
 }
 
 _remember_cfg_flatten_cache_load() {
@@ -366,10 +388,48 @@ EOF
     # still not enough on its own. Two passes on purpose: collecting every
     # line first means a cache that fails on its LAST line never partially
     # executes its first N-1.
-    local _line _lines=()
+    #
+    # The FIRST line must be the REMEMBER_DIR identity line the publisher
+    # now always writes first (see below): the filename this cache lives at
+    # is a MANY-to-one mangling of REMEMBER_DIR (every non-alnum character
+    # collapses to `-`), so two different project paths that differ only in
+    # which separator they use at the same position -- `my.project` and
+    # `my-project` both mangle to `my-project` -- can land on the identical
+    # cache filename. Without an identity check inside the file itself, the
+    # second project to publish would silently read back the FIRST
+    # project's flattened config on every subsequent hit: exactly the
+    # "silently serve stale/wrong content" failure #668's own design
+    # forbids, just via a different door than the mtime check closes. A
+    # cache file with no identity line at all -- including a fully empty
+    # (zero-byte) one, from external truncation/corruption rather than a
+    # genuinely empty config, which the publisher always writes an identity
+    # line for even when the config is empty -- is unrecognised and
+    # rejected outright, never treated as "zero keys and a clean hit".
+    # `#` rather than `_RCFG_`: no row the flattener ever emits begins with
+    # `#` (see the flattener's own comment further up this file), so this
+    # shape can never collide with a real config key's own line, unlike
+    # reusing the `_RCFG_` namespace would risk.
+    local _line _lines=() _first=1 _identity_raw=""
     while IFS= read -r _line || [ -n "$_line" ]; do
         _line="${_line%$'\r'}"
         [ -n "$_line" ] || continue
+        if [ "$_first" = "1" ]; then
+            _first=0
+            case "$_line" in
+                '#REMEMBER_DIR='*)
+                    _identity_raw="${_line#'#REMEMBER_DIR='}"
+                    _remember_cfg_flatten_cache_valid_value "$_identity_raw" || {
+                        rm -f "$_f" 2>/dev/null
+                        return 1
+                    }
+                    continue
+                    ;;
+                *)
+                    rm -f "$_f" 2>/dev/null
+                    return 1
+                    ;;
+            esac
+        fi
         if ! _remember_cfg_flatten_cache_valid_line "$_line"; then
             # Distrust the WHOLE file, and remove it: the next start must not
             # re-read the same poison and re-pay this same rejection forever.
@@ -378,13 +438,22 @@ EOF
         fi
         _lines[${#_lines[@]}]="$_line"
     done < "$_f"
+    # No lines at all (including "no identity line" -- see above): reject.
+    [ "$_first" = "0" ] || { rm -f "$_f" 2>/dev/null; return 1; }
+
+    local _identity
+    eval "_identity=$_identity_raw"
+    [ "$_identity" = "${REMEMBER_DIR:-}" ] || {
+        rm -f "$_f" 2>/dev/null
+        return 1
+    }
 
     local _assign
     for _assign in ${_lines[@]+"${_lines[@]}"}; do
         # shellcheck disable=SC1090  # each $_assign already passed
         # _remember_cfg_flatten_cache_valid_line above: it is exactly one
-        # `_RCFG_name=value` word, where `value` is one of the three shapes
-        # %q ever emits, so this evaluates a plain assignment and nothing
+        # `_RCFG_name=value` word, where `value` is one of the shapes %q
+        # ever emits, so this evaluates a plain assignment and nothing
         # else, by construction -- never a blanket `source` of bytes that
         # were never inspected.
         eval "$_assign"
@@ -400,11 +469,21 @@ _remember_cfg_flatten_cache_publish() {
     _f=$(_remember_cfg_flatten_cache_path) || return 0
     local _dir
     _dir="${_f%/*}"
-    mkdir -p "$_dir" 2>/dev/null || return 0
+    # Guarded, not unconditional (matching the same convention this file's
+    # own $REMEMBER_LOG_DIR creation already uses, and for the same reason
+    # its comment gives): the target is now `${TMPDIR:-/tmp}` itself (#682),
+    # which is essentially always already present, so re-asking `mkdir`
+    # every single publish would cost a process per cache-miss run to learn
+    # nothing new almost every time.
+    [ -d "$_dir" ] || mkdir -p "$_dir" 2>/dev/null || return 0
     local _t
     _t=$(mktemp "${_f}.XXXXXX" 2>/dev/null) || return 0
     local _k _v
     {
+        # Identity line FIRST, always -- see the #682 comment in the loader
+        # above for why a file at this (many-to-one-mangled) path cannot be
+        # trusted without one.
+        printf '#REMEMBER_DIR=%q\n' "${REMEMBER_DIR:-}"
         while IFS=$'\t' read -r _k _v; do
             [ -n "$_k" ] || continue
             printf '_RCFG_%s=%q\n' "${_k//./_}" "$_v"

--- a/scripts/log.sh
+++ b/scripts/log.sh
@@ -316,24 +316,50 @@ _remember_cfg_flatten_cache_is_standard_merge() {
 # a single word: `''` (empty), `$'...'` (any control character present --
 # real quoting, so a bare `;`/`|`/`&` INSIDE it is inert, only a raw,
 # unescaped closing `'` could break out, and the character class below
-# excludes that), or a run of characters %q never escapes plus backslash-
-# escaped pairs for everything else. Returns 1 for anything else, including
-# an empty value (the publisher always writes `''` for an empty string,
-# never nothing) or a raw, unescaped shell metacharacter anywhere in it.
+# excludes that), or a run of characters plus backslash-escaped pairs for
+# everything else. Returns 1 for anything else, including an empty value
+# (the publisher always writes `''` for an empty string, never nothing) or
+# a raw, unescaped shell metacharacter anywhere in it.
 #
-# `~` is deliberately NOT in the plain form's safe-character whitelist even
-# though %q sometimes leaves one bare (`a~b`, `foo/~bar` -- harmless,
-# embedded, no word boundary for tilde-expansion to trigger on): %q ALWAYS
-# escapes a LEADING tilde (`printf %q '~foo'` -> `\~foo`), because bash
-# performs tilde-expansion on the text right after a `=` in an assignment,
-# and `eval "$name=~foo"` would substitute a home directory instead of
-# assigning the literal string. A bare leading tilde is therefore a shape
-# the publisher could never have produced and is rejected outright, by
-# position, before the general character-class check ever runs -- a
-# non-leading one still passes it further down, since it is inert there and
-# %q is not guaranteed to escape it.
+# The plain-form check below is a BLACKLIST of what can actually change how
+# `eval "NAME=value"` parses a single plain assignment word -- unescaped
+# whitespace, `;` `&` `|` `(` `)` `<` `>` (word/control operators), `$` and
+# backtick (expansion), `'` and `"` (quoting) -- rather than a whitelist of
+# bytes %q is known to leave bare. An ASCII whitelist (an earlier shape of
+# this check) rejected two things %q plainly leaves bare and unescaped on
+# every bash tested (3.2 and 5): a mid-word `#` (`printf %q 'a#b'` ->
+# `a#b`), and any non-ASCII byte (`héllo`, `日本`) -- and a rejection here is
+# not a miss, it is `rm -f` on the cache followed by a full republish on
+# every single subsequent run, forever, for that value. Everything the
+# blacklist does not name (`#`, `,`, `*?[]{}!^`, non-ASCII bytes) is inert
+# inside a plain assignment value and is either left bare by %q or already
+# covered by the `\.` escaped-pair alternative.
+#
+# `~` is handled by position, not by the character class, in both
+# directions bash tilde-expands an assignment word from: a LEADING tilde
+# (`eval "$name=~foo"` substitutes a home directory), which %q ALWAYS
+# escapes (`printf %q '~foo'` -> `\~foo`) so a bare one is a shape the
+# publisher could never have produced; and a tilde immediately after an
+# unquoted `:` (`eval "$name=a:~"` substitutes one there too, per bash's
+# own assignment-specific tilde-expansion rule), which %q escapes on bash 5
+# (`a:~` -> `a:\~`) but NOT on bash 3.2 (macOS's stock `/bin/bash`; `a:~`
+# stays `a:~`, and `eval "v=a:~"` on 3.2 observably substitutes a real home
+# directory). Both positions are rejected outright, before the general
+# character-class check ever runs; a tilde anywhere else is inert and
+# still passes it further down, since %q is not guaranteed to escape it.
+#
+# `local LC_ALL=C` for the duration of this function only (restored on
+# return, never leaks to the caller): `[[ =~ ]]`'s character classes are
+# locale-dependent, and bash 3.2's own `%q` output for some multi-byte
+# UTF-8 input mixes raw bytes with `\NNN` octal escapes byte-by-byte in a
+# way that is not itself valid UTF-8 -- observed to make the very same
+# regex silently NOT match under an inherited UTF-8 locale, even though the
+# value still round-trips correctly through `eval`. Byte-wise (C-locale)
+# matching sees exactly the bytes %q actually wrote and is what the
+# character classes above are written against.
 _remember_cfg_flatten_cache_valid_value() {
     local _value="$1"
+    local LC_ALL=C
     [ -n "$_value" ] || return 1
     # %q's own empty-string spelling.
     [ "$_value" = "''" ] && return 0
@@ -342,11 +368,9 @@ _remember_cfg_flatten_cache_valid_value() {
     fi
     case "$_value" in
         \~*) return 1 ;;
+        *:\~*) return 1 ;;
     esac
-    # A bare, unescaped `;`, `$(`, backtick, `|`, `&`, quote, comma, brace
-    # or whitespace character matches neither alternative below and rejects
-    # the whole value.
-    if [[ "$_value" =~ ^(\\.|[A-Za-z0-9_./:@%+=~-])*$ ]]; then
+    if [[ "$_value" =~ ^(\\.|[^\\\$\`\'\"\;\&\|\(\)\<\>[:space:]])*$ ]]; then
         return 0
     fi
     return 1

--- a/tests/config_cache.py
+++ b/tests/config_cache.py
@@ -1,0 +1,24 @@
+"""Locate the #668 flattened-config cache without hardcoding its filename.
+
+#682 moved this cache out of the project tree (`$REMEMBER_DIR/tmp/config.rcfg`,
+committable and clonable) to a per-project file under the system temp dir,
+keyed by mangling `REMEMBER_DIR` itself (same convention as
+`_remember_env_cache_path` in lib-env-cache.sh). A test that hardcodes the
+mangled filename duplicates the mangling logic and drifts from it silently;
+globbing the fixed prefix `_remember_cfg_flatten_cache_path` always writes
+finds the real file regardless of the exact key shape, exactly the way
+`tests/env_cache.py`'\''s own `CACHE_GLOB` does for the sibling env cache.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# The fixed prefix `_remember_cfg_flatten_cache_path` (scripts/log.sh) always
+# writes; only the mangled-REMEMBER_DIR suffix varies.
+CACHE_GLOB = "remember-config-cache-*"
+
+
+def cache_files(tmpdir) -> list[Path]:
+    """Every published flattened-config cache file under `tmpdir`."""
+    return sorted(Path(tmpdir).glob(CACHE_GLOB))

--- a/tests/test_config_flatten_cache_668.py
+++ b/tests/test_config_flatten_cache_668.py
@@ -503,3 +503,253 @@ def test_two_projects_whose_mangled_paths_collide_never_share_a_config(tmp_path)
         "project B read project A's flattened config through a colliding "
         f"mangled cache filename: {result_b.stdout!r}"
     )
+
+
+# Coordinator follow-up review of the #682 fix above: `_remember_cfg_flatten_
+# cache_valid_value`'s plain-form branch was an ASCII whitelist
+# (`[A-Za-z0-9_./:@%+=~-]`) rather than a blacklist of what can actually
+# change how `eval "NAME=value"` parses a single plain assignment. Two
+# concrete costs of that over-narrow whitelist, both silent: any config
+# value containing `#` (a real, unremarkable byte -- e.g. `#deadbeef` as a
+# tag) or any non-ASCII byte (an accented or CJK path/value) was REJECTED
+# by a validator whose whole job is to accept everything `%q` actually
+# produces, and a rejection here is not just a missed hit -- the loader
+# `rm -f`s the file and the publisher republishes it on every single run
+# (mktemp + rm each time), forever, for that user. Separately: bash 3.2
+# (macOS's stock /bin/bash) tilde-expands after an unquoted `:` in an
+# assignment, not just at the start of the word, and 3.2's own `%q` does
+# NOT escape a tilde in that position (`printf %q 'a:~'` -> `a:~`, whereas
+# bash 5's does: `a:\~`) -- so a value shaped like `foo:~/bar` reaching the
+# blanket `eval` on 3.2 alone would substitute a home directory instead of
+# assigning the literal string.
+def _macos_system_bash():
+    """The specific `/bin/bash` (stock, unreplaced, bash 3.2.57) macOS ships
+    -- the interpreter finding 3 above is about. `resolve_bash()` (used by
+    every other test in this file) follows PATH, which on a dev machine
+    with Homebrew's bash ahead of `/bin` in PATH resolves to bash 5 instead
+    -- silently missing the one interpreter this specific behaviour needs."""
+    if sys.platform == "win32":
+        return None
+    candidate = "/bin/bash"
+    if not os.path.isfile(candidate):
+        return None
+    probe = subprocess.run(
+        [candidate, "-c", "echo $BASH_VERSION"],
+        capture_output=True, text=True, timeout=10, check=False,
+    )
+    if probe.returncode != 0:
+        return None
+    return candidate
+
+
+MACOS_SYSTEM_BASH = _macos_system_bash()
+
+
+def _run_with_shim_using(bash_path: str, tmp_path: Path, home: Path, project: Path, *, sys_tmp: Path | None = None):
+    """Same as `_run_with_shim` above, but against a caller-chosen bash
+    executable instead of the module-level `BASH` -- needed to pin down
+    behaviour that is specific to one interpreter (bash 3.2), not whichever
+    bash happens to be first on this machine's PATH."""
+    log = tmp_path / "spawn.log"
+    shims = make_shim_dir(tmp_path, log)
+    sys_tmp = sys_tmp if sys_tmp is not None else (tmp_path / "systmp")
+    sys_tmp.mkdir(parents=True, exist_ok=True)
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "CLAUDE_PROJECT_DIR": str(project),
+        "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
+        "REMEMBER_HOOK_CWD": str(project),
+        "SPAWN_LOG": str(log),
+        "TMPDIR": str(sys_tmp),
+        "PATH": f"{shims}{os.pathsep}{os.environ['PATH']}",
+    }
+    result = subprocess.run(
+        [bash_path, "-c", HARNESS], env=env, capture_output=True, text=True, timeout=30, check=False,
+    )
+    return spawns(log), result, sys_tmp
+
+
+def test_hash_comma_and_non_ascii_values_round_trip_through_a_warm_hit(tmp_path):
+    """Positive control for the whitelist-too-narrow finding: a config value
+    containing `#`, `,`, and accented Latin text (all bytes a real config
+    value can plainly carry, and all bytes `%q` leaves bare rather than
+    escaping) must survive a cold publish AND a warm load -- the warm run
+    must be an actual cache HIT (jq never forks again), not just "the
+    right value, because it fell through to a real flatten every time"."""
+    home, project, remember = _project(tmp_path)
+    cfg = remember / "config.json"
+    cfg.write_text(json.dumps({"probe": "a#b,héllo"}), encoding="utf-8")
+
+    lines1, result1, sys_tmp = _run_with_shim(tmp_path, home, project)
+    assert result1.returncode == 0, (result1.stdout, result1.stderr)
+
+    caches = cache_files(sys_tmp)
+    assert caches, f"no flattened-config cache ({CACHE_GLOB}) was published under {sys_tmp}"
+    cache = caches[0]
+    # Force the cache strictly newer than the config layer, independent of
+    # which second the two writes above landed in.
+    now = time.time()
+    os.utime(cache, (now + 5, now + 5))
+
+    harness2 = HARNESS.replace(
+        'config ".cooldowns.save_seconds" "default"',
+        'config ".probe" "default"',
+    )
+    log2 = tmp_path / "spawn2.log"
+    shims2 = make_shim_dir(tmp_path, log2)
+    env2 = {
+        **os.environ,
+        "HOME": str(home),
+        "CLAUDE_PROJECT_DIR": str(project),
+        "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
+        "REMEMBER_HOOK_CWD": str(project),
+        "SPAWN_LOG": str(log2),
+        "TMPDIR": str(sys_tmp),
+        "PATH": f"{shims2}{os.pathsep}{os.environ['PATH']}",
+    }
+    result2 = subprocess.run(
+        [BASH, "-c", harness2], env=env2, capture_output=True, text=True, timeout=30, check=False,
+    )
+    assert result2.returncode == 0, (result2.stdout, result2.stderr)
+    assert "a#b,héllo" in result2.stdout, (
+        "a config value containing '#', ',' and accented text did not "
+        f"round-trip through the flatten cache: {result2.stdout!r}"
+    )
+    lines2 = spawns(log2)
+    flatten_spawns_2 = [l for l in lines2 if l.startswith("jq ") and "paths(" in l]
+    assert not flatten_spawns_2, (
+        "the warm run re-forked jq's flattener instead of hitting the cache -- "
+        f"the value was rejected by the validator and re-flattened: {lines2}"
+    )
+
+
+def test_non_ascii_project_path_identity_line_still_hits_warm(tmp_path):
+    """The identity line the loader checks (`#REMEMBER_DIR=%q`) goes
+    through the exact same value validator as every `_RCFG_*` line. A
+    project path with a non-ASCII component (e.g. a user directory named
+    after themselves) must not make that identity line itself unreadable --
+    that would make the cache permanently cold for that user, every run,
+    forever, with no config value involved at all."""
+    home = tmp_path / "home"
+    project = tmp_path / "José-project"
+    remember = project / ".remember"
+    (remember / "tmp").mkdir(parents=True)
+    (home / ".remember").mkdir(parents=True)
+    cfg = remember / "config.json"
+    cfg.write_text(json.dumps({"cooldowns": {"save_seconds": 42}}), encoding="utf-8")
+
+    lines1, result1, sys_tmp = _run_with_shim(tmp_path, home, project)
+    assert result1.returncode == 0, (result1.stdout, result1.stderr)
+    assert "42" in result1.stdout
+
+    caches = cache_files(sys_tmp)
+    assert caches, f"no flattened-config cache ({CACHE_GLOB}) was published under {sys_tmp}"
+    cache = caches[0]
+    # Force the cache strictly newer than the config layer, independent of
+    # which second the two writes above landed in (same convention as
+    # test_second_run_with_unchanged_config_skips_the_flatten_fork above).
+    now = time.time()
+    os.utime(cache, (now + 5, now + 5))
+
+    lines2, result2, _sys_tmp2 = _run_with_shim(tmp_path, home, project, sys_tmp=sys_tmp)
+    assert result2.returncode == 0, (result2.stdout, result2.stderr)
+    assert "42" in result2.stdout
+    flatten_spawns_2 = [l for l in lines2 if l.startswith("jq ") and "paths(" in l]
+    assert not flatten_spawns_2, (
+        "a non-ASCII REMEMBER_DIR made the identity line fail validation, "
+        f"forcing a cold re-flatten on every run: {lines2}"
+    )
+
+
+@pytest.mark.parametrize(
+    "bad_value,desc",
+    [
+        ("x y", "unescaped space"),
+        ("x;y", "unescaped semicolon"),
+        ("x$(y)", "unescaped command substitution"),
+        ("x`y`", "unescaped backtick"),
+        ("x|y", "unescaped pipe"),
+        ("x'y", "unescaped single quote"),
+    ],
+)
+def test_unescaped_shell_metacharacters_in_a_plain_looking_value_are_rejected(tmp_path, bad_value, desc):
+    """None of these bytes are ever left bare by a real `%q` conversion in
+    this position -- they are exactly the shapes `_remember_cfg_flatten_
+    cache_valid_value`'s blacklist exists to catch. Each is planted as a
+    correct-looking `_RCFG_*` line so only the VALUE check stands between
+    it and `eval`; each must be rejected, remove the cache, and still
+    resolve the real config value from a fallback flatten."""
+    home, project, remember = _project(tmp_path)
+    cfg = remember / "config.json"
+    cfg.write_text(json.dumps({"cooldowns": {"save_seconds": 42}}), encoding="utf-8")
+
+    _lines1, result1, sys_tmp = _run_with_shim(tmp_path, home, project)
+    assert result1.returncode == 0, (result1.stdout, result1.stderr)
+    caches = cache_files(sys_tmp)
+    assert caches, f"no flattened-config cache ({CACHE_GLOB}) was published under {sys_tmp}"
+    cache = caches[0]
+
+    marker = tmp_path / f"pwned-682-followup-marker-{desc.replace(' ', '-')}"
+    good = cache.read_text(encoding="utf-8")
+    corrupted = good + f'_RCFG_cooldowns_save_seconds={bad_value}\n'
+    cache.write_text(corrupted, encoding="utf-8")
+    now = time.time()
+    os.utime(cache, (now + 5, now + 5))
+
+    lines2, result2, _sys_tmp2 = _run_with_shim(tmp_path, home, project, sys_tmp=sys_tmp)
+    assert result2.returncode == 0, (result2.stdout, result2.stderr)
+    assert not marker.exists()
+    assert "42" in result2.stdout, (
+        f"a value with {desc} was not cleanly rejected -- config "
+        f"resolution did not fall through to a real flatten: {result2.stdout!r}"
+    )
+
+
+@pytest.mark.skipif(MACOS_SYSTEM_BASH is None, reason="needs macOS's stock /bin/bash (3.2)")
+def test_colon_tilde_value_does_not_expand_a_home_directory_on_bash_3_2(tmp_path):
+    """bash 3.2 tilde-expands after an unquoted `:` in an assignment, and
+    3.2's own `printf %q` does NOT escape a tilde in that position (bash
+    5's does). A config value shaped like `foo:~/bar` -- plausible for
+    anything PATH-like -- reaching the blanket `eval` on 3.2 alone would
+    substitute a real home directory instead of the literal string.
+    Observed directly on this machine's `/bin/bash` before this test was
+    written: `eval "v=foo:~/bar"` on 3.2 yields `foo:/Users/<you>/bar`, not
+    the literal value. Reasoned, not observed, on Git Bash/Linux: their
+    `%q` already escapes the tilde in this position (`foo:\\~/bar`), so the
+    extra guard this test pins is a no-op there rather than untested."""
+    home, project, remember = _project(tmp_path)
+    cfg = remember / "config.json"
+    cfg.write_text(json.dumps({"probe": "foo:~/bar"}), encoding="utf-8")
+
+    lines1, result1, sys_tmp = _run_with_shim_using(MACOS_SYSTEM_BASH, tmp_path, home, project)
+    assert result1.returncode == 0, (result1.stdout, result1.stderr)
+
+    harness2 = HARNESS.replace(
+        'config ".cooldowns.save_seconds" "default"',
+        'config ".probe" "default"',
+    )
+    log2 = tmp_path / "spawn2.log"
+    shims2 = make_shim_dir(tmp_path, log2)
+    env2 = {
+        **os.environ,
+        "HOME": str(home),
+        "CLAUDE_PROJECT_DIR": str(project),
+        "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
+        "REMEMBER_HOOK_CWD": str(project),
+        "SPAWN_LOG": str(log2),
+        "TMPDIR": str(sys_tmp),
+        "PATH": f"{shims2}{os.pathsep}{os.environ['PATH']}",
+    }
+    result2 = subprocess.run(
+        [MACOS_SYSTEM_BASH, "-c", harness2], env=env2, capture_output=True, text=True, timeout=30, check=False,
+    )
+    assert result2.returncode == 0, (result2.stdout, result2.stderr)
+    out = result2.stdout
+    assert str(home) not in out, (
+        "a colon-tilde config value was tilde-expanded into a real home "
+        f"directory on bash 3.2 instead of staying a literal string: {out!r}"
+    )
+    assert "foo:~/bar" in out or "foo:/" not in out, (
+        f"the colon-tilde value was mangled rather than preserved literally: {out!r}"
+    )

--- a/tests/test_config_flatten_cache_668.py
+++ b/tests/test_config_flatten_cache_668.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -309,12 +310,16 @@ def test_planted_cache_in_old_project_path_is_never_executed(tmp_path):
 
 
 def test_malformed_line_in_new_cache_location_is_rejected_not_executed(tmp_path):
-    """The second #682 half: even at the new (system-tmp-dir) location, the
-    loader must not trust `source`. A line the publisher could never write
-    -- here, one with an unquoted second word and a `;` -- must reject the
-    WHOLE cache before anything is evaluated, remove the poisoned file, and
-    still resolve the config correctly by falling through to a real
-    flatten."""
+    """The second #682 half, name-check side: even at the new (system-tmp-
+    dir) location, the loader must not trust `source`. A line whose NAME
+    does not even carry the `_RCFG_` prefix the publisher always writes --
+    here, `SOME_VAR=...` -- must be rejected on that alone, remove the
+    poisoned file, and still resolve the config correctly by falling
+    through to a real flatten. This case alone does not prove the VALUE-
+    shape validator is doing any work (a wrong-prefix line is rejected
+    before `_remember_cfg_flatten_cache_valid_value` is ever reached) --
+    see test_malformed_value_with_a_correct_name_prefix_is_rejected_not_executed
+    just below for that."""
     home, project, remember = _project(tmp_path)
     cfg = remember / "config.json"
     cfg.write_text(json.dumps({"cooldowns": {"save_seconds": 42}}), encoding="utf-8")
@@ -352,3 +357,149 @@ def test_malformed_line_in_new_cache_location_is_rejected_not_executed(tmp_path)
         )
     else:
         pass  # also acceptable: rejection removed it and nothing republished
+
+
+def test_malformed_value_with_a_correct_name_prefix_is_rejected_not_executed(tmp_path):
+    """The second #682 half, VALUE-shape side. The sibling test just above
+    plants a line whose NAME already fails the `_RCFG_` prefix check --
+    which proves nothing about `_remember_cfg_flatten_cache_valid_value`,
+    the function that actually decides whether a value shaped like `%q`
+    output is safe to `eval`. This plants a line with a fully correct,
+    real-looking name (`_RCFG_cooldowns_save_seconds=`) carrying a value a
+    real `%q` conversion could never produce -- unescaped command
+    substitution -- so only the VALUE check stands between it and
+    execution."""
+    home, project, remember = _project(tmp_path)
+    cfg = remember / "config.json"
+    cfg.write_text(json.dumps({"cooldowns": {"save_seconds": 42}}), encoding="utf-8")
+
+    _lines1, result1, sys_tmp = _run_with_shim(tmp_path, home, project)
+    assert result1.returncode == 0, (result1.stdout, result1.stderr)
+    caches = cache_files(sys_tmp)
+    assert caches, f"no flattened-config cache ({CACHE_GLOB}) was published under {sys_tmp}"
+    cache = caches[0]
+
+    marker = tmp_path / "pwned-682-value-marker"
+    good = cache.read_text(encoding="utf-8")
+    corrupted = good + f'_RCFG_cooldowns_save_seconds=$(touch "{marker.as_posix()}")\n'
+    cache.write_text(corrupted, encoding="utf-8")
+    now = time.time()
+    os.utime(cache, (now + 5, now + 5))
+
+    # Positive control: `eval`ing this exact line, with nothing in the way,
+    # must actually create the marker -- otherwise the negative assertion
+    # below would pass even if the value check were deleted outright.
+    assert not marker.exists()
+    subprocess.run(
+        [BASH, "-c", f'eval \'_RCFG_x=$(touch "{marker.as_posix()}")\''],
+        capture_output=True, text=True, timeout=10, check=False,
+    )
+    assert marker.exists(), (
+        "positive control failed: eval-ing the malicious value directly "
+        "did not create the marker -- the harness cannot see execution"
+    )
+    marker.unlink()
+
+    lines2, result2, _sys_tmp2 = _run_with_shim(tmp_path, home, project, sys_tmp=sys_tmp)
+    assert result2.returncode == 0, (result2.stdout, result2.stderr)
+    assert not marker.exists(), (
+        f"a malformed cache VALUE (correct name, unescaped $(...)) was "
+        f"evaluated as shell: {lines2}"
+    )
+    assert "42" in result2.stdout, (
+        "the malformed cache was not cleanly rejected -- config resolution "
+        f"did not fall through to a correct real flatten: {result2.stdout!r}"
+    )
+    if cache.exists():
+        assert marker.as_posix() not in cache.read_text(encoding="utf-8"), (
+            "the rejected cache was republished still carrying the "
+            "malformed value -- the poison survived the rejection"
+        )
+
+
+def test_a_zero_byte_cache_is_rejected_not_treated_as_an_empty_hit(tmp_path):
+    """A genuinely empty config (zero flattened keys) still publishes a
+    cache -- just one carrying no `_RCFG_*` lines. Before the identity line
+    the loader now always requires as its first line, a cache file reduced
+    to zero bytes by anything OTHER than the normal publish path (an
+    external truncate, a half-finished write that somehow kept a fresh
+    mtime) was indistinguishable from that legitimate "zero keys" case: the
+    validate loop simply never ran its body, and the loader returned a
+    clean hit. Pin that this can no longer happen: a hand-planted, genuinely
+    empty file at the real cache location must be rejected, not read as
+    "nothing to say"."""
+    home, project, remember = _project(tmp_path)
+    cfg = remember / "config.json"
+    cfg.write_text(json.dumps({"cooldowns": {"save_seconds": 42}}), encoding="utf-8")
+
+    # Publish once for real, so the cache path this test plants over is the
+    # one the loader will actually look at.
+    _lines1, result1, sys_tmp = _run_with_shim(tmp_path, home, project)
+    assert result1.returncode == 0, (result1.stdout, result1.stderr)
+    caches = cache_files(sys_tmp)
+    assert caches, f"no flattened-config cache ({CACHE_GLOB}) was published under {sys_tmp}"
+    cache = caches[0]
+
+    cache.write_text("", encoding="utf-8")
+    now = time.time()
+    os.utime(cache, (now + 5, now + 5))
+
+    _lines2, result2, _sys_tmp2 = _run_with_shim(tmp_path, home, project, sys_tmp=sys_tmp)
+    assert result2.returncode == 0, (result2.stdout, result2.stderr)
+    assert "42" in result2.stdout, (
+        "a zero-byte cache was treated as a clean, valid hit instead of "
+        f"being rejected and falling through to a real flatten: {result2.stdout!r}"
+    )
+
+
+def test_two_projects_whose_mangled_paths_collide_never_share_a_config(tmp_path):
+    """The cache filename is a MANY-to-one mangling of REMEMBER_DIR (every
+    non-alnum character collapses to `-`), so two different project paths
+    that differ only in which separator they use at the same position can
+    land on the identical cache filename -- verified directly: mangling
+    both "my.project" and "my-project" produces the string "my-project".
+    Without an identity check inside the file itself, the second project
+    to publish would silently read back the FIRST project's config on
+    every subsequent hit. This drives that exact collision through the
+    real chain for two sibling projects and asserts the second one's own
+    config value is never shadowed by the first's."""
+    home = tmp_path / "home"
+    (home / ".remember").mkdir(parents=True)
+    project_a = tmp_path / "my.project"
+    project_b = tmp_path / "my-project"
+    remember_a = project_a / ".remember"
+    remember_b = project_b / ".remember"
+    (remember_a / "tmp").mkdir(parents=True)
+    (remember_b / "tmp").mkdir(parents=True)
+    # Mirrors log.sh's own `${REMEMBER_DIR//[!a-zA-Z0-9]/-}` mangling
+    # exactly (every non-alnum character, not just the dot) -- so this
+    # checks the actual collision the cache filename would hit, not an
+    # approximation of it.
+    mangle = lambda p: re.sub(r"[^A-Za-z0-9]", "-", str(p))
+    assert mangle(remember_a) == mangle(remember_b), (
+        "test setup assumption broke -- these two paths no longer mangle "
+        "to the same filename, so this test would not be reproducing the "
+        "collision it claims to"
+    )
+
+    (remember_a / "config.json").write_text(
+        json.dumps({"cooldowns": {"save_seconds": 111}}), encoding="utf-8"
+    )
+    (remember_b / "config.json").write_text(
+        json.dumps({"cooldowns": {"save_seconds": 222}}), encoding="utf-8"
+    )
+
+    # Publish A first, so if B's load ever fell through to A's file by
+    # mistake, B would read A's value (111) instead of its own (222).
+    _lines_a, result_a, sys_tmp = _run_with_shim(tmp_path, home, project_a)
+    assert result_a.returncode == 0, (result_a.stdout, result_a.stderr)
+    assert "111" in result_a.stdout
+
+    _lines_b, result_b, _sys_tmp_b = _run_with_shim(
+        tmp_path, home, project_b, sys_tmp=sys_tmp
+    )
+    assert result_b.returncode == 0, (result_b.stdout, result_b.stderr)
+    assert "222" in result_b.stdout, (
+        "project B read project A's flattened config through a colliding "
+        f"mangled cache filename: {result_b.stdout!r}"
+    )

--- a/tests/test_config_flatten_cache_668.py
+++ b/tests/test_config_flatten_cache_668.py
@@ -99,7 +99,7 @@ def _run_with_shim(tmp_path: Path, home: Path, project: Path, *, sys_tmp: Path |
         "PATH": f"{shims}{os.pathsep}{os.environ['PATH']}",
     }
     result = subprocess.run(
-        [BASH, "-c", HARNESS], env=env, capture_output=True, text=True, timeout=30, check=False,
+        [BASH, "-c", HARNESS], env=env, capture_output=True, text=True, encoding="utf-8", timeout=30, check=False,
     )
     return spawns(log), result, sys_tmp
 
@@ -287,7 +287,7 @@ def test_planted_cache_in_old_project_path_is_never_executed(tmp_path):
     assert not marker.exists()
     subprocess.run(
         [BASH, "-c", f'source "{planted.as_posix()}"'],
-        capture_output=True, text=True, timeout=10, check=False,
+        capture_output=True, text=True, encoding="utf-8", timeout=10, check=False,
     )
     assert marker.exists(), (
         "positive control failed: sourcing the planted file directly did "
@@ -392,7 +392,7 @@ def test_malformed_value_with_a_correct_name_prefix_is_rejected_not_executed(tmp
     assert not marker.exists()
     subprocess.run(
         [BASH, "-c", f'eval \'_RCFG_x=$(touch "{marker.as_posix()}")\''],
-        capture_output=True, text=True, timeout=10, check=False,
+        capture_output=True, text=True, encoding="utf-8", timeout=10, check=False,
     )
     assert marker.exists(), (
         "positive control failed: eval-ing the malicious value directly "
@@ -535,7 +535,7 @@ def _macos_system_bash():
         return None
     probe = subprocess.run(
         [candidate, "-c", "echo $BASH_VERSION"],
-        capture_output=True, text=True, timeout=10, check=False,
+        capture_output=True, text=True, encoding="utf-8", timeout=10, check=False,
     )
     if probe.returncode != 0:
         return None
@@ -565,7 +565,7 @@ def _run_with_shim_using(bash_path: str, tmp_path: Path, home: Path, project: Pa
         "PATH": f"{shims}{os.pathsep}{os.environ['PATH']}",
     }
     result = subprocess.run(
-        [bash_path, "-c", HARNESS], env=env, capture_output=True, text=True, timeout=30, check=False,
+        [bash_path, "-c", HARNESS], env=env, capture_output=True, text=True, encoding="utf-8", timeout=30, check=False,
     )
     return spawns(log), result, sys_tmp
 
@@ -609,7 +609,7 @@ def test_hash_comma_and_non_ascii_values_round_trip_through_a_warm_hit(tmp_path)
         "PATH": f"{shims2}{os.pathsep}{os.environ['PATH']}",
     }
     result2 = subprocess.run(
-        [BASH, "-c", harness2], env=env2, capture_output=True, text=True, timeout=30, check=False,
+        [BASH, "-c", harness2], env=env2, capture_output=True, text=True, encoding="utf-8", timeout=30, check=False,
     )
     assert result2.returncode == 0, (result2.stdout, result2.stderr)
     assert "a#b,héllo" in result2.stdout, (
@@ -742,7 +742,7 @@ def test_colon_tilde_value_does_not_expand_a_home_directory_on_bash_3_2(tmp_path
         "PATH": f"{shims2}{os.pathsep}{os.environ['PATH']}",
     }
     result2 = subprocess.run(
-        [MACOS_SYSTEM_BASH, "-c", harness2], env=env2, capture_output=True, text=True, timeout=30, check=False,
+        [MACOS_SYSTEM_BASH, "-c", harness2], env=env2, capture_output=True, text=True, encoding="utf-8", timeout=30, check=False,
     )
     assert result2.returncode == 0, (result2.stdout, result2.stderr)
     out = result2.stdout

--- a/tests/test_config_flatten_cache_668.py
+++ b/tests/test_config_flatten_cache_668.py
@@ -9,6 +9,15 @@ already a short-lived scratch file deleted at process exit
 (lib-memory-dir.sh's own comment); a persistent cache of it would extend
 that secret's on-disk lifetime. Both flatteners already drop the whole
 "haiku" key before emitting a row, so the persisted cache never sees it.
+
+#682: the cache used to live at `$REMEMBER_DIR/tmp/config.rcfg` -- inside
+the PROJECT tree, a directory users commit and share -- and was loaded with
+a bare `source`. A repository could ship that file and have every hook that
+sources log.sh execute its contents as shell. The tests below cover both
+halves of the fix: the cache moved to the system temp dir (never inside a
+clonable project directory), keyed on `REMEMBER_DIR` so two projects never
+share a file; and the loader validates every line's shape before assigning
+any of it, rather than trusting `source` with an unread file.
 """
 
 from __future__ import annotations
@@ -24,6 +33,7 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(__file__))
 from _bash_runner import resolve_bash
+from config_cache import CACHE_GLOB, cache_files
 from spawn_counting import make_shim_dir, spawns
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -67,9 +77,16 @@ config ".cooldowns.save_seconds" "default"
 """
 
 
-def _run_with_shim(tmp_path: Path, home: Path, project: Path):
+def _run_with_shim(tmp_path: Path, home: Path, project: Path, *, sys_tmp: Path | None = None):
     log = tmp_path / "spawn.log"
     shims = make_shim_dir(tmp_path, log)
+    # A dedicated, per-test system tmp dir (#682): the cache now lives under
+    # `${TMPDIR:-/tmp}`, so a test that left TMPDIR at its real system value
+    # would read and write a real, shared, cross-test location -- isolate it
+    # the same way tests/test_detect_tools_cache_668.py already does for the
+    # sibling tools cache.
+    sys_tmp = sys_tmp if sys_tmp is not None else (tmp_path / "systmp")
+    sys_tmp.mkdir(parents=True, exist_ok=True)
     env = {
         **os.environ,
         "HOME": str(home),
@@ -77,12 +94,13 @@ def _run_with_shim(tmp_path: Path, home: Path, project: Path):
         "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
         "REMEMBER_HOOK_CWD": str(project),
         "SPAWN_LOG": str(log),
+        "TMPDIR": str(sys_tmp),
         "PATH": f"{shims}{os.pathsep}{os.environ['PATH']}",
     }
     result = subprocess.run(
         [BASH, "-c", HARNESS], env=env, capture_output=True, text=True, timeout=30, check=False,
     )
-    return spawns(log), result
+    return spawns(log), result, sys_tmp
 
 
 def test_first_run_is_a_miss_and_forks_jq_to_flatten(tmp_path):
@@ -93,14 +111,18 @@ def test_first_run_is_a_miss_and_forks_jq_to_flatten(tmp_path):
     (remember / "config.json").write_text(
         json.dumps({"cooldowns": {"save_seconds": 42}}), encoding="utf-8"
     )
-    lines, result = _run_with_shim(tmp_path, home, project)
+    lines, result, sys_tmp = _run_with_shim(tmp_path, home, project)
     assert result.returncode == 0, (result.stdout, result.stderr)
     jq_spawns = [l for l in lines if l.startswith("jq ")]
     assert jq_spawns, (
         "positive control failed: no jq fork observed on the first (cold) "
         f"run -- got spawns: {lines}"
     )
-    assert (remember / "tmp" / "config.rcfg").is_file()
+    assert cache_files(sys_tmp), (
+        f"no flattened-config cache ({CACHE_GLOB}) was published under {sys_tmp}"
+    )
+    # #682: the cache must never land back inside the project tree.
+    assert not (remember / "tmp" / "config.rcfg").exists()
 
 
 def test_second_run_with_unchanged_config_skips_the_flatten_fork(tmp_path):
@@ -110,16 +132,17 @@ def test_second_run_with_unchanged_config_skips_the_flatten_fork(tmp_path):
     cfg = remember / "config.json"
     cfg.write_text(json.dumps({"cooldowns": {"save_seconds": 42}}), encoding="utf-8")
 
-    _lines1, result1 = _run_with_shim(tmp_path, home, project)
+    _lines1, result1, sys_tmp = _run_with_shim(tmp_path, home, project)
     assert result1.returncode == 0, (result1.stdout, result1.stderr)
-    cache = remember / "tmp" / "config.rcfg"
-    assert cache.is_file()
+    caches = cache_files(sys_tmp)
+    assert caches, f"no flattened-config cache ({CACHE_GLOB}) was published under {sys_tmp}"
+    cache = caches[0]
     # Force the cache strictly newer than the config layer, independent of
     # which second the two writes above landed in.
     now = time.time()
     os.utime(cache, (now + 5, now + 5))
 
-    lines2, result2 = _run_with_shim(tmp_path, home, project)
+    lines2, result2, _sys_tmp2 = _run_with_shim(tmp_path, home, project, sys_tmp=sys_tmp)
     assert result2.returncode == 0, (result2.stdout, result2.stderr)
     assert result2.stdout == result1.stdout
     # `jq -s reduce ...` is lib-memory-dir.sh's own three-layer MERGE, which
@@ -142,10 +165,12 @@ def test_editing_the_config_invalidates_the_flatten_cache(tmp_path):
     cfg = remember / "config.json"
     cfg.write_text(json.dumps({"cooldowns": {"save_seconds": 42}}), encoding="utf-8")
 
-    _lines1, result1 = _run_with_shim(tmp_path, home, project)
+    _lines1, result1, sys_tmp = _run_with_shim(tmp_path, home, project)
     assert result1.returncode == 0, (result1.stdout, result1.stderr)
     assert "42" in result1.stdout
-    cache = remember / "tmp" / "config.rcfg"
+    caches = cache_files(sys_tmp)
+    assert caches
+    cache = caches[0]
     now = time.time()
     os.utime(cache, (now + 5, now + 5))
 
@@ -153,7 +178,7 @@ def test_editing_the_config_invalidates_the_flatten_cache(tmp_path):
     cfg.write_text(json.dumps({"cooldowns": {"save_seconds": 99}}), encoding="utf-8")
     os.utime(cfg, (now + 10, now + 10))
 
-    _lines2, result2 = _run_with_shim(tmp_path, home, project)
+    _lines2, result2, _sys_tmp2 = _run_with_shim(tmp_path, home, project, sys_tmp=sys_tmp)
     assert result2.returncode == 0, (result2.stdout, result2.stderr)
     assert "99" in result2.stdout, (
         "stale cache must be impossible to serve silently -- expected the "
@@ -165,11 +190,11 @@ def test_haiku_key_never_reaches_the_persisted_cache(tmp_path):
     """Security property the cache design depends on, stated in both this
     file's own docstring and log.sh's own comment on the cache: a live
     haiku.oauth_token in config.json must never be written into the
-    persisted config.rcfg cache, which survives long past the single
-    process the raw merged config.json scratch file is deleted at exit of.
-    Both flatteners drop the whole "haiku" key before a row is ever emitted
-    -- this pins that guarantee against the PERSISTED file specifically,
-    not just against config()'s own in-process read."""
+    persisted config cache, which survives long past the single process the
+    raw merged config.json scratch file is deleted at exit of. Both
+    flatteners drop the whole "haiku" key before a row is ever emitted --
+    this pins that guarantee against the PERSISTED file specifically, not
+    just against config()'s own in-process read."""
     home, project, remember = _project(tmp_path)
     cfg = remember / "config.json"
     cfg.write_text(
@@ -182,12 +207,12 @@ def test_haiku_key_never_reaches_the_persisted_cache(tmp_path):
         encoding="utf-8",
     )
 
-    _lines, result = _run_with_shim(tmp_path, home, project)
+    _lines, result, sys_tmp = _run_with_shim(tmp_path, home, project)
     assert result.returncode == 0, (result.stdout, result.stderr)
 
-    cache = remember / "tmp" / "config.rcfg"
-    assert cache.is_file()
-    cache_text = cache.read_text(encoding="utf-8")
+    caches = cache_files(sys_tmp)
+    assert caches
+    cache_text = caches[0].read_text(encoding="utf-8")
     assert "oauth_token" not in cache_text, (
         "the haiku.oauth_token key leaked into the persisted config cache: "
         f"{cache_text!r}"
@@ -200,16 +225,18 @@ def test_haiku_key_never_reaches_the_persisted_cache(tmp_path):
 
 def test_a_symlinked_config_cache_is_refused_not_followed(tmp_path):
     """Positive control for the -L/-O checks themselves: a planted symlink at
-    config.rcfg must never be sourced -- the loader must fall back to a live
-    reflatten rather than executing an attacker-controlled file as shell."""
+    the cache's real (new, #682) location must never be sourced -- the
+    loader must fall back to a live reflatten rather than executing an
+    attacker-controlled file as shell."""
     home, project, remember = _project(tmp_path)
     cfg = remember / "config.json"
     cfg.write_text(json.dumps({"cooldowns": {"save_seconds": 42}}), encoding="utf-8")
 
-    _lines, result = _run_with_shim(tmp_path, home, project)
+    _lines, result, sys_tmp = _run_with_shim(tmp_path, home, project)
     assert result.returncode == 0, (result.stdout, result.stderr)
-    cache = remember / "tmp" / "config.rcfg"
-    assert cache.is_file()
+    caches = cache_files(sys_tmp)
+    assert caches
+    cache = caches[0]
 
     victim = tmp_path / "attacker-controlled.rcfg"
     victim.write_text("touch /tmp/pwned-668-poc\n_RCFG_cooldowns_save_seconds=666\n",
@@ -217,7 +244,7 @@ def test_a_symlinked_config_cache_is_refused_not_followed(tmp_path):
     cache.unlink()
     os.symlink(victim, cache)
 
-    _lines2, result2 = _run_with_shim(tmp_path, home, project)
+    _lines2, result2, _sys_tmp2 = _run_with_shim(tmp_path, home, project, sys_tmp=sys_tmp)
     assert result2.returncode == 0, (result2.stdout, result2.stderr)
     assert "666" not in result2.stdout, (
         "a symlinked config cache was sourced instead of refused -- "
@@ -227,3 +254,101 @@ def test_a_symlinked_config_cache_is_refused_not_followed(tmp_path):
         "the symlinked cache's shell content actually executed"
     )
     assert "42" in result2.stdout
+
+
+def test_planted_cache_in_old_project_path_is_never_executed(tmp_path):
+    """#682's core reproduction. Before the fix, `_remember_cfg_flatten_
+    cache_load` did `source "$REMEMBER_DIR/tmp/config.rcfg"` -- a path
+    INSIDE the project tree, which a cloned repository can ship. `-O`
+    (owned by the current user) passes for a file the user's own `git
+    clone` wrote; `-L` passes for a regular file; `-nt` against an absent
+    `.remember/config.json` (the common case with no project-level config)
+    reads as "fresh". Planting a file there and running it through the
+    real, unmodified detect-tools.sh -> bootstrap-dirs.sh -> log.sh chain
+    must never execute its contents, no matter where the cache used to live.
+    """
+    home, project, remember = _project(tmp_path)
+    cfg = remember / "config.json"
+    cfg.write_text(json.dumps({"cooldowns": {"save_seconds": 42}}), encoding="utf-8")
+
+    marker = tmp_path / "pwned-682-marker"
+    planted = remember / "tmp" / "config.rcfg"
+    planted.write_text(
+        f'touch "{marker.as_posix()}"\n_RCFG_cooldowns_save_seconds=42\n',
+        encoding="utf-8",
+    )
+
+    # Positive control FIRST, and independent of the guard under test: the
+    # marker-based assertion below is only meaningful if sourcing this exact
+    # file, with nothing in the way, actually creates the marker. If it
+    # doesn't, the negative assertion after it would pass for free on a
+    # broken harness.
+    assert not marker.exists()
+    subprocess.run(
+        [BASH, "-c", f'source "{planted.as_posix()}"'],
+        capture_output=True, text=True, timeout=10, check=False,
+    )
+    assert marker.exists(), (
+        "positive control failed: sourcing the planted file directly did "
+        "not create the marker -- the harness cannot see execution"
+    )
+    marker.unlink()
+
+    # The real case: the shipped chain must never read, let alone execute,
+    # a config.rcfg that lives inside the project tree.
+    lines, result, _sys_tmp = _run_with_shim(tmp_path, home, project)
+    assert result.returncode == 0, (result.stdout, result.stderr)
+    assert not marker.exists(), (
+        "the repo-shipped .remember/tmp/config.rcfg was executed as shell "
+        f"by the real hook chain -- spawns: {lines}"
+    )
+    assert "42" in result.stdout, (
+        "config resolution broke instead of just ignoring the planted file: "
+        f"{result.stdout!r}"
+    )
+
+
+def test_malformed_line_in_new_cache_location_is_rejected_not_executed(tmp_path):
+    """The second #682 half: even at the new (system-tmp-dir) location, the
+    loader must not trust `source`. A line the publisher could never write
+    -- here, one with an unquoted second word and a `;` -- must reject the
+    WHOLE cache before anything is evaluated, remove the poisoned file, and
+    still resolve the config correctly by falling through to a real
+    flatten."""
+    home, project, remember = _project(tmp_path)
+    cfg = remember / "config.json"
+    cfg.write_text(json.dumps({"cooldowns": {"save_seconds": 42}}), encoding="utf-8")
+
+    _lines1, result1, sys_tmp = _run_with_shim(tmp_path, home, project)
+    assert result1.returncode == 0, (result1.stdout, result1.stderr)
+    caches = cache_files(sys_tmp)
+    assert caches, f"no flattened-config cache ({CACHE_GLOB}) was published under {sys_tmp}"
+    cache = caches[0]
+
+    marker = tmp_path / "pwned-682-malformed-marker"
+    good = cache.read_text(encoding="utf-8")
+    corrupted = good + f'SOME_VAR=x; touch "{marker.as_posix()}"\n'
+    cache.write_text(corrupted, encoding="utf-8")
+    now = time.time()
+    os.utime(cache, (now + 5, now + 5))
+
+    lines2, result2, _sys_tmp2 = _run_with_shim(tmp_path, home, project, sys_tmp=sys_tmp)
+    assert result2.returncode == 0, (result2.stdout, result2.stderr)
+    assert not marker.exists(), (
+        f"a malformed cache line was evaluated as shell: {lines2}"
+    )
+    assert "42" in result2.stdout, (
+        "the malformed cache was not cleanly rejected -- config resolution "
+        f"did not fall through to a correct real flatten: {result2.stdout!r}"
+    )
+    # The loader removes the poisoned file before falling through, and
+    # _config_load's own fallback path republishes a fresh cache at the
+    # SAME name once it has re-flattened for real -- so "the file is gone"
+    # is the wrong check; "the poison is gone" is the one that matters.
+    if cache.exists():
+        assert marker.as_posix() not in cache.read_text(encoding="utf-8"), (
+            "the rejected cache was republished still carrying the "
+            "malformed line -- the poison survived the rejection"
+        )
+    else:
+        pass  # also acceptable: rejection removed it and nothing republished

--- a/tests/test_now_md_append_atomicity.py
+++ b/tests/test_now_md_append_atomicity.py
@@ -336,9 +336,17 @@ class TestNowMdAppendIsAtomic:
         # exactly as lib-env-cache.sh's own `remember-env-*` cache file
         # would need to be if any script in THIS harness's chain called
         # its publish function (none currently do).
+        # #682: the flattened-config cache moved out of the project tree to a
+        # per-project file under TMPDIR too (scripts/log.sh's
+        # `_remember_cfg_flatten_cache_path`), for the identical security
+        # reason #668's tools-verdict cache already lives here -- and for
+        # the identical reason it is excluded from this leak check: one
+        # file, rewritten in place on every cache-miss run via a
+        # temp-then-rename, never accumulating one per invocation.
         in_tmpdir = sorted(
             p.name for p in Path(env["TMPDIR"]).glob("remember-*")
             if p.name != "remember-detect-tools-cache"
+            and not p.name.startswith("remember-config-cache-")
         )
         assert not beside and not in_tmpdir, (
             f"a failed commit orphaned its temp. beside={beside} tmpdir={in_tmpdir}"

--- a/tests/test_post_tool_hook_spawns.py
+++ b/tests/test_post_tool_hook_spawns.py
@@ -131,8 +131,9 @@ def _env(tmp_path: Path, home: Path, project: Path, extra: dict | None = None) -
         # not a test-only seam, so what runs here is the shipped cold path.
         "REMEMBER_ENV_CACHE": "0",
         # Same reasoning, same #303 class, one mechanism later (#668): log.sh's
-        # flattened-config cache (config.rcfg) is ALSO mtime-keyed against
-        # config.json, and this fixture creates config.json once, then runs
+        # flattened-config cache (moved out of the project tree by #682; no
+        # longer named config.rcfg) is ALSO mtime-keyed against config.json,
+        # and this fixture creates config.json once, then runs
         # the hook twice -- whether the SECOND run's cache read ties or hits
         # depends on whether the first run's cache write landed in the same
         # whole second as config.json's own creation, which this test must

--- a/tests/test_session_start_fork_tax_665.py
+++ b/tests/test_session_start_fork_tax_665.py
@@ -59,6 +59,7 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(__file__))
 from _bash_runner import resolve_bash
+from config_cache import CACHE_GLOB, cache_files
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 RESOLVE_PATHS = REPO_ROOT / "scripts" / "resolve-paths.sh"
@@ -201,8 +202,16 @@ config '.cooldowns.save_seconds' '0'
     }
     result = subprocess.run([BASH, "-c", script], env=env, capture_output=True, text=True, timeout=30, check=False)
     assert result.returncode == 0, (result.stdout, result.stderr)
-    cache = remember / "tmp" / "config.rcfg"
-    assert cache.is_file()
+    # #682: the flattened-config cache no longer lives at
+    # `$REMEMBER_DIR/tmp/config.rcfg` -- it moved to a per-project file
+    # under `${TMPDIR:-/tmp}`, keyed by mangling REMEMBER_DIR itself. `env`
+    # above never overrides TMPDIR (inherits the real one from os.environ,
+    # same as `_count_forks`'s own env, so the two calls agree on where to
+    # look), so locate it there rather than at the old in-project path.
+    sys_tmp = Path(os.environ.get("TMPDIR") or "/tmp")
+    caches = cache_files(sys_tmp)
+    assert caches, f"no flattened-config cache ({CACHE_GLOB}) was published under {sys_tmp}"
+    cache = caches[0]
     now = time.time()
     os.utime(cache, (now + 5, now + 5))
 

--- a/tests/test_session_start_fork_tax_665.py
+++ b/tests/test_session_start_fork_tax_665.py
@@ -168,7 +168,15 @@ echo "{END}"
         "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
         "REMEMBER_HOOK_CWD": str(project),
         "PATH": os.environ["PATH"],
+        # #682: the flattened-config cache this probe warms via
+        # `_warm_config` now lives under TMPDIR, not inside the project
+        # tree -- pin it to a directory keyed on `tmp_path` (the same value
+        # `_warm_config`'s own env below uses) so this call and that one
+        # agree on where to find it, rather than both falling through to
+        # the real, shared, cross-test system tmp dir.
+        "TMPDIR": str(tmp_path / "systmp"),
     }
+    (tmp_path / "systmp").mkdir(parents=True, exist_ok=True)
     result = subprocess.run(
         [BASH, "-c", script], env=env, capture_output=True, text=True,
         errors="replace", timeout=30, check=False,
@@ -192,6 +200,18 @@ source "{BOOTSTRAP_DIRS.as_posix()}" || exit 99
 source "{LOG_SH.as_posix()}" 2>/dev/null
 config '.cooldowns.save_seconds' '0'
 """
+    # #682: the flattened-config cache no longer lives at
+    # `$REMEMBER_DIR/tmp/config.rcfg` -- it moved to a per-project file
+    # under TMPDIR, keyed by mangling REMEMBER_DIR itself. Pin TMPDIR to a
+    # directory keyed on `tmp_path`, the SAME one `_count_forks`'s own env
+    # uses (both take `tmp_path` from the same test), rather than letting
+    # either call fall through to the real, shared, cross-test system tmp
+    # dir -- that dir accumulates one file per test run across the whole
+    # suite's history and is never cleaned up, so a bare `caches[0]` there
+    # can silently pick up an unrelated leftover from an earlier test
+    # instead of the cache this call just published.
+    sys_tmp = tmp_path / "systmp"
+    sys_tmp.mkdir(parents=True, exist_ok=True)
     env = {
         **os.environ,
         "HOME": str(home),
@@ -199,16 +219,10 @@ config '.cooldowns.save_seconds' '0'
         "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
         "REMEMBER_HOOK_CWD": str(project),
         "PATH": os.environ["PATH"],
+        "TMPDIR": str(sys_tmp),
     }
     result = subprocess.run([BASH, "-c", script], env=env, capture_output=True, text=True, timeout=30, check=False)
     assert result.returncode == 0, (result.stdout, result.stderr)
-    # #682: the flattened-config cache no longer lives at
-    # `$REMEMBER_DIR/tmp/config.rcfg` -- it moved to a per-project file
-    # under `${TMPDIR:-/tmp}`, keyed by mangling REMEMBER_DIR itself. `env`
-    # above never overrides TMPDIR (inherits the real one from os.environ,
-    # same as `_count_forks`'s own env, so the two calls agree on where to
-    # look), so locate it there rather than at the old in-project path.
-    sys_tmp = Path(os.environ.get("TMPDIR") or "/tmp")
     caches = cache_files(sys_tmp)
     assert caches, f"no flattened-config cache ({CACHE_GLOB}) was published under {sys_tmp}"
     cache = caches[0]


### PR DESCRIPTION
## What

`_remember_cfg_flatten_cache_load` (scripts/log.sh) used to `source "$REMEMBER_DIR/tmp/config.rcfg"` -- a path INSIDE the project tree, which a cloned repository can ship. `-O` passes for a file the cloning user's own checkout wrote, `-L` passes for a regular file, and the `-nt` freshness check reads an absent `.remember/config.json` (the common case) as "fresh" -- so a repository shipping that file had every hook that sources `log.sh` execute its contents as shell, in the cloning user's own session. This closes gate 3 (`executes`) that blocked the 0.32.0 release audit.

Two independent fixes:

1. The cache now lives under `${TMPDIR:-/tmp}`, keyed by mangling `REMEMBER_DIR` with the same fork-free convention `lib-env-cache.sh`'s `_remember_env_cache_path` already uses (non-alnum-to-`-`, 120-char tail-keep truncation), so nothing a `git clone` brings in can plant it.
2. The loader no longer trusts `source` even there. It reads the file line by line and validates every line against the exact `_RCFG_<name>=<value>` shape the publisher writes -- `<name>` is `[A-Za-z0-9_]+`, `<value>` is one of the three shapes bash's own `%q` conversion ever produces. Any line outside that shape rejects the whole cache before a byte is evaluated, and the file is removed so the next start does not re-read the same poison. Validated lines are then assigned with one `eval "$name=$value"` each -- `%q` output is exactly the word `eval` re-reads, so this is safe by construction.

## Self-review round (two spawns: Explore, oss:auditor)

Both reviewers found real issues in the first commit, all addressed in a second commit on this branch:

- **Cache-filename collision, no identity check.** The mangled filename is many-to-one (`my.project` and `my-project` both mangle to `my-project`), and nothing verified a loaded file actually belonged to the reading `REMEMBER_DIR` -- unlike the sibling env cache, which stores and checks its own key. Reproduced directly: two sibling projects collided on one cache file and the second silently read the first's config value. Fixed by writing a `#REMEMBER_DIR=<%q>` identity line first in every published cache and checking it back on load; a cache with no identity line (including one truncated to zero bytes by anything other than the normal publish path) is now rejected outright rather than read as "zero keys, clean hit" -- which also closes a related ambiguity the auditor separately flagged (ranked non-blocking, `misreports`), fixed as a byproduct of the same change.
- The value-shape validator's whitelist admitted a bare leading `~`, a shape `%q` never actually produces (it always escapes a LEADING tilde specifically because bash performs tilde-expansion right after `=` in an assignment); tightened to reject it by position, and dropped a bare comma too (needless slack, not a reachable exploit).
- The cache publisher's `mkdir -p` is now guarded (`[ -d ] ||`), removing an almost-always-wasted fork now that the target is bare `${TMPDIR:-/tmp}`.
- A test file's helper globbed the real, unisolated system TMPDIR and could silently pick up an unrelated leftover cache from an earlier test run; both call sites now pin `TMPDIR` to a directory keyed on the test's own `tmp_path`.
- One new regression test exercised only the cache line's NAME-prefix check, never the VALUE-shape validator that is the actual new security logic; added a sibling test with a correct name and an unescaped `$(...)` value, with its own positive control.
- A stale filename reference in an untouched adjacent test comment was updated.

Two new regression tests pin the collision and the zero-byte-cache fixes directly, each confirmed red against the pre-review-fix code before being confirmed green against the final one.

## Tests

Targeted set green (34 tests across the four touched/adjacent files). Full `pytest`: 2405 passed, 47 skipped, 0 failed. The `#669` Windows benchmark was re-measured on this platform: warm-path spawn count is IDENTICAL before and after this whole change (jq present 24, jq absent 24) -- zero added forks on the hot path. Cold dropped by one fork (43->42, 73->72), matching the `mkdir` guard fix.

Do not "fix" this by dropping the cache -- it is a measured warm-start win from #668/#670/#675/#679/#681. This preserves the same hit rate on a valid cache and zero execution of an invalid one.

## Coordinator review follow-up (commit 972368d)

The maintainer reviewed the committed diff directly and found the value validator's ASCII whitelist too narrow: it rejected any value containing a mid-word `#` or any non-ASCII byte (both left bare/unescaped by `printf %q` on every bash tested), and it missed a bash-3.2-only gap where `%q` does not escape a tilde immediately after an unquoted `:` in an assignment word (`eval "v=a:~"` on stock macOS `/bin/bash` substitutes a real home directory). A rejected valid value is not a silent miss -- it deletes the cache and forces a full republish on every subsequent run, forever, for that value. Replaced the whitelist with a blacklist of the bytes that can actually change how `eval "NAME=value"` parses a plain assignment word (unescaped whitespace, `; & | ( ) < >`, `$`/backtick, quotes), added a function-local `LC_ALL=C` so the character-class check matches the raw bytes `%q` wrote regardless of the caller's locale, and added a `*:~*` case guard beside the existing leading-`~` one. 19 targeted tests green (positive round-trips for `#`, accented and CJK values, a non-ASCII project-path identity line, and a colon-tilde value; negative tests for every unescaped metacharacter). Full suite was run green locally (2405 passed, 0 failed) after the prior commit; for this last commit the CI matrix is the gate.

Closes #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScdCn6Xq622o2cRQhzVhi5

[AI-generated]